### PR TITLE
fix(ci): fetch ffmpeg sidecar before macOS cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,14 @@ jobs:
         with:
           workspaces: src-tauri
 
+      # macOS bundles an ffmpeg sidecar (externalBin in tauri.macos.conf.json). Tauri's build script
+      # resolves that path during cargo check, so the sidecar must exist or the check aborts with
+      # "resource path binaries/ffmpeg-aarch64-apple-darwin doesn't exist". The release workflow already
+      # fetches it; the check job needs the same step. Other platforms have no sidecar, so skip them.
+      - name: Fetch bundled ffmpeg (macOS check needs the sidecar)
+        if: matrix.os == 'macos-latest'
+        run: bash scripts/fetch-ffmpeg-macos.sh
+
       - name: Run cargo check
         working-directory: src-tauri
         run: cargo check --verbose


### PR DESCRIPTION
## Description

The macOS check job added to the CI matrix in `3d3aa9f` fails on master because it never fetches the bundled ffmpeg sidecar.

The macOS bundle declares `"externalBin": ["binaries/ffmpeg"]` in `tauri.macos.conf.json`. Tauri's build script resolves that path during `cargo check`, so if the sidecar is not present the job aborts with:

```
resource path binaries/ffmpeg-aarch64-apple-darwin doesn't exist
```

The release workflow already fetches it via `scripts/fetch-ffmpeg-macos.sh`. This PR adds the same step to the CI check job, gated to `macos-latest` only since Windows and Linux have no ffmpeg sidecar. Ubuntu and Windows jobs are untouched.

The macOS check on this PR is the verification: it exercises the new step end to end.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring / Code health
- [ ] Documentation
- [X] Build / CI

## Checklist

- [ ] I have tested the changes locally (dev + relevant build)
- [X] No unrelated changes
- [ ] Documentation (ROADMAP / CHANGELOG) updated if needed

Note: this is a CI workflow only change (single step in `.github/workflows/ci.yml`), so `npm run check` and `cargo check` are not affected. The fix is validated by the macOS check on this PR run.