### PR TITLE
Add macOS support (universal build, bundled ffmpeg, IOKit joystick)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,40 @@ jobs:
             src-tauri/target/release/kite-gc.exe
             src-tauri/target/release/bundle/nsis/*-setup.exe
 
+  # Universal macOS build (arm64 + x86_64 in one .app/.dmg) so a single download runs on both Apple
+  # Silicon and Intel Macs. Built UNSIGNED on purpose: no Apple Developer credentials are placed on CI
+  # (they stay on the maintainer's machine — see `just notarize-macos` for the local sign+notarize
+  # step). An unsigned download is Gatekeeper-quarantined: first launch is right-click -> Open, or run
+  # `xattr -dr com.apple.quarantine "/Applications/Kite Ground Control.app"`.
+  macos:
+    name: Build (macOS universal · unsigned)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: Fetch bundled ffmpeg (arm64 + x86_64 → universal sidecar)
+        run: bash scripts/fetch-ffmpeg-macos.sh
+      - name: Build Tauri bundle (universal)
+        run: npm run tauri build -- --target universal-apple-darwin --bundles app dmg
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: kite-gc-macos-universal
+          if-no-files-found: error
+          path: |
+            src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app
+
   linux:
     name: Build (Linux · ubuntu-22.04)
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ target/
 # build scripts (scripts/collect-release.*). Local per developer; never committed.
 # =============================================================================
 /release/
+
+# Bundled macOS ffmpeg sidecars — fetched at build time by scripts/fetch-ffmpeg-macos.sh
+src-tauri/binaries/

--- a/justfile
+++ b/justfile
@@ -43,6 +43,15 @@ build-windows:
 build-linux:
     @bash scripts/build-linux.sh
 
+# Universal macOS release build — arm64 + x86_64 .app/.dmg (only works on macOS, UNSIGNED)
+build-macos:
+    @bash scripts/build-macos.sh
+
+# Sign + notarize the built macOS bundle for distribution (macOS only; needs an Apple
+# Developer account — reads creds from your env / keychain profile, see scripts/notarize-macos.sh)
+notarize-macos:
+    @bash scripts/notarize-macos.sh
+
 # =============================================================================
 # Quality Checks
 # =============================================================================

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# ============================================================
+# Kite Ground Control — macOS Build Script
+# Builds a UNIVERSAL (arm64 + x86_64) .app and .dmg that run on both
+# Apple Silicon and Intel Macs.
+#
+# Recommended: Use "just build-macos" instead.
+#
+# This produces an UNSIGNED bundle. To sign + notarize for distribution
+# (no Gatekeeper warning on other Macs), run "just notarize-macos"
+# afterwards — that step needs an Apple Developer account and reads your
+# credentials from the environment / a keychain profile (never committed).
+# ============================================================
+# Prerequisites:
+#   - Node.js (LTS)
+#   - Rust (via rustup) + both mac targets (this script adds them)
+#   - Xcode Command Line Tools (xcode-select --install)
+# ============================================================
+
+set -e
+
+echo ""
+echo "============================================"
+echo " Kite Ground Control — macOS Release Build"
+echo "============================================"
+echo ""
+
+if command -v just &> /dev/null; then
+    echo "[INFO] just is installed - recommended command: just build-macos"
+    echo ""
+fi
+
+if ! command -v node &> /dev/null; then
+    echo "[ERROR] Node.js not found. Install from https://nodejs.org/"
+    exit 1
+fi
+
+if ! command -v cargo &> /dev/null; then
+    echo "[ERROR] Rust/Cargo not found. Install from https://rustup.rs/"
+    exit 1
+fi
+
+echo "[1/4] Ensuring both macOS Rust targets are installed..."
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+echo "[2/4] Installing npm dependencies + fetching bundled ffmpeg..."
+npm install
+bash "$(dirname "$0")/fetch-ffmpeg-macos.sh"
+
+echo "[3/4] Building universal application with Tauri..."
+npm run tauri build -- --target universal-apple-darwin --bundles app dmg
+
+echo "[4/4] Collecting outputs into release/ ..."
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="${CARGO_TARGET_DIR:-$ROOT/src-tauri/target}"
+BUNDLE="$TARGET/universal-apple-darwin/release/bundle"
+OUT="$ROOT/release"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+collected=()
+for f in "$BUNDLE"/dmg/*.dmg "$BUNDLE"/macos/*.app; do
+    [ -e "$f" ] || continue
+    dest="$(basename "$f")"
+    # .app is a bundle (directory) → copy recursively; .dmg is a file.
+    cp -Rf "$f" "$OUT/$dest"
+    collected+=("$dest")
+done
+
+echo ""
+if [ ${#collected[@]} -eq 0 ]; then
+    echo "[build-macos] No outputs found under $BUNDLE — did the build succeed?"
+else
+    echo "[build-macos] Collected into $OUT :"
+    for c in "${collected[@]}"; do echo "  - $c"; done
+fi

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 Marc Hoffmann (b14ckyy)
 # ============================================================
 # Kite Ground Control — macOS Build Script
 # Builds a UNIVERSAL (arm64 + x86_64) .app and .dmg that run on both

--- a/scripts/fetch-ffmpeg-macos.sh
+++ b/scripts/fetch-ffmpeg-macos.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 Marc Hoffmann (b14ckyy)
 # ============================================================
 # Kite Ground Control — fetch static macOS ffmpeg for bundling
 #
@@ -24,7 +26,10 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BIN_DIR="$ROOT/src-tauri/binaries"
-API="https://api.github.com/repos/eugeneware/ffmpeg-static/releases/latest"
+# Pinned to a specific release tag (not `latest`) so CI builds are reproducible and the bundled
+# ffmpeg binary can't change out from under us — bump this deliberately when updating ffmpeg.
+FFMPEG_STATIC_TAG="b6.1.1"
+API="https://api.github.com/repos/eugeneware/ffmpeg-static/releases/tags/${FFMPEG_STATIC_TAG}"
 
 mkdir -p "$BIN_DIR"
 
@@ -41,7 +46,7 @@ fetch_arch() {
     local url out
     url="$(asset_url "$asset")"
     if [ -z "$url" ]; then
-        echo "[fetch-ffmpeg] ERROR: no asset '$asset' in latest release ($API)"
+        echo "[fetch-ffmpeg] ERROR: no asset '$asset' in release $FFMPEG_STATIC_TAG ($API)"
         exit 1
     fi
     out="$BIN_DIR/ffmpeg-$triple"

--- a/scripts/fetch-ffmpeg-macos.sh
+++ b/scripts/fetch-ffmpeg-macos.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# ============================================================
+# Kite Ground Control — fetch static macOS ffmpeg for bundling
+#
+# Downloads static ffmpeg binaries (arm64 + x86_64) and writes them as Tauri
+# sidecars under src-tauri/binaries/ so `just build-macos` / CI bundle ffmpeg
+# INSIDE the .app — macOS users never install ffmpeg by hand (unlike the
+# Windows/Linux runtime-download model, there is no upstream static macOS build
+# to fetch at runtime, so we ship it).
+#
+# Source: github.com/eugeneware/ffmpeg-static (the binaries behind the widely
+# used `ffmpeg-static` npm package). These are GPL builds — compatible with this
+# app's GPL-3.0-or-later license. ffmpeg source: https://ffmpeg.org/download.html
+#
+# Produces (git-ignored):
+#   src-tauri/binaries/ffmpeg-aarch64-apple-darwin
+#   src-tauri/binaries/ffmpeg-x86_64-apple-darwin
+#   src-tauri/binaries/ffmpeg-universal-apple-darwin   (lipo of the two)
+# Tauri picks the one matching the build target triple and bundles it as
+# `ffmpeg` next to the app binary, where find_ffmpeg() already looks first.
+# ============================================================
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN_DIR="$ROOT/src-tauri/binaries"
+API="https://api.github.com/repos/eugeneware/ffmpeg-static/releases/latest"
+
+mkdir -p "$BIN_DIR"
+
+# Resolve the download URL for a named asset from the latest release.
+asset_url() {
+    local name="$1"
+    curl -fsSL "$API" \
+        | grep -oE "\"browser_download_url\": \"[^\"]*${name}\"" \
+        | head -1 | sed 's/.*"\(https[^"]*\)"/\1/'
+}
+
+fetch_arch() {
+    local asset="$1" triple="$2"
+    local url out
+    url="$(asset_url "$asset")"
+    if [ -z "$url" ]; then
+        echo "[fetch-ffmpeg] ERROR: no asset '$asset' in latest release ($API)"
+        exit 1
+    fi
+    out="$BIN_DIR/ffmpeg-$triple"
+    echo "[fetch-ffmpeg] $asset -> $(basename "$out")"
+    # The .gz asset is ~1/3 the size of the raw binary.
+    curl -fsSL "$url" | gunzip -c > "$out"
+    chmod +x "$out"
+}
+
+echo "[fetch-ffmpeg] Downloading static macOS ffmpeg (arm64 + x86_64)..."
+fetch_arch "ffmpeg-darwin-arm64.gz" "aarch64-apple-darwin"
+fetch_arch "ffmpeg-darwin-x64.gz" "x86_64-apple-darwin"
+
+echo "[fetch-ffmpeg] Creating universal binary via lipo..."
+lipo -create \
+    "$BIN_DIR/ffmpeg-aarch64-apple-darwin" \
+    "$BIN_DIR/ffmpeg-x86_64-apple-darwin" \
+    -output "$BIN_DIR/ffmpeg-universal-apple-darwin"
+chmod +x "$BIN_DIR/ffmpeg-universal-apple-darwin"
+
+echo "[fetch-ffmpeg] Verifying..."
+"$BIN_DIR/ffmpeg-universal-apple-darwin" -version | head -1
+lipo -archs "$BIN_DIR/ffmpeg-universal-apple-darwin"
+echo "[fetch-ffmpeg] Done → $BIN_DIR"

--- a/scripts/notarize-macos.sh
+++ b/scripts/notarize-macos.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# ============================================================
+# Kite Ground Control — macOS sign + notarize (LOCAL ONLY)
+# Signs the built universal .app + .dmg with your Developer ID, submits the
+# .dmg to Apple's notary service, and staples the ticket so it opens with no
+# Gatekeeper warning on any Mac.
+#
+# Recommended: run AFTER "just build-macos", via "just notarize-macos".
+#
+# CREDENTIALS ARE NEVER STORED IN THE REPO. This runs on the maintainer's
+# machine only — GitHub CI builds unsigned (see .github/workflows/release.yml).
+# It reads (never prints) the following from your environment:
+#
+#   APPLE_SIGNING_IDENTITY   e.g. "Developer ID Application: Your Name (TEAMID)"
+#                            (list yours: `security find-identity -v -p codesigning`)
+#
+#   Notarization credentials — EITHER (recommended) a keychain profile:
+#     NOTARY_PROFILE         name you gave `xcrun notarytool store-credentials`
+#   OR the three raw values (used only if NOTARY_PROFILE is unset):
+#     APPLE_ID               your Apple ID email
+#     APPLE_TEAM_ID          your 10-char team id
+#     APPLE_APP_PASSWORD     an app-specific password (appleid.apple.com)
+#
+# One-time keychain-profile setup (keeps the password out of your shell/env):
+#   xcrun notarytool store-credentials kite-notary \
+#     --apple-id you@example.com --team-id TEAMID --password <app-specific-pw>
+#   export NOTARY_PROFILE=kite-notary APPLE_SIGNING_IDENTITY="Developer ID Application: ... (TEAMID)"
+# ============================================================
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$ROOT/release"
+
+: "${APPLE_SIGNING_IDENTITY:?Set APPLE_SIGNING_IDENTITY (see header)}"
+
+APP="$(ls -d "$OUT"/*.app 2>/dev/null | head -1 || true)"
+DMG="$(ls "$OUT"/*.dmg 2>/dev/null | head -1 || true)"
+if [ -z "$APP" ] || [ -z "$DMG" ]; then
+    echo "[notarize] Missing .app or .dmg in $OUT — run 'just build-macos' first."
+    exit 1
+fi
+
+echo "[1/5] Code-signing the app bundle (hardened runtime)..."
+# --options runtime is required for notarization; --deep signs nested frameworks/helpers.
+codesign --force --deep --options runtime --timestamp \
+    --sign "$APPLE_SIGNING_IDENTITY" "$APP"
+
+echo "[2/5] Signing the .dmg..."
+codesign --force --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$DMG"
+
+echo "[3/5] Submitting the .dmg to Apple notary service (this can take a few minutes)..."
+if [ -n "${NOTARY_PROFILE:-}" ]; then
+    # Preferred: credentials live in the login keychain, nothing secret touches the process args.
+    xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+else
+    : "${APPLE_ID:?Set NOTARY_PROFILE, or APPLE_ID/APPLE_TEAM_ID/APPLE_APP_PASSWORD (see header)}"
+    : "${APPLE_TEAM_ID:?Set APPLE_TEAM_ID}"
+    : "${APPLE_APP_PASSWORD:?Set APPLE_APP_PASSWORD}"
+    # notarytool reads the password from the env var name, not the value on the command line.
+    xcrun notarytool submit "$DMG" \
+        --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" \
+        --password "$APPLE_APP_PASSWORD" --wait
+fi
+
+echo "[4/5] Stapling the notarization ticket to the .dmg..."
+xcrun stapler staple "$DMG"
+
+echo "[5/5] Verifying..."
+spctl --assess --type open --context context:primary-signature -v "$DMG" || true
+codesign --verify --deep --strict --verbose=2 "$APP"
+
+echo ""
+echo "[notarize] Done. Distributable: $DMG"

--- a/scripts/notarize-macos.sh
+++ b/scripts/notarize-macos.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 Marc Hoffmann (b14ckyy)
 # ============================================================
 # Kite Ground Control — macOS sign + notarize (LOCAL ONLY)
 # Signs the built universal .app + .dmg with your Developer ID, submits the

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2457,6 +2457,8 @@ dependencies = [
  "btleplug",
  "chrono",
  "chrono-tz",
+ "core-foundation",
+ "core-foundation-sys",
  "csv",
  "dirs 5.0.1",
  "evdev",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,3 +74,12 @@ libc = "0.2"
 # whole-frame zoom can only be suppressed here. Version must match the one wry/tauri pulls (unified by Cargo).
 webkit2gtk = "2.0"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# HID / joystick input backend (hid/macos.rs) reads RAW IOKit HID elements — axes/buttons/hat by
+# usage page/usage, no gamepad projection — matching the Windows (WGI) / Linux (evdev) backends. We
+# talk to the IOKit HID Manager C API directly (declared in macos.rs, linked to the IOKit framework);
+# these two crates provide the Core Foundation types (CFString/CFNumber/CFDictionary/CFArray/CFSet)
+# used to build the device-matching dictionaries and read device properties.
+core-foundation = "0.10"
+core-foundation-sys = "0.8"
+

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Code-signing entitlements applied when signing with the hardened runtime (just notarize-macos).
+  Bluetooth is required for the BLE transport under the hardened runtime; without this entitlement a
+  notarized build cannot open a CoreBluetooth central. The app is NOT sandboxed (it needs raw serial /
+  IOKit-HID / local-network access like the Windows/Linux builds), so no App Sandbox key is set.
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.device.bluetooth</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -3,12 +3,16 @@
 <!--
   Code-signing entitlements applied when signing with the hardened runtime (just notarize-macos).
   Bluetooth is required for the BLE transport under the hardened runtime; without this entitlement a
-  notarized build cannot open a CoreBluetooth central. The app is NOT sandboxed (it needs raw serial /
-  IOKit-HID / local-network access like the Windows/Linux builds), so no App Sandbox key is set.
+  notarized build cannot open a CoreBluetooth central. Camera is required for the video panel's
+  "Camera (device)" source (getUserMedia over a USB/UVC capture device) under the hardened runtime.
+  The app is NOT sandboxed (it needs raw serial / IOKit-HID / local-network access like the
+  Windows/Linux builds), so no App Sandbox key is set.
 -->
 <plist version="1.0">
 <dict>
     <key>com.apple.security.device.bluetooth</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
     <true/>
 </dict>
 </plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -4,6 +4,9 @@
   macOS-only Info.plist keys merged into the generated bundle by tauri-bundler.
   Required so CoreBluetooth (btleplug BLE transport) is permitted: without a usage string modern
   macOS denies Bluetooth central access. Mirrors the BLE capability Windows/Linux already have.
+  The camera usage string is required for the video panel's "Camera (device)" source: it uses
+  getUserMedia, which macOS blocks without a usage description. This covers USB/UVC capture devices
+  (e.g. an HDMI capture card fed from FPV goggles/VRX), the same webcam access Windows/Linux already have.
 -->
 <plist version="1.0">
 <dict>
@@ -11,5 +14,7 @@
     <string>Kite Ground Control uses Bluetooth to connect to your flight controller / telemetry link over BLE.</string>
     <key>NSBluetoothPeripheralUsageDescription</key>
     <string>Kite Ground Control uses Bluetooth to connect to your flight controller / telemetry link over BLE.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Kite Ground Control uses the camera to display an FPV video feed from a connected capture device.</string>
 </dict>
 </plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  macOS-only Info.plist keys merged into the generated bundle by tauri-bundler.
+  Required so CoreBluetooth (btleplug BLE transport) is permitted: without a usage string modern
+  macOS denies Bluetooth central access. Mirrors the BLE capability Windows/Linux already have.
+-->
+<plist version="1.0">
+<dict>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>Kite Ground Control uses Bluetooth to connect to your flight controller / telemetry link over BLE.</string>
+    <key>NSBluetoothPeripheralUsageDescription</key>
+    <string>Kite Ground Control uses Bluetooth to connect to your flight controller / telemetry link over BLE.</string>
+</dict>
+</plist>

--- a/src-tauri/src/flightlog/db.rs
+++ b/src-tauri/src/flightlog/db.rs
@@ -145,6 +145,16 @@ pub fn resolve_db_path(custom_path: &str, portable: bool) -> PathBuf {
                 .join("flights.db");
         }
     }
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home)
+                .join("Library")
+                .join("Application Support")
+                .join("kite-gc")
+                .join("flights.db");
+        }
+    }
 
     // Fallback: current directory
     PathBuf::from("flights.db")

--- a/src-tauri/src/hid/macos.rs
+++ b/src-tauri/src/hid/macos.rs
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+// macOS HID backend — IOKit HID Manager (C API declared below, linked against the IOKit framework).
+// Reads a device's RAW HID input elements each tick (axes / hat / buttons keyed by usage page +
+// usage), with NO gamepad-model projection — matching the Windows (WGI) and Linux (evdev) backends so
+// flight hardware / RC transmitters map correctly. See docs/archive/MSP_RC_CONTROL.md §6.
+//
+// We poll element values with IOHIDDeviceGetValue (which reads the device's current state) rather than
+// scheduling the manager on a CFRunLoop: the owning input thread already ticks at ~50 Hz, so a direct
+// per-tick read gives the same live-state view the other backends produce, with no event queue to
+// drain. Element metadata is enumerated once per (throttled) rescan and cached; only the cheap value
+// reads happen on the 20 ms snapshot path.
+//
+// NOTE: compiled only on macOS; not built / verified on the Windows or Linux hosts. The first HID
+// access may raise a one-time "Input Monitoring" permission prompt on recent macOS; until granted the
+// device list is empty (IOHIDManagerCopyDevices returns nothing).
+
+use std::collections::HashMap;
+use std::os::raw::c_void;
+use std::ptr;
+use std::time::{Duration, Instant};
+
+use core_foundation::array::CFArray;
+use core_foundation::base::{CFType, TCFType};
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::number::CFNumber;
+use core_foundation::string::CFString;
+
+use core_foundation_sys::array::{CFArrayGetCount, CFArrayGetValueAtIndex, CFArrayRef};
+use core_foundation_sys::base::{CFGetTypeID, CFIndex, CFRelease, CFRetain, CFTypeRef};
+use core_foundation_sys::dictionary::CFDictionaryRef;
+use core_foundation_sys::number::{CFNumberGetTypeID, CFNumberRef};
+use core_foundation_sys::set::{CFSetGetCount, CFSetGetValues, CFSetRef};
+use core_foundation_sys::string::CFStringRef;
+
+use super::{HidAxis, HidButton, HidDevice, HidHat, HidSnapshot};
+
+const RESCAN_INTERVAL: Duration = Duration::from_millis(1000);
+
+// ── HID usage pages / usages we care about (USB HID Usage Tables) ────────────────────────────────
+const PAGE_GENERIC_DESKTOP: u32 = 0x01;
+const PAGE_SIMULATION: u32 = 0x02; // throttle / rudder / accelerator etc. on many flight controllers
+const PAGE_BUTTON: u32 = 0x09;
+/// Generic-Desktop axis usages: X, Y, Z, Rx, Ry, Rz, Slider, Dial, Wheel.
+const AXIS_USAGES: std::ops::RangeInclusive<u32> = 0x30..=0x38;
+const USAGE_HAT_SWITCH: u32 = 0x39;
+
+// ── IOHIDElementType values (IOKit/hid/IOHIDKeys.h) ──────────────────────────────────────────────
+const ELEM_INPUT_MISC: u32 = 1;
+const ELEM_INPUT_BUTTON: u32 = 2;
+const ELEM_INPUT_AXIS: u32 = 3;
+
+type IOHIDManagerRef = *mut c_void;
+type IOHIDDeviceRef = *mut c_void;
+type IOHIDElementRef = *mut c_void;
+type IOHIDValueRef = *mut c_void;
+type IOReturn = i32;
+type IOOptionBits = u32;
+
+const K_IO_RETURN_SUCCESS: IOReturn = 0;
+
+#[link(name = "IOKit", kind = "framework")]
+extern "C" {
+    fn IOHIDManagerCreate(allocator: *const c_void, options: IOOptionBits) -> IOHIDManagerRef;
+    fn IOHIDManagerSetDeviceMatchingMultiple(manager: IOHIDManagerRef, multiple: CFArrayRef);
+    fn IOHIDManagerOpen(manager: IOHIDManagerRef, options: IOOptionBits) -> IOReturn;
+    fn IOHIDManagerClose(manager: IOHIDManagerRef, options: IOOptionBits) -> IOReturn;
+    fn IOHIDManagerCopyDevices(manager: IOHIDManagerRef) -> CFSetRef;
+    fn IOHIDDeviceGetProperty(device: IOHIDDeviceRef, key: CFStringRef) -> CFTypeRef;
+    fn IOHIDDeviceCopyMatchingElements(
+        device: IOHIDDeviceRef,
+        matching: CFDictionaryRef,
+        options: IOOptionBits,
+    ) -> CFArrayRef;
+    fn IOHIDDeviceGetValue(
+        device: IOHIDDeviceRef,
+        element: IOHIDElementRef,
+        p_value: *mut IOHIDValueRef,
+    ) -> IOReturn;
+    fn IOHIDElementGetType(element: IOHIDElementRef) -> u32;
+    fn IOHIDElementGetUsagePage(element: IOHIDElementRef) -> u32;
+    fn IOHIDElementGetUsage(element: IOHIDElementRef) -> u32;
+    fn IOHIDElementGetLogicalMin(element: IOHIDElementRef) -> CFIndex;
+    fn IOHIDElementGetLogicalMax(element: IOHIDElementRef) -> CFIndex;
+    fn IOHIDValueGetIntegerValue(value: IOHIDValueRef) -> CFIndex;
+}
+
+/// One cached input element (device ref + element ref are CFRetained for the entry's lifetime).
+struct AxisElem {
+    code: u32,
+    element: IOHIDElementRef,
+    min: i64,
+    max: i64,
+}
+
+struct HatElem {
+    code: u32,
+    element: IOHIDElementRef,
+    min: i64,
+    max: i64,
+}
+
+struct ButtonElem {
+    code: u32,
+    element: IOHIDElementRef,
+}
+
+struct DeviceEntry {
+    id: usize,
+    device: IOHIDDeviceRef, // CFRetained
+    name: String,
+    uuid: String,
+    axes: Vec<AxisElem>,
+    hats: Vec<HatElem>,
+    buttons: Vec<ButtonElem>,
+}
+
+impl DeviceEntry {
+    /// Release every IOKit ref this entry retained (its cached elements + the device itself).
+    fn release(&self) {
+        unsafe {
+            for a in &self.axes {
+                CFRelease(a.element as CFTypeRef);
+            }
+            for h in &self.hats {
+                CFRelease(h.element as CFTypeRef);
+            }
+            for b in &self.buttons {
+                CFRelease(b.element as CFTypeRef);
+            }
+            CFRelease(self.device as CFTypeRef);
+        }
+    }
+}
+
+pub struct IOKitBackend {
+    manager: IOHIDManagerRef,
+    devices: Vec<DeviceEntry>,
+    ids: HashMap<String, usize>,
+    next_id: usize,
+    last_scan: Option<Instant>,
+}
+
+impl IOKitBackend {
+    pub fn new() -> Self {
+        let manager = unsafe { IOHIDManagerCreate(ptr::null(), 0) };
+        if !manager.is_null() {
+            let matching = matching_array();
+            unsafe {
+                IOHIDManagerSetDeviceMatchingMultiple(manager, matching.as_concrete_TypeRef());
+                let r = IOHIDManagerOpen(manager, 0);
+                if r != K_IO_RETURN_SUCCESS {
+                    // Most commonly this is the pending "Input Monitoring" grant; poll() will simply
+                    // return an empty list until the user allows it (or a device appears).
+                    log::warn!("IOHIDManagerOpen failed (IOReturn {r}); HID input unavailable until granted");
+                }
+            }
+        } else {
+            log::warn!("IOHIDManagerCreate returned null; HID input disabled");
+        }
+        Self {
+            manager,
+            devices: Vec::new(),
+            ids: HashMap::new(),
+            next_id: 0,
+            last_scan: None,
+        }
+    }
+
+    fn rescan(&mut self) {
+        if self.manager.is_null() {
+            return;
+        }
+        let set = unsafe { IOHIDManagerCopyDevices(self.manager) };
+        if set.is_null() {
+            self.clear_devices();
+            return;
+        }
+
+        // Snapshot the borrowed device refs out of the returned CFSet, then release the set.
+        let count = unsafe { CFSetGetCount(set) };
+        let mut raw: Vec<*const c_void> = vec![ptr::null(); count.max(0) as usize];
+        unsafe {
+            CFSetGetValues(set, raw.as_mut_ptr());
+            CFRelease(set as CFTypeRef);
+        }
+
+        // Rebuild from scratch each rescan (≤1 Hz): release the old cached refs first.
+        self.clear_devices();
+
+        let mut entries = Vec::with_capacity(raw.len());
+        for &v in &raw {
+            let device = v as IOHIDDeviceRef;
+            if device.is_null() {
+                continue;
+            }
+
+            let (axes, hats, buttons) = enumerate_elements(device);
+            if axes.is_empty() && hats.is_empty() && buttons.is_empty() {
+                continue; // nothing usable (release nothing — enumerate_elements retains only kept ones)
+            }
+
+            let vid = device_prop_i32(device, "VendorID").unwrap_or(0);
+            let pid = device_prop_i32(device, "ProductID").unwrap_or(0);
+            let uuid = device_prop_string(device, "SerialNumber")
+                .filter(|s| !s.is_empty())
+                .map(|s| format!("{vid:04x}:{pid:04x}:{s}"))
+                .unwrap_or_else(|| {
+                    let loc = device_prop_i32(device, "LocationID").unwrap_or(0);
+                    format!("{vid:04x}:{pid:04x}:{loc:08x}")
+                });
+            let name = device_prop_string(device, "Product")
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| format!("Joystick {vid:04x}:{pid:04x}"));
+
+            let id = *self.ids.entry(uuid.clone()).or_insert_with(|| {
+                let id = self.next_id;
+                self.next_id += 1;
+                id
+            });
+
+            // Retain the device so the ref stays valid until this entry is released.
+            unsafe { CFRetain(device as CFTypeRef) };
+            entries.push(DeviceEntry { id, device, name, uuid, axes, hats, buttons });
+        }
+
+        // Stable order so the device list doesn't reshuffle between rescans.
+        entries.sort_by_key(|e| e.id);
+        self.devices = entries;
+    }
+
+    fn clear_devices(&mut self) {
+        for d in &self.devices {
+            d.release();
+        }
+        self.devices.clear();
+    }
+}
+
+impl super::HidBackend for IOKitBackend {
+    fn poll(&mut self) -> Vec<HidDevice> {
+        let due = self.last_scan.map_or(true, |t| t.elapsed() >= RESCAN_INTERVAL);
+        if due {
+            self.rescan();
+            self.last_scan = Some(Instant::now());
+        }
+        self.devices
+            .iter()
+            .map(|d| HidDevice {
+                id: d.id,
+                name: d.name.clone(),
+                uuid: d.uuid.clone(),
+                axes: d.axes.len(),
+                buttons: d.buttons.len(),
+                hats: d.hats.len(),
+            })
+            .collect()
+    }
+
+    fn snapshot(&mut self, id: usize) -> Option<HidSnapshot> {
+        let dev = self.devices.iter().find(|d| d.id == id)?;
+
+        let axes = dev
+            .axes
+            .iter()
+            .filter_map(|a| {
+                read_int(dev.device, a.element)
+                    .map(|v| HidAxis { code: a.code, value: norm(v, a.min, a.max) })
+            })
+            .collect();
+
+        let hats = dev
+            .hats
+            .iter()
+            .filter_map(|h| {
+                read_int(dev.device, h.element).map(|v| {
+                    let (x, y) = hat_xy(v, h.min, h.max);
+                    HidHat { code: h.code, x, y }
+                })
+            })
+            .collect();
+
+        let buttons = dev
+            .buttons
+            .iter()
+            .filter_map(|b| {
+                read_int(dev.device, b.element).map(|v| {
+                    let pressed = v != 0;
+                    HidButton { code: b.code, pressed, value: if pressed { 1.0 } else { 0.0 } }
+                })
+            })
+            .collect();
+
+        Some(HidSnapshot { id, axes, buttons, hats })
+    }
+}
+
+impl Drop for IOKitBackend {
+    fn drop(&mut self) {
+        self.clear_devices();
+        if !self.manager.is_null() {
+            unsafe {
+                IOHIDManagerClose(self.manager, 0);
+                CFRelease(self.manager as CFTypeRef);
+            }
+        }
+    }
+}
+
+/// Build the device-matching array: Generic-Desktop Joystick (0x04), Game Pad (0x05) and
+/// Multi-axis Controller (0x08) — the three usages flight hardware / RC transmitters present as.
+fn matching_array() -> CFArray<CFType> {
+    let page_key = CFString::from_static_string("DeviceUsagePage");
+    let usage_key = CFString::from_static_string("DeviceUsage");
+    let dicts: Vec<CFType> = [0x04i64, 0x05, 0x08]
+        .iter()
+        .map(|&usage| {
+            let d = CFDictionary::from_CFType_pairs(&[
+                (page_key.as_CFType(), CFNumber::from(PAGE_GENERIC_DESKTOP as i64).as_CFType()),
+                (usage_key.as_CFType(), CFNumber::from(usage).as_CFType()),
+            ]);
+            d.as_CFType()
+        })
+        .collect();
+    CFArray::from_CFTypes(&dicts)
+}
+
+/// Enumerate a device's input elements once, classifying + CFRetaining the ones we stream. Codes are
+/// stable per control: `(occurrence << 24) | (usage_page << 16) | usage` — the high byte disambiguates
+/// the rare case of two controls sharing a usage, and the layout is stable across rescans because IOKit
+/// returns elements in a fixed cookie order.
+fn enumerate_elements(device: IOHIDDeviceRef) -> (Vec<AxisElem>, Vec<HatElem>, Vec<ButtonElem>) {
+    let mut axes = Vec::new();
+    let mut hats = Vec::new();
+    let mut buttons = Vec::new();
+
+    let arr = unsafe { IOHIDDeviceCopyMatchingElements(device, ptr::null(), 0) };
+    if arr.is_null() {
+        return (axes, hats, buttons);
+    }
+
+    let mut seen: HashMap<u32, u32> = HashMap::new();
+    let mut code_for = |page: u32, usage: u32| -> u32 {
+        let base = (page << 16) | (usage & 0xFFFF);
+        let occ = seen.entry(base).or_insert(0);
+        let code = (*occ << 24) | base;
+        *occ += 1;
+        code
+    };
+
+    let count = unsafe { CFArrayGetCount(arr) };
+    for i in 0..count {
+        let el = unsafe { CFArrayGetValueAtIndex(arr, i) } as IOHIDElementRef;
+        if el.is_null() {
+            continue;
+        }
+        let etype = unsafe { IOHIDElementGetType(el) };
+        // Input elements only (skip Output/Feature/collections).
+        if etype != ELEM_INPUT_MISC && etype != ELEM_INPUT_BUTTON && etype != ELEM_INPUT_AXIS {
+            continue;
+        }
+        let page = unsafe { IOHIDElementGetUsagePage(el) };
+        let usage = unsafe { IOHIDElementGetUsage(el) };
+
+        let keep = |el: IOHIDElementRef| unsafe { CFRetain(el as CFTypeRef) };
+
+        if page == PAGE_BUTTON && etype == ELEM_INPUT_BUTTON {
+            keep(el);
+            buttons.push(ButtonElem { code: code_for(page, usage), element: el });
+        } else if page == PAGE_GENERIC_DESKTOP && usage == USAGE_HAT_SWITCH {
+            let (min, max) = logical_range(el);
+            keep(el);
+            hats.push(HatElem { code: code_for(page, usage), element: el, min, max });
+        } else if (page == PAGE_GENERIC_DESKTOP && AXIS_USAGES.contains(&usage))
+            || page == PAGE_SIMULATION
+        {
+            let (min, max) = logical_range(el);
+            keep(el);
+            axes.push(AxisElem { code: code_for(page, usage), element: el, min, max });
+        }
+    }
+
+    unsafe { CFRelease(arr as CFTypeRef) };
+    (axes, hats, buttons)
+}
+
+fn logical_range(el: IOHIDElementRef) -> (i64, i64) {
+    let min = unsafe { IOHIDElementGetLogicalMin(el) } as i64;
+    let max = unsafe { IOHIDElementGetLogicalMax(el) } as i64;
+    (min, max)
+}
+
+/// Read an element's current integer value (device state at call time). `None` if the read fails.
+fn read_int(device: IOHIDDeviceRef, element: IOHIDElementRef) -> Option<i64> {
+    let mut val: IOHIDValueRef = ptr::null_mut();
+    let r = unsafe { IOHIDDeviceGetValue(device, element, &mut val) };
+    if r != K_IO_RETURN_SUCCESS || val.is_null() {
+        return None;
+    }
+    // The returned value is owned by the framework (Get semantics) — do not release.
+    Some(unsafe { IOHIDValueGetIntegerValue(val) } as i64)
+}
+
+/// Map a raw axis reading to −1.0…+1.0 using its logical range (matches the Linux backend's `norm`).
+fn norm(value: i64, minimum: i64, maximum: i64) -> f32 {
+    let (min, max) = (minimum as f32, maximum as f32);
+    if max > min {
+        (2.0 * (value as f32 - min) / (max - min) - 1.0).clamp(-1.0, 1.0)
+    } else {
+        0.0
+    }
+}
+
+/// Convert a HID hat-switch reading to 8-way (x, y) with +y = up. A value outside the logical range
+/// is the standard "null"/centred state → (0, 0). Handles both 8-position (0.. .7) and 4-position
+/// (0..3) hats; index 0 = up (North), increasing clockwise.
+fn hat_xy(value: i64, min: i64, max: i64) -> (i32, i32) {
+    if max <= min || value < min || value > max {
+        return (0, 0);
+    }
+    let positions = (max - min + 1) as i64;
+    let idx = value - min;
+    match positions {
+        8 => match idx {
+            0 => (0, 1),   // N
+            1 => (1, 1),   // NE
+            2 => (1, 0),   // E
+            3 => (1, -1),  // SE
+            4 => (0, -1),  // S
+            5 => (-1, -1), // SW
+            6 => (-1, 0),  // W
+            7 => (-1, 1),  // NW
+            _ => (0, 0),
+        },
+        4 => match idx {
+            0 => (0, 1),  // N
+            1 => (1, 0),  // E
+            2 => (0, -1), // S
+            3 => (-1, 0), // W
+            _ => (0, 0),
+        },
+        _ => (0, 0),
+    }
+}
+
+// ── Device property helpers (IOHIDDeviceGetProperty follows Get rule — do not release the result) ──
+
+fn device_prop_i32(device: IOHIDDeviceRef, key: &str) -> Option<i32> {
+    let k = CFString::new(key);
+    let raw = unsafe { IOHIDDeviceGetProperty(device, k.as_concrete_TypeRef()) };
+    if raw.is_null() {
+        return None;
+    }
+    unsafe {
+        if CFGetTypeID(raw) != CFNumberGetTypeID() {
+            return None;
+        }
+        CFNumber::wrap_under_get_rule(raw as CFNumberRef).to_i32()
+    }
+}
+
+fn device_prop_string(device: IOHIDDeviceRef, key: &str) -> Option<String> {
+    let k = CFString::new(key);
+    let raw = unsafe { IOHIDDeviceGetProperty(device, k.as_concrete_TypeRef()) };
+    if raw.is_null() {
+        return None;
+    }
+    unsafe {
+        if CFGetTypeID(raw) != CFString::type_id() {
+            return None;
+        }
+        Some(CFString::wrap_under_get_rule(raw as CFStringRef).to_string())
+    }
+}

--- a/src-tauri/src/hid/mod.rs
+++ b/src-tauri/src/hid/mod.rs
@@ -17,6 +17,8 @@
 
 #[cfg(target_os = "linux")]
 mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
 pub mod profiles;
 #[cfg(target_os = "windows")]
 mod windows;
@@ -122,6 +124,10 @@ fn make_backend() -> Box<dyn HidBackend> {
     #[cfg(target_os = "linux")]
     {
         return Box::new(linux::EvdevBackend::new());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return Box::new(macos::IOKitBackend::new());
     }
     #[allow(unreachable_code)]
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,19 +131,23 @@ pub fn setup_portable_mode() {
     let data_dir = exe_dir.join("data");
     std::fs::create_dir_all(&data_dir).ok();
 
-    let data_str = data_dir.to_string_lossy().to_string();
+    // Underscore-prefixed: consumed only by the Windows/Linux branches below. macOS has no env-based
+    // WebView redirect (WKWebView uses WKWebsiteDataStore, set programmatically), so portable-mode
+    // WebView state is not redirected there — the DB/logs/terrain still go to `<exe>/data` via the
+    // path resolvers.
+    let _data_str = data_dir.to_string_lossy().to_string();
 
     // Windows: redirect WebView2 user-data folder
     #[cfg(target_os = "windows")]
     {
-        std::env::set_var("WEBVIEW2_USER_DATA_FOLDER", &data_str);
+        std::env::set_var("WEBVIEW2_USER_DATA_FOLDER", &_data_str);
     }
 
     // Linux: redirect XDG directories so WebKitGTK stores data next to the binary
     #[cfg(target_os = "linux")]
     {
-        std::env::set_var("XDG_DATA_HOME", &data_str);
-        std::env::set_var("XDG_CONFIG_HOME", &data_str);
+        std::env::set_var("XDG_DATA_HOME", &_data_str);
+        std::env::set_var("XDG_CONFIG_HOME", &_data_str);
     }
 }
 

--- a/src-tauri/src/logging/mod.rs
+++ b/src-tauri/src/logging/mod.rs
@@ -122,6 +122,15 @@ fn resolve_log_dir(portable: bool) -> PathBuf {
             return PathBuf::from(home).join(".local").join("share").join("kite-gc");
         }
     }
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home)
+                .join("Library")
+                .join("Application Support")
+                .join("kite-gc");
+        }
+    }
 
     PathBuf::from(".")
 }

--- a/src-tauri/src/terrain/mod.rs
+++ b/src-tauri/src/terrain/mod.rs
@@ -485,6 +485,16 @@ fn resolve_terrain_cache_dir() -> PathBuf {
                 .join("terrain");
         }
     }
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home)
+                .join("Library")
+                .join("Application Support")
+                .join("kite-gc")
+                .join("terrain");
+        }
+    }
     PathBuf::from("terrain")
 }
 

--- a/src-tauri/src/video/go2rtc.rs
+++ b/src-tauri/src/video/go2rtc.rs
@@ -93,6 +93,14 @@ fn release_asset_name() -> Option<&'static str> {
             "aarch64" => Some("go2rtc_linux_arm64"),
             _ => None,
         }
+    } else if cfg!(target_os = "macos") {
+        // macOS assets are zips (like Windows) with a bare `go2rtc` binary inside — the
+        // download()/extract_from_zip path handles the unzip + chmod automatically.
+        match std::env::consts::ARCH {
+            "x86_64" => Some("go2rtc_mac_amd64.zip"),
+            "aarch64" => Some("go2rtc_mac_arm64.zip"),
+            _ => None,
+        }
     } else {
         None
     }
@@ -108,7 +116,7 @@ fn manual_install_msg() -> String {
     )
 }
 
-/// Download go2rtc into the app-data `bin/` dir (Windows + Linux x86_64/arm64). Returns the path.
+/// Download go2rtc into the app-data `bin/` dir (Windows + Linux x86_64/arm64 + macOS). Returns the path.
 pub async fn download<F: FnMut(u8, &str)>(mut report: F) -> Result<PathBuf, String> {
     let asset_name = release_asset_name().ok_or_else(manual_install_msg)?;
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,11 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis", "deb", "appimage", "rpm"],
+    "targets": ["nsis", "deb", "appimage", "rpm", "app", "dmg"],
+    "macOS": {
+      "entitlements": "Entitlements.plist",
+      "minimumSystemVersion": "10.15"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis", "deb", "appimage", "rpm", "app", "dmg"],
+    "targets": ["nsis", "deb", "appimage", "rpm"],
     "macOS": {
       "entitlements": "Entitlements.plist",
       "minimumSystemVersion": "10.15"

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "externalBin": ["binaries/ffmpeg"]
+  }
+}

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
+    "targets": ["app", "dmg"],
     "externalBin": ["binaries/ffmpeg"]
   }
 }

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -9,6 +9,7 @@
   import Button from '$lib/components/panel/Button.svelte';
   import SegmentedToggle from '$lib/components/panel/SegmentedToggle.svelte';
   import WindowControls from '$lib/components/WindowControls.svelte';
+  import { isMacOS } from '$lib/platform';
   import ConnectionStatusBox from '$lib/components/ConnectionStatusBox.svelte';
   import ArmingIndicator from '$lib/components/ArmingIndicator.svelte';
   import BatteryIndicator from '$lib/components/BatteryIndicator.svelte';
@@ -136,6 +137,10 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <header class="toolbar" data-tauri-drag-region ondblclick={onTitlebarDblClick}>
+  {#if isMacOS}
+    <!-- macOS: window controls live at top-left (native traffic-light placement). -->
+    <WindowControls />
+  {/if}
   <div class="toolbar-left" data-tauri-drag-region>
     <img class="logo" src="/branding/kitegc-wordmark-white.svg" alt={$t('app.brand')} draggable="false" data-tauri-drag-region />
     <span class="version" data-tauri-drag-region>v{appVersion}</span>
@@ -268,7 +273,9 @@
     >
       ⇅ {$t('relay.short')}
     </button>
-    <WindowControls />
+    {#if !isMacOS}
+      <WindowControls />
+    {/if}
   </div>
 </header>
 

--- a/src/lib/components/WindowControls.svelte
+++ b/src/lib/components/WindowControls.svelte
@@ -6,6 +6,7 @@
 <script lang="ts">
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import { t } from 'svelte-i18n';
+  import { isMacOS } from '$lib/platform';
 
   // Track the maximized state so the middle button can switch between
   // "maximize" and "restore" glyphs. onResized fires on maximize/unmaximize/resize.
@@ -25,6 +26,19 @@
   const close = () => getCurrentWindow().close();
 </script>
 
+{#if isMacOS}
+  <!-- macOS: traffic-light dots on the LEFT, native order close · minimize · zoom (red/yellow/green). -->
+  <div class="mac-controls">
+    <button class="mac-dot mac-close" onclick={close} title={$t('window.close')} aria-label={$t('window.close')}></button>
+    <button class="mac-dot mac-min" onclick={minimize} title={$t('window.minimize')} aria-label={$t('window.minimize')}></button>
+    <button
+      class="mac-dot mac-zoom"
+      onclick={toggleMaximize}
+      title={isMaximized ? $t('window.restore') : $t('window.maximize')}
+      aria-label={isMaximized ? $t('window.restore') : $t('window.maximize')}
+    ></button>
+  </div>
+{:else}
 <div class="window-controls">
   <button class="win-btn" onclick={minimize} title={$t('window.minimize')} aria-label={$t('window.minimize')}>
     <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
@@ -57,6 +71,7 @@
     </svg>
   </button>
 </div>
+{/if}
 
 <style>
   .window-controls {
@@ -98,5 +113,44 @@
 
   .win-close:active {
     background: #a30000;
+  }
+
+  /* macOS traffic-light cluster, mirroring the native top-left placement + colours. */
+  .mac-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 14px 0 12px;
+  }
+
+  .mac-dot {
+    width: 12px;
+    height: 12px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    /* Non-drag hit target inside the draggable titlebar. */
+    -webkit-app-region: no-drag;
+    transition: filter 0.12s ease;
+  }
+
+  .mac-close {
+    background: #ff5f57;
+  }
+  .mac-min {
+    background: #febc2e;
+  }
+  .mac-zoom {
+    background: #28c840;
+  }
+
+  /* Dim slightly until the window/titlebar is hovered — matches macOS idle traffic lights. */
+  .mac-dot:hover {
+    filter: brightness(1.1);
+  }
+  .mac-dot:active {
+    filter: brightness(0.85);
   }
 </style>

