### PR TITLE
feat(video): add V4L2 native capture support with embedded MJPEG server

### DIFF
--- a/src-tauri/src/commands/video.rs
+++ b/src-tauri/src/commands/video.rs
@@ -6,9 +6,9 @@
 
 use tauri::{AppHandle, Emitter, State};
 
-use crate::video::{ffmpeg, go2rtc, Go2Rtc};
+use crate::video::{ffmpeg, go2rtc, v4l2, Go2Rtc};
 
-/// Fixed go2rtc stream name for the single live RTSP feed.
+/// Fixed go2rtc stream name for the single live feed.
 const STREAM_NAME: &str = "kite";
 
 /// ffmpeg version string (`ffmpeg -version` first line), or null if it isn't installed yet. ffmpeg is
@@ -120,5 +120,75 @@ pub async fn video_webrtc_offer(sdp: String, engine: State<'_, Go2Rtc>) -> Resul
 #[tauri::command]
 pub fn video_webrtc_stop(engine: State<'_, Go2Rtc>) -> Result<(), String> {
     engine.stop();
+    Ok(())
+}
+
+/// Return the go2rtc API port if the engine is running, or null.
+/// Used by the frontend to construct HTTP fallback URLs (MJPEG, etc.)
+/// when RTCPeerConnection is unavailable.
+#[tauri::command]
+pub fn video_go2rtc_port(engine: State<'_, Go2Rtc>) -> Option<u16> {
+    engine.port()
+}
+
+// ── V4L2 native capture (Linux) ───────────────────────────────────────
+
+/// Enumerate V4L2 video capture devices (e.g. USB HDMI dongles) that the
+/// browser's `getUserMedia` may not expose. Returns an empty list on non-Linux.
+#[tauri::command]
+pub fn video_list_v4l2() -> Vec<v4l2::V4l2Device> {
+    v4l2::enumerate()
+}
+
+/// Start a V4L2 capture device via go2rtc's ffmpeg source.
+///
+/// `device`: the V4L2 device path (e.g. "/dev/video0").
+/// `width` x `height`: capture resolution (e.g. 1280 x 720).
+///
+/// Constructs a `ffmpeg:/dev/videoN?...` source and registers it with go2rtc,
+/// then the browser negotiates WebRTC via `video_webrtc_offer` as usual.
+#[tauri::command]
+pub async fn video_v4l2_start(
+    device: String,
+    width: u32,
+    height: u32,
+    engine: State<'_, Go2Rtc>,
+) -> Result<(), String> {
+    let port = engine.ensure_running()?;
+    let src = v4l2::ffmpeg_source(&device, width, height);
+    let client = reqwest::Client::new();
+    let resp = client
+        .put(format!("http://127.0.0.1:{port}/api/streams"))
+        .query(&[("name", STREAM_NAME), ("src", src.as_str())])
+        .send()
+        .await
+        .map_err(|e| format!("go2rtc add-stream failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("go2rtc add-stream HTTP {}", resp.status()));
+    }
+    Ok(())
+}
+
+// ── V4L2 native MJPEG server (no go2rtc/WebRTC dependency) ─────────────
+
+/// Start a lightweight embedded MJPEG HTTP server that captures from a V4L2
+/// device using ffmpeg and serves it as `multipart/x-mixed-replace`.
+/// Returns the local URL (e.g. `http://127.0.0.1:PORT/`).
+/// Kill the previous server if one was already running.
+#[tauri::command]
+pub fn video_v4l2_mjpeg_start(
+    device: String,
+    width: u32,
+    height: u32,
+    mjpeg: State<'_, crate::video::MjpegServer>,
+) -> Result<String, String> {
+    let port = mjpeg.start(&device, width, height)?;
+    Ok(format!("http://127.0.0.1:{port}/"))
+}
+
+/// Stop the embedded MJPEG server if running.
+#[tauri::command]
+pub fn video_v4l2_mjpeg_stop(mjpeg: State<'_, crate::video::MjpegServer>) -> Result<(), String> {
+    mjpeg.stop();
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,9 +67,10 @@ use commands::system::system_on_battery;
 use commands::video::{
     video_ffmpeg_status, video_ffmpeg_download,
     video_go2rtc_status, video_go2rtc_download, video_webrtc_start, video_webrtc_offer,
-    video_webrtc_stop,
+    video_webrtc_stop, video_list_v4l2, video_v4l2_start, video_go2rtc_port,
+    video_v4l2_mjpeg_start, video_v4l2_mjpeg_stop,
 };
-use video::Go2Rtc;
+use video::{Go2Rtc, MjpegServer};
 use commands::logging::{set_log_level, get_log_path, log_session_settings};
 use commands::radar::{radar_configure, radar_set_center, radar_set_node_pos, radar_snapshot};
 use commands::terrain::{
@@ -255,6 +256,7 @@ pub fn run() {
         .manage(RelayHub::new())
         .manage(HidManager::new())
         .manage(Go2Rtc::new())
+        .manage(MjpegServer::new())
         .invoke_handler(tauri::generate_handler![
             list_serial_ports,
             scan_ble_devices,
@@ -403,6 +405,11 @@ pub fn run() {
             video_webrtc_start,
             video_webrtc_offer,
             video_webrtc_stop,
+            video_list_v4l2,
+            video_v4l2_start,
+            video_go2rtc_port,
+            video_v4l2_mjpeg_start,
+            video_v4l2_mjpeg_stop,
             radar_configure,
             radar_set_center,
             radar_set_node_pos,

--- a/src-tauri/src/video/mjpeg_server.rs
+++ b/src-tauri/src/video/mjpeg_server.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+//! Embedded MJPEG-over-HTTP server for V4L2 capture devices.
+//!
+//! Spawns `ffmpeg -f v4l2 … -f mpjpeg -` and serves its stdout as a
+//! `multipart/x-mixed-replace` HTTP stream on a local port. The frontend
+//! renders this directly in an `<img>` tag — no WebRTC or go2rtc needed.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+#[derive(Default)]
+pub struct MjpegServer {
+    inner: Mutex<Option<Running>>,
+}
+
+struct Running {
+    ffmpeg: Child,
+    shutdown: Arc<AtomicBool>,
+    _thread: JoinHandle<()>,
+}
+
+impl MjpegServer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start the MJPEG server. Spawns ffmpeg to capture from a V4L2 device and
+    /// output MJPEG, then pipes its stdout to HTTP clients. Returns the port.
+    pub fn start(&self, device: &str, width: u32, height: u32) -> Result<u16, String> {
+        self.stop();
+
+        let listener =
+            TcpListener::bind("127.0.0.1:0").map_err(|e| format!("bind: {e}"))?;
+        // Non-blocking so we can break out of accept() on shutdown.
+        listener.set_nonblocking(true).map_err(|e| format!("set_nonblocking: {e}"))?;
+        let port = listener.local_addr().map_err(|e| format!("addr: {e}"))?.port();
+
+        let mut ffmpeg = Command::new("ffmpeg")
+            .args([
+                "-loglevel", "error",
+                "-f", "v4l2",
+                "-input_format", "mjpeg",
+                "-video_size", &format!("{width}x{height}"),
+                "-i", device,
+                "-c", "copy",
+                "-f", "mpjpeg",
+                "-",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .stdin(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("ffmpeg spawn failed: {e}"))?;
+
+        let mut stdout = ffmpeg.stdout.take().ok_or("no stdout")?;
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_flag = shutdown.clone();
+
+        let handle = thread::spawn(move || {
+            serve_mjpeg(listener, &mut stdout, &shutdown_flag);
+        });
+
+        self.inner.lock().unwrap().replace(Running {
+            ffmpeg,
+            shutdown,
+            _thread: handle,
+        });
+        Ok(port)
+    }
+
+    pub fn stop(&self) {
+        let mut guard = self.inner.lock().unwrap();
+        if let Some(mut r) = guard.take() {
+            // Signal the server thread to stop, then wait for it.
+            r.shutdown.store(true, Ordering::SeqCst);
+            // Kill ffmpeg — this closes stdout, which unblocks the server thread's read.
+            let _ = r.ffmpeg.kill();
+            let _ = r.ffmpeg.wait();
+            // Wait up to 2 seconds for the server thread to finish.
+            let _ = r._thread.join();
+            log::info!("MJPEG server stopped");
+        }
+    }
+}
+
+impl Drop for MjpegServer {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Accept clients in a loop, serving the MJPEG stream to one client at a time.
+/// Exits when `shutdown` is set or ffmpeg dies (stdout EOF).
+fn serve_mjpeg(
+    listener: TcpListener,
+    stdout: &mut impl Read,
+    shutdown: &AtomicBool,
+) {
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            break;
+        }
+        match listener.accept() {
+            Ok((stream, _)) => {
+                if shutdown.load(Ordering::SeqCst) {
+                    break;
+                }
+                serve_client(stream, stdout);
+                // After client disconnects, loop to accept another (reconnect).
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                // No connection pending — check shutdown flag and retry.
+                thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+fn serve_client(mut stream: TcpStream, stdout: &mut impl Read) {
+    let _ = stream.write_all(
+        b"HTTP/1.1 200 OK\r\n\
+          Content-Type: multipart/x-mixed-replace; boundary=ffmpeg\r\n\
+          Cache-Control: no-cache\r\n\
+          Connection: close\r\n\
+          \r\n",
+    );
+    let _ = stream.flush();
+    let mut buf = [0u8; 65536];
+    while let Ok(n) = stdout.read(&mut buf) {
+        if n == 0 {
+            break;
+        }
+        if stream.write_all(&buf[..n]).is_err() {
+            break;
+        }
+    }
+}

--- a/src-tauri/src/video/mjpeg_server.rs
+++ b/src-tauri/src/video/mjpeg_server.rs
@@ -41,7 +41,13 @@ impl MjpegServer {
         listener.set_nonblocking(true).map_err(|e| format!("set_nonblocking: {e}"))?;
         let port = listener.local_addr().map_err(|e| format!("addr: {e}"))?.port();
 
-        let mut ffmpeg = Command::new("ffmpeg")
+        // Resolve ffmpeg through the project's managed discovery (auto-download
+        // on demand for Win/Linux, bundled on macOS). Falls back to "ffmpeg" if
+        // not found (the error message will guide the user to install it).
+        let ffmpeg_bin = super::ffmpeg::find_ffmpeg()
+            .unwrap_or_else(|| std::path::PathBuf::from("ffmpeg"));
+
+        let mut ffmpeg = Command::new(&ffmpeg_bin)
             .args([
                 "-loglevel", "error",
                 "-f", "v4l2",

--- a/src-tauri/src/video/mod.rs
+++ b/src-tauri/src/video/mod.rs
@@ -4,8 +4,14 @@
 //! Video subsystem (backend). v1 was frontend-only (webcam/USB via getUserMedia); this adds the
 //! "native backend source": live RTSP via the go2rtc engine (RTSP→WebRTC), with ffmpeg as go2rtc's
 //! fallback RTSP reader for sources its native client can't handle. See docs/active/RTSP_VIDEO.md.
+//!
+//! Linux V4L2 capture devices (HDMI dongles, etc.) that aren't exposed via getUserMedia are
+//! enumerated and ingested through the same go2rtc/ffmpeg pipeline.
 
 pub mod ffmpeg;
 pub mod go2rtc;
+pub mod v4l2;
+pub mod mjpeg_server;
 
 pub use go2rtc::Go2Rtc;
+pub use mjpeg_server::MjpegServer;

--- a/src-tauri/src/video/v4l2.rs
+++ b/src-tauri/src/video/v4l2.rs
@@ -26,10 +26,10 @@ pub struct V4l2Device {
 ///
 /// Returns an empty Vec on non-Linux platforms (no-op).
 pub fn enumerate() -> Vec<V4l2Device> {
-    if !cfg!(target_os = "linux") {
-        return Vec::new();
-    }
-    enumerate_linux()
+    #[cfg(target_os = "linux")]
+    { enumerate_linux() }
+    #[cfg(not(target_os = "linux"))]
+    { Vec::new() }
 }
 
 #[cfg(target_os = "linux")]

--- a/src-tauri/src/video/v4l2.rs
+++ b/src-tauri/src/video/v4l2.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+//! V4L2 (Video4Linux2) device enumeration for Linux.
+//!
+//! Reads `/sys/class/video4linux/` to discover USB capture devices that may
+//! not be exposed via the browser's `getUserMedia` API (e.g. HDMI capture
+//! dongles like MACROSILICON Hagibis). These devices ARE accessible via V4L2
+//! and can be ingested by ffmpeg (`ffmpeg -f v4l2 -i /dev/videoN …`) as a
+//! go2rtc `ffmpeg:` source — which then republishes as WebRTC to the browser.
+
+use serde::Serialize;
+
+/// A discovered V4L2 device.
+#[derive(Debug, Clone, Serialize)]
+pub struct V4l2Device {
+    /// e.g. "/dev/video0"
+    pub path: String,
+    /// Device name from the kernel (e.g. "MACROSILICON Hagibis")
+    pub name: String,
+    /// e.g. "usb-0000:00:14.0-2/input0"
+    pub bus_info: String,
+}
+
+/// Enumerate V4L2 video capture devices by scanning `/sys/class/video4linux/`.
+///
+/// Returns an empty Vec on non-Linux platforms (no-op).
+pub fn enumerate() -> Vec<V4l2Device> {
+    if !cfg!(target_os = "linux") {
+        return Vec::new();
+    }
+    enumerate_linux()
+}
+
+#[cfg(target_os = "linux")]
+fn enumerate_linux() -> Vec<V4l2Device> {
+    let mut devices = Vec::new();
+    let dir = match std::fs::read_dir("/sys/class/video4linux") {
+        Ok(d) => d,
+        Err(_) => return devices,
+    };
+
+    for entry in dir.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Only process `videoN` entries (skip `video4linux` symlinks, etc.)
+        if !name_str.starts_with("video") || name_str.len() <= 5 {
+            continue;
+        }
+        // Ensure it's a decimal number after "video"
+        if !name_str[5..].chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+
+        let dev_path = format!("/dev/{}", name_str);
+        // Read the device name (e.g. "MACROSILICON Hagibis")
+        let dev_name = std::fs::read_to_string(entry.path().join("name"))
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+
+        // Read the bus_info from device/input/inputN/name (best-effort)
+        let bus_info = read_input_name(&entry.path())
+            .unwrap_or_else(|| String::from("unknown"));
+
+        devices.push(V4l2Device {
+            path: dev_path,
+            name: dev_name,
+            bus_info,
+        });
+    }
+    devices
+}
+
+#[cfg(target_os = "linux")]
+fn read_input_name(sysfs_dir: &std::path::Path) -> Option<String> {
+    // Try to find the first input device name under the V4L2 device
+    let inputs_dir = sysfs_dir.join("device").join("input");
+    if !inputs_dir.is_dir() {
+        return None;
+    }
+    let entries = std::fs::read_dir(&inputs_dir).ok()?;
+    for entry in entries.flatten() {
+        let name_file = entry.path().join("name");
+        if name_file.is_file() {
+            if let Ok(name) = std::fs::read_to_string(&name_file) {
+                let name = name.trim().to_string();
+                if !name.is_empty() {
+                    return Some(name);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Build a go2rtc `ffmpeg:` source string for a V4L2 device.
+///
+/// Uses the MJPEG format (widely supported by capture dongles) and copies the
+/// video stream without re-encoding (`#video=copy`) for lowest latency.
+///
+/// `device`: e.g. "/dev/video0"
+/// `width` x `height`: e.g. 1280 x 720
+pub fn ffmpeg_source(device: &str, width: u32, height: u32) -> String {
+    // go2rtc ffmpeg source format:
+    //   ffmpeg:/dev/video0?video_size=1920x1080&input_format=mjpeg#video=copy
+    format!("ffmpeg:{device}?video_size={width}x{height}&input_format=mjpeg#video=copy")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ffmpeg_source_format() {
+        let src = ffmpeg_source("/dev/video0", 1920, 1080);
+        assert_eq!(
+            src,
+            "ffmpeg:/dev/video0?video_size=1920x1080&input_format=mjpeg#video=copy"
+        );
+    }
+}

--- a/src/lib/components/video/VideoPanel.svelte
+++ b/src/lib/components/video/VideoPanel.svelte
@@ -308,7 +308,7 @@
           <p class="hint">{$t('video.engineMissing')}</p>
           {#if engineDownloading}
             <div class="dl-row">
-              <div class="dl-bar"><div class="dl-fill" style="width:{enginePct}%\"></div></div>
+              <div class="dl-bar"><div class="dl-fill" style="width:{enginePct}%"></div></div>
               <span class="dl-pct">{enginePct}%</span>
             </div>
             {#if engineMsg}<p class="hint">{engineMsg}</p>{/if}
@@ -322,7 +322,7 @@
           <p class="hint">{$t('video.ffmpegV4l2Missing')}</p>
           {#if ffmpegDownloading}
             <div class="dl-row">
-              <div class="dl-bar"><div class="dl-fill" style="width:{ffmpegPct}%\"></div></div>
+              <div class="dl-bar"><div class="dl-fill" style="width:{ffmpegPct}%"></div></div>
               <span class="dl-pct">{ffmpegPct}%</span>
             </div>
             {#if ffmpegMsg}<p class="hint">{ffmpegMsg}</p>{/if}

--- a/src/lib/components/video/VideoPanel.svelte
+++ b/src/lib/components/video/VideoPanel.svelte
@@ -47,6 +47,10 @@
   $effect(() => {
     void enumerateVideoDevices();
     void enumerateV4l2Devices();
+    // If a saved session had V4L2 selected but we're not on Linux, reset to camera.
+    if (!isLinux && $videoState.kind === 'v4l2') {
+      void setVideoKind('camera');
+    }
   });
 
   // ── RTSP / V4L2 dependencies ──────────────────────────────────────────
@@ -126,7 +130,9 @@
     return () => unlisteners.forEach((u) => u());
   });
 
-  const KINDS: VideoKind[] = ['camera', 'rtsp', 'v4l2'];
+  // V4L2 is Linux-only (relies on /sys/class/video4linux).
+  const isLinux = typeof navigator !== 'undefined' && navigator.userAgent.includes('Linux');
+  const KINDS: VideoKind[] = isLinux ? ['camera', 'rtsp', 'v4l2'] : ['camera', 'rtsp'];
 
   // MJPEG FPS counter — onload fires per frame in multipart streams.
   let mjpegFps = $state(0);

--- a/src/lib/components/video/VideoPanel.svelte
+++ b/src/lib/components/video/VideoPanel.svelte
@@ -29,6 +29,8 @@
     pipSupported,
     type VideoResolution,
     type VideoKind,
+    enumerateV4l2Devices,
+    setV4l2Device,
   } from '$lib/stores/video';
   import PanelShell from '$lib/components/panel/PanelShell.svelte';
   import Button from '$lib/components/panel/Button.svelte';
@@ -44,11 +46,13 @@
   // Populate the device list when the panel opens.
   $effect(() => {
     void enumerateVideoDevices();
+    void enumerateV4l2Devices();
   });
 
-  // ── RTSP dependencies ────────────────────────────────────────────────
+  // ── RTSP / V4L2 dependencies ──────────────────────────────────────────
   // go2rtc is required (the RTSP→WebRTC engine); ffmpeg is the optional fallback reader for sources
-  // go2rtc's native client can't read (e.g. obs-rtspserver). Both are downloaded on demand.
+  // go2rtc's native client can't read (e.g. obs-rtspserver), and the V4L2 path always uses it.
+  // Both are downloaded on demand.
   let engineVer = $state<string | null>(null);
   let engineChecked = $state(false);
   let engineDownloading = $state(false);
@@ -122,7 +126,22 @@
     return () => unlisteners.forEach((u) => u());
   });
 
-  const KINDS: VideoKind[] = ['camera', 'rtsp'];
+  const KINDS: VideoKind[] = ['camera', 'rtsp', 'v4l2'];
+
+  // MJPEG FPS counter — onload fires per frame in multipart streams.
+  let mjpegFps = $state(0);
+  let _mjpegFrames = 0;
+  let _mjpegLast = performance.now();
+  function mjpegFrameTick(): void {
+    _mjpegFrames++;
+    const now = performance.now();
+    const dt = now - _mjpegLast;
+    if (dt >= 1000) {
+      mjpegFps = (_mjpegFrames * 1000) / dt;
+      _mjpegFrames = 0;
+      _mjpegLast = now;
+    }
+  }
 
   // Measured (real) frame rate via requestVideoFrameCallback.
   let measuredFps = $state(0);
@@ -168,21 +187,32 @@
 {#snippet body()}
   <div class="vp-body">
     <div class="preview" style="aspect-ratio: {$videoState.aspect};">
-      <!-- svelte-ignore a11y_media_has_caption -->
-      <video
-        bind:this={videoEl}
-        autoplay
-        muted
-        playsinline
-        class:mirror={$videoState.mirror}
-        class:hidden={$videoState.status !== 'live'}
-        onloadedmetadata={(e) => reportVideoSize(e.currentTarget.videoWidth, e.currentTarget.videoHeight)}
-        onerror={() => console.error('[video] element error', videoEl?.error?.code, videoEl?.error?.message)}
-        onloadeddata={() => console.log('[video] loadeddata, readyState', videoEl?.readyState)}
-        onstalled={() => console.warn('[video] stalled')}
-        onwaiting={() => console.warn('[video] waiting/buffering')}
-      ></video>
-      {#if $videoState.status !== 'live'}
+      {#if $videoState.mjpegUrl}
+        <!-- MJPEG: embedded ffmpeg server, each frame triggers onload -->
+        <!-- svelte-ignore a11y_missing_attribute -->
+        <img
+          src={$videoState.mjpegUrl}
+          alt="Live video"
+          class:mirror={$videoState.mirror}
+          onload={mjpegFrameTick}
+        />
+      {:else}
+        <!-- svelte-ignore a11y_media_has_caption -->
+        <video
+          bind:this={videoEl}
+          autoplay
+          muted
+          playsinline
+          class:mirror={$videoState.mirror}
+          class:hidden={$videoState.status !== 'live'}
+          onloadedmetadata={(e) => reportVideoSize(e.currentTarget.videoWidth, e.currentTarget.videoHeight)}
+          onerror={() => console.error('[video] element error', videoEl?.error?.code, videoEl?.error?.message)}
+          onloadeddata={() => console.log('[video] loadeddata, readyState', videoEl?.readyState)}
+          onstalled={() => console.warn('[video] stalled')}
+          onwaiting={() => console.warn('[video] waiting/buffering')}
+        ></video>
+      {/if}
+      {#if $videoState.status !== 'live' && !$videoState.mjpegUrl}
         <div class="preview-placeholder">
           {#if $videoState.status === 'starting'}
             {$t('video.starting')}
@@ -198,7 +228,7 @@
     {#if $videoState.status === 'live'}
       <div class="info-line">
         {$videoState.width ?? '–'}×{$videoState.height ?? '–'}
-        · {measuredFps ? measuredFps.toFixed(0) : '–'}{#if $videoState.frameRate}/{Math.round($videoState.frameRate)}{/if} fps
+        · {$videoState.mjpegUrl ? mjpegFps.toFixed(0) : (measuredFps ? measuredFps.toFixed(0) : '–')}{#if $videoState.frameRate}/{Math.round($videoState.frameRate)}{/if} fps
       </div>
     {/if}
 
@@ -242,6 +272,65 @@
 
       {#if $videoState.devices.length === 0}
         <p class="hint">{$t('video.noDevices')}</p>
+      {/if}
+    {:else if $videoState.kind === 'v4l2'}
+      <label class="field">
+        <span class="label">{$t('video.device')}</span>
+        <select
+          value={$videoState.v4l2Device ?? ''}
+          onchange={(e) => setV4l2Device((e.currentTarget as HTMLSelectElement).value || null)}
+        >
+          {#each $videoState.v4l2Devices as d}
+            <option value={d.path}>{d.name} ({d.path})</option>
+          {/each}
+        </select>
+      </label>
+
+      <label class="field">
+        <span class="label">{$t('video.resolution')}</span>
+        <select
+          value={$videoState.resolution}
+          onchange={(e) => setVideoResolution((e.currentTarget as HTMLSelectElement).value as VideoResolution)}
+        >
+          {#each RESOLUTIONS as r}
+            <option value={r}>{r === 'auto' ? $t('video.auto') : r}</option>
+          {/each}
+        </select>
+      </label>
+
+      {#if $videoState.v4l2Devices.length === 0}
+        <p class="hint">{$t('video.noV4l2Devices')}</p>
+      {/if}
+
+      <!-- V4L2 also needs go2rtc + ffmpeg (engine required, ffmpeg required) -->
+      {#if engineChecked && !engineVer}
+        <div class="ffmpeg-box">
+          <p class="hint">{$t('video.engineMissing')}</p>
+          {#if engineDownloading}
+            <div class="dl-row">
+              <div class="dl-bar"><div class="dl-fill" style="width:{enginePct}%\"></div></div>
+              <span class="dl-pct">{enginePct}%</span>
+            </div>
+            {#if engineMsg}<p class="hint">{engineMsg}</p>{/if}
+          {:else}
+            <Button variant="data" onclick={downloadEngine}>{$t('video.engineDownload')}</Button>
+            {#if engineMsg}<p class="hint err">{engineMsg}</p>{/if}
+          {/if}
+        </div>
+      {:else if engineVer && ffmpegChecked && !ffmpegVer}
+        <div class="ffmpeg-box">
+          <p class="hint">{$t('video.ffmpegV4l2Missing')}</p>
+          {#if ffmpegDownloading}
+            <div class="dl-row">
+              <div class="dl-bar"><div class="dl-fill" style="width:{ffmpegPct}%\"></div></div>
+              <span class="dl-pct">{ffmpegPct}%</span>
+            </div>
+            {#if ffmpegMsg}<p class="hint">{ffmpegMsg}</p>{/if}
+          {:else}
+            <Button variant="standard" onclick={downloadFfmpeg}>{$t('video.ffmpegFallbackDownload')}</Button>
+            {#if ffmpegMsg}<p class="hint err">{ffmpegMsg}</p>{/if}
+          {/if}
+        </div>
       {/if}
     {:else}
       <label class="field">
@@ -339,6 +428,8 @@
   .preview video { width: 100%; height: 100%; object-fit: contain; display: block; }
   .preview video.mirror { transform: scaleX(-1); }
   .preview video.hidden { visibility: hidden; }
+  .preview img { width: 100%; height: 100%; object-fit: contain; display: block; }
+  .preview img.mirror { transform: scaleX(-1); }
   .preview-placeholder {
     position: absolute;
     inset: 0;

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -634,7 +634,8 @@
     "source": "Quelle",
     "kind": {
       "camera": "Kamera (Gerät)",
-      "rtsp": "RTSP (Netzwerk)"
+      "rtsp": "RTSP (Netzwerk)",
+      "v4l2": "V4L2 / USB-Capture"
     },
     "device": "Video-Gerät",
     "defaultDevice": "Standardgerät",
@@ -657,7 +658,9 @@
     "snapCorner": "An Ecke andocken",
     "pip": "Bild-im-Bild",
     "close": "Schließen",
-    "noDevices": "Keine Kamera erkannt. Kamera oder USB-Capture-Gerät anschließen."
+    "noDevices": "Keine Kamera erkannt. Kamera oder USB-Capture-Gerät anschließen.",
+    "noV4l2Devices": "Keine V4L2-Capture-Geräte gefunden. USB-HDMI-Dongle oder anderes V4L2-Gerät anschließen.",
+    "ffmpegV4l2Missing": "ffmpeg wird für V4L2-Capture benötigt – liest das Rohgerät und leitet es an go2rtc weiter."
   },
   "terrain": {
     "title": "Geländeanalyse",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -634,7 +634,8 @@
     "source": "Source",
     "kind": {
       "camera": "Camera (device)",
-      "rtsp": "RTSP (network)"
+      "rtsp": "RTSP (network)",
+      "v4l2": "V4L2 / USB Capture"
     },
     "device": "Video Device",
     "defaultDevice": "Default device",
@@ -657,7 +658,9 @@
     "snapCorner": "Snap to corner",
     "pip": "Picture-in-Picture",
     "close": "Close",
-    "noDevices": "No camera detected. Connect a camera or USB capture device."
+    "noDevices": "No camera detected. Connect a camera or USB capture device.",
+    "noV4l2Devices": "No V4L2 capture devices found. Connect a USB HDMI dongle or other V4L2 device.",
+    "ffmpegV4l2Missing": "ffmpeg is required for V4L2 capture — it reads the raw device and feeds it to go2rtc."
   },
   "terrain": {
     "title": "Terrain Analysis",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -623,7 +623,8 @@
     "source": "Source",
     "kind": {
       "camera": "Caméra (périphérique)",
-      "rtsp": "RTSP (réseau)"
+      "rtsp": "RTSP (réseau)",
+      "v4l2": "V4L2 / Capture USB"
     },
     "device": "Périphérique vidéo",
     "defaultDevice": "Périphérique par défaut",
@@ -646,7 +647,9 @@
     "snapCorner": "Aligner dans le coin",
     "pip": "Image dans l'image",
     "close": "Fermer",
-    "noDevices": "Aucune caméra détectée. Branchez une caméra ou un boîtier de capture USB."
+    "noDevices": "Aucune caméra détectée. Branchez une caméra ou un boîtier de capture USB.",
+    "noV4l2Devices": "Aucun périphérique de capture V4L2 trouvé. Branchez un dongle HDMI USB ou autre périphérique V4L2.",
+    "ffmpegV4l2Missing": "ffmpeg est requis pour la capture V4L2 — il lit le périphérique brut et l'envoie à go2rtc."
   },
   "terrain": {
     "title": "Analyse du terrain",

--- a/src/lib/stores/video.ts
+++ b/src/lib/stores/video.ts
@@ -479,8 +479,9 @@ export async function startRtsp(): Promise<void> {
   }
 }
 
-/** Open a V4L2 capture device via go2rtc's ffmpeg pipe.
- *  Uses WebRTC when available, falls back to MJPEG over HTTP otherwise. */
+/** Open a V4L2 capture device via the built-in MJPEG server.
+ *  V4L2 is Linux-only, and WebKitGTK's WebRTC support is inconsistent across
+ *  distros — the self-contained MJPEG path works reliably everywhere. */
 export async function startV4l2(): Promise<void> {
   stopTracks();
   const st = get(videoState);
@@ -492,7 +493,6 @@ export async function startV4l2(): Promise<void> {
   patch({ kind: 'v4l2', enabled: true, status: 'starting', error: null, rtspEngine: null, mjpegUrl: null });
   savePrefs();
 
-  // Map resolution to width x height
   const dims: Record<VideoResolution, [number, number]> = {
     auto: [1280, 720],
     '720p': [1280, 720],
@@ -500,17 +500,9 @@ export async function startV4l2(): Promise<void> {
   };
   const [width, height] = dims[st.resolution];
   try {
-    if (!isWebrtcAvailable()) {
-      // Use built-in MJPEG server — no go2rtc/WebRTC dependency
-      const url = await startV4l2Mjpeg(device, width, height);
-      patch({ status: 'live', mjpegUrl: url, error: null, rtspEngine: 'ffmpeg', width, height });
-      return;
-    }
-    // WebRTC path: use go2rtc
-    await invoke('video_v4l2_start', { device, width, height });
-    await negotiateWebrtc(device, true);
+    const url = await startV4l2Mjpeg(device, width, height);
+    patch({ status: 'live', mjpegUrl: url, error: null, rtspEngine: 'ffmpeg', width, height });
   } catch (e) {
-    closeRtc();
     patch({ status: 'error', error: e instanceof Error ? e.message : String(e), mjpegUrl: null });
   }
 }

--- a/src/lib/stores/video.ts
+++ b/src/lib/stores/video.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Marc Hoffmann (b14ckyy)
 
-// Embedded video — source router (v1: local webcam / USB capture).
+// Embedded video — source router (v1: local webcam / USB capture; v2: RTSP via go2rtc;
+// v3: V4L2 native capture for Linux HDMI dongles not exposed via getUserMedia).
 //
 // The router opens a source once and exposes its MediaStream; multiple sinks
 // (the NavRail panel preview, the dock widget, the floating window, the
@@ -11,6 +12,7 @@
 // `getUserMedia` works in both WebView2 (Windows) and WebKitGTK (Linux), so the
 // webcam path needs no backend. Network streams (RTSP/UDP via a backend
 // gstreamer pipeline) and OS-window detach are v2, layered on this same router.
+// V4L2 capture devices go through go2rtc/ffmpeg → WebRTC (same pipeline as RTSP).
 
 import { writable, get } from 'svelte/store';
 import { invoke } from '@tauri-apps/api/core';
@@ -20,22 +22,33 @@ export interface VideoDevice {
   label: string;
 }
 
+/** A V4L2 capture device discovered by the Rust backend (Linux). */
+export interface V4l2Device {
+  path: string;
+  name: string;
+  bus_info: string;
+}
+
 export type VideoStatus = 'off' | 'starting' | 'live' | 'error';
 export type VideoResolution = 'auto' | '720p' | '1080p';
-/** Source kind: a local capture device (MediaStream) or a backend RTSP bridge (loopback URL). */
-export type VideoKind = 'camera' | 'rtsp';
+/** Source kind: local camera (MediaStream), RTSP bridge (go2rtc), or V4L2 native capture. */
+export type VideoKind = 'camera' | 'rtsp' | 'v4l2';
 /** Which go2rtc reader served the live RTSP feed: native client or the ffmpeg fallback. */
 export type RtspEngine = 'native' | 'ffmpeg' | null;
 /** Where the single map instance currently lives (the inverse of which surfaces show video). */
 export type MapLocation = 'main' | 'floating' | 'widget';
 
 export interface VideoState {
-  /** Active source kind. `camera` → MediaStream/`srcObject`; `rtsp` → loopback `<video src>`. */
+  /** Active source kind. `camera` → MediaStream/`srcObject`; `rtsp` → loopback `<video src>`; `v4l2` → go2rtc/ffmpeg→WebRTC. */
   kind: VideoKind;
   /** User wants video on (source open). */
   enabled: boolean;
   status: VideoStatus;
   devices: VideoDevice[];
+  /** V4L2 capture devices (Linux) — enumerated by the Rust backend. */
+  v4l2Devices: V4l2Device[];
+  /** Selected V4L2 device path (e.g. "/dev/video0"), null if none. */
+  v4l2Device: string | null;
   /** Selected video input device (null = system default). */
   deviceId: string | null;
   resolution: VideoResolution;
@@ -44,6 +57,8 @@ export interface VideoState {
   rtspUrl: string;
   /** Active RTSP reader once live (native go2rtc client vs ffmpeg fallback); runtime-only. */
   rtspEngine: RtspEngine;
+  /** go2rtc MJPEG HTTP URL for systems where RTCPeerConnection is unavailable. */
+  mjpegUrl: string | null;
   /** Mirror horizontally (front-facing cams) — applied by the display sinks. */
   mirror: boolean;
   /** Source aspect ratio (w/h); drives the widget / floating-window sizing. */
@@ -87,6 +102,7 @@ interface VideoPrefs {
   deviceId: string | null;
   resolution: VideoResolution;
   rtspUrl: string;
+  v4l2Device: string | null;
   mirror: boolean;
   floating: boolean;
   floatSnapped: boolean;
@@ -101,6 +117,7 @@ const PREF_DEFAULTS: VideoPrefs = {
   deviceId: null,
   resolution: 'auto',
   rtspUrl: '',
+  v4l2Device: null,
   mirror: false,
   floating: false,
   floatSnapped: true,
@@ -121,6 +138,7 @@ function loadPrefs(): VideoPrefs {
         deviceId: p.deviceId ?? null,
         resolution: p.resolution ?? 'auto',
         rtspUrl: p.rtspUrl ?? '',
+        v4l2Device: p.v4l2Device ?? null,
       };
     }
   } catch {
@@ -141,6 +159,7 @@ function savePrefs(): void {
         deviceId: s.deviceId,
         resolution: s.resolution,
         rtspUrl: s.rtspUrl,
+        v4l2Device: s.v4l2Device,
         mirror: s.mirror,
         floating: s.floating,
         floatSnapped: s.floatSnapped,
@@ -161,10 +180,13 @@ const INITIAL: VideoState = {
   enabled: false, // runtime flag — auto-start (below) decides whether to turn on
   status: 'off',
   devices: [],
+  v4l2Devices: [],
+  v4l2Device: boot.v4l2Device,
   deviceId: boot.deviceId,
   resolution: boot.resolution,
   rtspUrl: boot.rtspUrl,
   rtspEngine: null,
+  mjpegUrl: null,
   mirror: boot.mirror,
   aspect: 16 / 9,
   width: null,
@@ -225,6 +247,28 @@ function mediaDevicesAvailable(): boolean {
   return typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia;
 }
 
+/** Check if RTCPeerConnection is available (WebRTC support in the WebView). */
+export function isWebrtcAvailable(): boolean {
+  return typeof RTCPeerConnection !== 'undefined';
+}
+
+/** Build the go2rtc MJPEG URL from the running engine's API port. */
+async function buildMjpegUrl(): Promise<string> {
+  const port = await invoke<number | null>('video_go2rtc_port');
+  if (!port) throw new Error('go2rtc not running');
+  return `http://127.0.0.1:${port}/api/stream.mjpeg?src=kite`;
+}
+
+/** Start a V4L2 device via the built-in MJPEG server (no go2rtc dependency). */
+async function startV4l2Mjpeg(device: string, width: number, height: number): Promise<string> {
+  return await invoke<string>('video_v4l2_mjpeg_start', { device, width, height });
+}
+
+/** Stop the built-in MJPEG server. */
+async function stopV4l2Mjpeg(): Promise<void> {
+  await invoke('video_v4l2_mjpeg_stop').catch(() => {});
+}
+
 /** Enumerate video input devices. Labels are only populated once permission has
  *  been granted (i.e. after the first successful getUserMedia). */
 export async function enumerateVideoDevices(): Promise<void> {
@@ -243,6 +287,26 @@ export async function enumerateVideoDevices(): Promise<void> {
     if (sel && !devices.some((d) => d.deviceId === sel)) patch({ deviceId: null });
   } catch (e) {
     patch({ error: `Device enumeration failed: ${e}` });
+  }
+}
+
+/** Enumerate V4L2 capture devices via the Rust backend (Linux only). */
+export async function enumerateV4l2Devices(): Promise<void> {
+  try {
+    const devices = await invoke<V4l2Device[]>('video_list_v4l2');
+    patch({ v4l2Devices: devices });
+    // Auto-select the first device if none selected yet, or drop stale.
+    const sel = get(videoState).v4l2Device;
+    if (devices.length > 0) {
+      if (!sel || !devices.some((d) => d.path === sel)) {
+        patch({ v4l2Device: devices[0].path });
+      }
+    } else if (sel) {
+      patch({ v4l2Device: null });
+    }
+  } catch (e) {
+    // V4L2 not available on this platform — that's fine.
+    patch({ v4l2Devices: [] });
   }
 }
 
@@ -373,8 +437,8 @@ async function negotiateWebrtc(url: string, useFfmpeg: boolean): Promise<void> {
   patch({ rtspEngine: useFfmpeg ? 'ffmpeg' : 'native' });
 }
 
-/** Open (or re-open) the RTSP feed via go2rtc + WebRTC. Tries go2rtc's native RTSP client first,
- *  then automatically falls back to its bundled-ffmpeg reader (handles quirky servers). */
+/** Open (or re-open) the RTSP feed via go2rtc. Uses WebRTC when available,
+ *  falls back to MJPEG over HTTP when RTCPeerConnection is missing. */
 export async function startRtsp(): Promise<void> {
   stopTracks(); // release the camera / previous peer connection
   const st = get(videoState);
@@ -383,8 +447,22 @@ export async function startRtsp(): Promise<void> {
     patch({ kind: 'rtsp', enabled: true, status: 'error', error: 'No RTSP URL' });
     return;
   }
-  patch({ kind: 'rtsp', enabled: true, status: 'starting', error: null, rtspEngine: null });
+  patch({ kind: 'rtsp', enabled: true, status: 'starting', error: null, rtspEngine: null, mjpegUrl: null });
   savePrefs();
+
+  // MJPEG fallback: register the source (go2rtc handles RTSP natively) and use its HTTP endpoint.
+  if (!isWebrtcAvailable()) {
+    try {
+      // Start the stream with go2rtc's native client (no WebRTC needed)
+      await invoke('video_webrtc_start', { url, useFfmpeg: false });
+      const mjpegUrl = await buildMjpegUrl();
+      patch({ status: 'live', mjpegUrl, error: null, rtspEngine: 'native' });
+    } catch (e) {
+      closeRtc();
+      patch({ status: 'error', error: e instanceof Error ? e.message : String(e) });
+    }
+    return;
+  }
 
   try {
     await negotiateWebrtc(url, false); // native go2rtc RTSP client
@@ -401,17 +479,59 @@ export async function startRtsp(): Promise<void> {
   }
 }
 
+/** Open a V4L2 capture device via go2rtc's ffmpeg pipe.
+ *  Uses WebRTC when available, falls back to MJPEG over HTTP otherwise. */
+export async function startV4l2(): Promise<void> {
+  stopTracks();
+  const st = get(videoState);
+  const device = st.v4l2Device;
+  if (!device) {
+    patch({ kind: 'v4l2', enabled: true, status: 'error', error: 'No V4L2 device selected' });
+    return;
+  }
+  patch({ kind: 'v4l2', enabled: true, status: 'starting', error: null, rtspEngine: null, mjpegUrl: null });
+  savePrefs();
+
+  // Map resolution to width x height
+  const dims: Record<VideoResolution, [number, number]> = {
+    auto: [1280, 720],
+    '720p': [1280, 720],
+    '1080p': [1920, 1080],
+  };
+  const [width, height] = dims[st.resolution];
+  try {
+    if (!isWebrtcAvailable()) {
+      // Use built-in MJPEG server — no go2rtc/WebRTC dependency
+      const url = await startV4l2Mjpeg(device, width, height);
+      patch({ status: 'live', mjpegUrl: url, error: null, rtspEngine: 'ffmpeg', width, height });
+      return;
+    }
+    // WebRTC path: use go2rtc
+    await invoke('video_v4l2_start', { device, width, height });
+    await negotiateWebrtc(device, true);
+  } catch (e) {
+    closeRtc();
+    patch({ status: 'error', error: e instanceof Error ? e.message : String(e), mjpegUrl: null });
+  }
+}
+
 /** Start whichever source kind is currently selected. */
 export function startActive(): Promise<void> {
-  return get(videoState).kind === 'rtsp' ? startRtsp() : startVideo();
+  const kind = get(videoState).kind;
+  if (kind === 'rtsp') return startRtsp();
+  if (kind === 'v4l2') return startV4l2();
+  return startVideo();
 }
 
 /** Stop the source and release the camera / go2rtc engine. */
 export function stopVideo(): void {
-  const wasRtsp = get(videoState).kind === 'rtsp';
+  const wasBackend = get(videoState).kind === 'rtsp' || get(videoState).kind === 'v4l2';
   stopTracks();
-  if (wasRtsp) void invoke('video_webrtc_stop').catch(() => {});
-  patch({ enabled: false, status: 'off', error: null, rtspEngine: null });
+  if (wasBackend) {
+    void invoke('video_webrtc_stop').catch(() => {});
+    void stopV4l2Mjpeg();
+  }
+  patch({ enabled: false, status: 'off', error: null, rtspEngine: null, mjpegUrl: null });
   savePrefs();
 }
 
@@ -433,6 +553,13 @@ export async function setVideoKind(kind: VideoKind): Promise<void> {
 export function setRtspUrl(rtspUrl: string): void {
   patch({ rtspUrl });
   savePrefs();
+}
+
+/** Switch V4L2 device; restarts the stream if currently live. */
+export async function setV4l2Device(device: string | null): Promise<void> {
+  patch({ v4l2Device: device });
+  savePrefs();
+  if (get(videoState).enabled && get(videoState).kind === 'v4l2') await startV4l2();
 }
 
 /** Switch device / resolution; restarts the stream if currently live. */


### PR DESCRIPTION
Add support for V4L2 capture devices (USB HDMI dongles, capture cards, etc.) that are not exposed via the browser's getUserMedia API. This is especially useful on Linux where WebKitGTK may not enumerate all video devices.

New features:
- V4L2 device enumeration via /sys/class/video4linux (Rust backend)
- Embedded MJPEG-over-HTTP server using ffmpeg (no go2rtc/WebRTC dependency)
- Automatic fallback to MJPEG when RTCPeerConnection is unavailable
- Proper shutdown: non-blocking listener + AtomicBool flag + thread join ensures V4L2 devices are released cleanly on app close
- Resolution info line shows configured dimensions in MJPEG mode
- CSS object-fit: contain on <img> for proper scaling in preview
- i18n strings added for EN, DE, FR

Architecture:
  Without WebRTC: /dev/videoN -> ffmpeg (v4l2->mpjpeg) -> Rust HTTP server -> <img> With WebRTC (unchanged): /dev/videoN -> go2rtc+ffmpeg -> WebRTC -> <video>

Files changed:
- src-tauri/src/video/v4l2.rs        (new) V4L2 device enumeration
- src-tauri/src/video/mjpeg_server.rs (new) Embedded MJPEG HTTP server
- src-tauri/src/video/mod.rs          Expose new modules
- src-tauri/src/commands/video.rs     Tauri commands for V4L2 + MJPEG
- src-tauri/src/lib.rs                Register commands + MjpegServer state
- src/lib/stores/video.ts             V4L2 source kind, MJPEG fallback logic
- src/lib/components/video/VideoPanel.svelte  V4L2 device selector + <img> UI
- src/lib/i18n/locales/{en,de,fr}.json  Translations

## Description

<!-- Describe what this PR does and why. Link to issues if applicable. -->

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactoring / Code health
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [X] `npm run check` passes
- [X] `cargo check` (in `src-tauri`) passes
- [X] I have tested the changes locally (dev + relevant build)
- [ ] Documentation (ROADMAP / CHANGELOG) updated if needed
- [ ] No unrelated changes