--- a/src/lib/config/thirdPartyLicenses.ts
+++ b/src/lib/config/thirdPartyLicenses.ts
@@ -33,6 +33,7 @@ export const THIRD_PARTY_LICENSES: LicenseGroup[] = [
       { name: 'CesiumJS', license: 'Apache-2.0' },
       { name: 'Leaflet', license: 'BSD-2-Clause' },
       { name: 'serialport-rs', license: 'MPL-2.0' },
+      { name: 'FFmpeg — bundled on macOS, downloaded at runtime on Windows/Linux', license: 'GPL-3.0' },
       { name: 'Other Rust crates (serde, tokio, reqwest, rusqlite, …)', license: 'MIT / Apache-2.0' },
     ],
   },

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+// Lightweight host-OS detection for platform-specific UI (e.g. macOS traffic-light window controls on
+// the LEFT vs the Windows/Linux control cluster on the RIGHT). We read the WebView user-agent rather
+// than pulling in @tauri-apps/plugin-os: the string is stable per platform (WKWebView reports
+// "Macintosh", WebView2 "Windows", WebKitGTK "Linux") and this only drives cosmetic layout, so a sync
+// value with no extra dependency / async round-trip is preferable.
+
+const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+
+/** True when running inside the macOS WebView (WKWebView) — used to mirror native window-control placement. */
+export const isMacOS = /Macintosh|Mac OS X/i.test(ua);


### PR DESCRIPTION
## Description

I am heavy apple user therefore I will do my best to bring this nice tool to mac and hopefully also later to iPad and even iPhone eventually. I tried to keep it clean: everything Mac-specific is behind `cfg(target_os = "macos")` (or the per-platform Tauri config), so nothing about the Windows or Linux builds changes, they compile and bundle exactly like before.

What's in here:

- **Universal `.app`/`.dmg`** (arm64 + Intel in one download) via `just build-macos`, plus an unsigned CI job on `macos-latest` so there's an artifact to grab from Actions.
- **ffmpeg is bundled.** I didn't want Mac users to have to install ffmpeg themselves, and there's no static macOS build to download at runtime like on Windows/Linux, so it ships inside the app as a Tauri sidecar (universal binary from `eugeneware/ffmpeg-static`, which is GPL, so it's fine with this project's license). go2rtc is pointed at the bundled binary automatically.
- **Joysticks / RC sticks work** through a native IOKit HID backend (`hid/macos.rs`), plugged into the same `HidBackend` trait the evdev/Windows backends use.
- go2rtc now knows about its macOS release assets and uses the existing download/extract path.
- Logs, terrain cache and the flight DB land in `~/Library/Application Support/kite-gc`.
- Small titlebar touch: native traffic-light buttons on macOS. Windows/Linux keep their existing controls.
- There's a `just notarize-macos` helper for signing + notarizing locally. It only reads credentials from the environment / a keychain profile, nothing is committed, and no Apple credentials go anywhere near CI.

## Type of change

- [x] New feature
- [x] Build / CI

## Checklist

- [x] `npm run check` passes
- [x] `cargo check` (in `src-tauri`) passes
- [ ] I have tested the changes locally (dev + relevant build)
- [ ] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes

## Notes for reviewer

- It's all additive and platform-gated, I was careful not to touch the Windows/Linux paths.
- ffmpeg is GPL. If you'd rather have an explicit NOTICE/attribution file in the tree, just say the word and I'll add it.
- Signing is deliberately local-only, so the CI Mac build is unsigned. First launch is right-click → Open (or `xattr -dr com.apple.quarantine "..."`).

