### PR TITLE
fix(replay): anchor relative-altitude tracks to terrain, restore armed state

### DIFF
--- a/src/lib/adapters/telemetryAdapter.ts
+++ b/src/lib/adapters/telemetryAdapter.ts
@@ -11,6 +11,7 @@
 
 import type { TelemetryData } from '$lib/stores/telemetry';
 import type { TelemetryRecord } from '$lib/stores/flightlog';
+import { ARMED_BIT } from '$lib/helpers/arming';
 
 /** Normalize a recorded raw RSSI to 0–100 %. The scale isn't stored, so infer it from the magnitude:
  *  ≤100 already a percentage, ≤255 the MAVLink 0–254 range, otherwise the INAV 0–1023 range. */
@@ -85,7 +86,12 @@ export function toTelemetryData(r: TelemetryRecord, fcVariant = 'INAV'): Telemet
     },
 
     // Status
-    armingFlags: r.state_flags ?? 0,
+    // `state_flags` is INAV's stateFlags bitfield and only blackbox imports populate it — the live
+    // recorder has no source for it (`recorder.rs`) and stores NULL, which left every replayed live
+    // flight looking permanently disarmed. Recover it from the recording itself: the recorder opens a
+    // flight on the arm edge and finalises it on disarm, so every sample in a flight row was taken
+    // while armed, and any sample carrying a flight mode proves telemetry was flowing at that moment.
+    armingFlags: r.state_flags ?? (r.mode_primary ? ARMED_BIT : 0),
     cpuLoad: r.cpu_load ?? 0,
     sensorStatus: r.hw_health_status ?? 0,
     flightModeFlags: 0, // raw custom_mode is live-only (vehicle control); not replayed from the DB

--- a/src/lib/components/Map3D.svelte
+++ b/src/lib/components/Map3D.svelte
@@ -28,6 +28,7 @@
   import { loadTileBytes } from "$lib/cache/tileLoader";
   import { isKnownUnavailable, isPlaceholderTile } from "$lib/cache/tileAvailability";
   import { isValidGpsCoordinate, MIN_FIX_SATELLITES } from "$lib/helpers/telemetry";
+  import { isRelativeAltitudeProtocol } from "$lib/helpers/altReference";
   import {
     segmentTrackByFlightMode,
     segmentTrackByAltitude,
@@ -88,6 +89,7 @@
     active = true,
     playbackTrack = [],
     playbackPoint = null,
+    playbackProtocol = null,
     replayStartEpochMs = null,
     trackColorMode = 'flightmode' as TrackColorMode,
     platformType = PLATFORM_MULTIROTOR as PlatformType,
@@ -104,6 +106,9 @@
     active?: boolean;
     playbackTrack?: TelemetryRecord[];
     playbackPoint?: TelemetryRecord | null;
+    /** Replayed flight's `protocol` label — decides whether its `alt_m` is true MSL or arming-relative
+     *  (see `helpers/altReference`). Null while live or before a flight is selected. */
+    playbackProtocol?: string | null;
     /** Absolute flight-start epoch (ms); playbackPoint.timestamp_ms is relative to this. */
     replayStartEpochMs?: number | null;
     trackColorMode?: TrackColorMode;
@@ -3048,10 +3053,20 @@
 
   $effect(() => {
     if (!viewer) return;
-    updatePlaybackTrack3D(playbackTrack, trackColorMode);
+    updatePlaybackTrack3D(playbackTrack, trackColorMode, playbackProtocol);
   });
 
-    async function updatePlaybackTrack3D(track: TelemetryRecord[], colorMode: TrackColorMode) {
+  /** Terrain MSL (m) at a coordinate, or null when the sample is unavailable (offline / no coverage). */
+  async function terrainGroundMsl(lat: number, lon: number): Promise<number | null> {
+    try {
+      return await invoke<number | null>('terrain_elevation', { lat, lon });
+    } catch (e) {
+      console.warn('[Map3D] terrain lookup failed', e);
+      return null;
+    }
+  }
+
+    async function updatePlaybackTrack3D(track: TelemetryRecord[], colorMode: TrackColorMode, protocol: string | null) {
     if (!viewer) return;
 
     // Mark a load in progress and drop the previous track reference up front: this function is async
@@ -3091,15 +3106,31 @@
 
     // Anchor: GPS MSL at the first fix (absolute reference for the relative, fused track altitude).
     // Includes any real height-above-ground at the start (e.g. tower/rooftop) — NOT snapped to ground.
+    //
+    // …unless the protocol never carried MSL in the first place. CRSF and LTM report altitude relative
+    // to the arming point, so their `alt_m` starts near zero and this anchor would place the whole
+    // track at sea level — i.e. buried by the local terrain elevation (issue #26: a flight at ~550 m
+    // rendered ~550 m underground). For those, take the anchor from terrain at the start point, which
+    // is what the relative altitude is measured against. Same reference the live path captures at the
+    // arm edge (`captureGroundAnchor` in stores/telemetry), and the same limitation: arming on a roof
+    // or tower shifts the whole track down by that height, because nothing in the stream records it.
     startMslGps = firstPt?.alt_m ?? 0;
+    if (isRelativeAltitudeProtocol(protocol) && firstPt) {
+      const ground = await terrainGroundMsl(firstPt.lat!, firstPt.lon!);
+      // No terrain sample (offline / gap in coverage) → keep the raw value rather than inventing one.
+      if (ground != null) startMslGps = ground;
+    }
 
     // Geoid offset for the track ellipsoid heights: N = cesiumGround_ellipsoid − copernicusGround_MSL at
     // the first point. Derived purely from terrain (NOT the UAV's GPS altitude), so it's the true
     // MSL→ellipsoid conversion regardless of arm height; must wait for Cesium World Terrain to load. Uses
     // the SAME single-flight path as the mission, so a linked mission loading moments later (see +page)
     // shares this exact computation and draws at the same height instead of racing it. Copernicus MSL is
-    // preferred; first-fix GPS MSL is the fallback ground.
-    if (firstPt) await computeGeoidOnce(firstPt.lat!, firstPt.lon!, firstPt.alt_m ?? undefined);
+    // preferred; the start anchor is the fallback ground. That anchor is the first fix's GPS MSL for a
+    // true-MSL protocol (unchanged), and the terrain sample above for a relative one — passing the raw
+    // `alt_m` there would hand the fallback a near-zero "ground" and skew the offset by the whole local
+    // elevation on exactly the flights this fix is about.
+    if (firstPt) await computeGeoidOnce(firstPt.lat!, firstPt.lon!, startMslGps);
 
     // Filter to valid GPS points and convert to Cartesian3 with geoid correction
     const validTrack = track.filter(

--- a/src/lib/helpers/altReference.ts
+++ b/src/lib/helpers/altReference.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+// Which *recorded* flights carry arming-relative altitude instead of true MSL.
+//
+// The live path already knows this: the passive backend emits `telemetry-alt-ref` when it locks a
+// protocol (`handler.rs`, `msl = !matches!(p, Protocol::Ltm | Protocol::Crsf)`), and the frontend
+// anchors the relative value to a ground MSL captured at the arm edge. A *replayed* flight has no such
+// event — the only surviving hint is the `protocol` label the recorder wrote onto the flight row.
+//
+// So this matches on that label. It is deliberately the ONLY place that does, because the match makes
+// the label part of a data contract: renaming it in `handler.rs` would silently break every stored
+// flight. The clean fix is a dedicated column plus a migration that back-fills it from exactly this
+// function — worth doing on the next schema change, not worth a migration on its own.
+
+/** Flight-row `protocol` labels written by the passive backend (see `passive_telemetry/handler.rs`). */
+const RELATIVE_ALTITUDE_PROTOCOLS = ['CRSF', 'LTM'];
+
+/**
+ * True when a recorded flight's GPS altitude (`alt_m`) is relative to the arming point rather than
+ * true MSL — currently the passive CRSF and LTM links, which carry no MSL at all.
+ *
+ * Callers must anchor such a track to a ground reference (terrain elevation at the start point)
+ * instead of trusting `alt_m` as an absolute height.
+ */
+export function isRelativeAltitudeProtocol(protocol: string | null | undefined): boolean {
+  if (!protocol) return false;
+  // Only the passive "Telemetry (…)" labels are relative; an MSP or MAVLink flight reports true MSL.
+  if (!protocol.startsWith('Telemetry (')) return false;
+  return RELATIVE_ALTITUDE_PROTOCOLS.some((p) => protocol.includes(p));
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1981,6 +1981,10 @@
   // FC variant for the selected flight (used by mode widgets + map coloring)
   const replayFcVariant = $derived((selectedFlight as Flight | null)?.fc_variant ?? 'INAV');
 
+  // Recording protocol of the selected flight — the 3D map needs it to tell a true-MSL track from an
+  // arming-relative one (CRSF/LTM), which decides how its altitude anchor is derived.
+  const replayProtocol = $derived((selectedFlight as Flight | null)?.protocol ?? null);
+
   // Absolute flight-start epoch (ms) — telemetry timestamp_ms is flight-relative, so the
   // 3D sky clock needs this origin to reconstruct the real instant for sun positioning.
   const replayStartEpochMs = $derived.by(() => {
@@ -2479,6 +2483,7 @@
           active={mapViewMode === '3d'}
           playbackTrack={mapTrack}
           playbackPoint={playbackPoint}
+          playbackProtocol={replayProtocol}
           {replayStartEpochMs}
           {trackColorMode}
           platformType={mapPlatformType}


### PR DESCRIPTION
Fixes #26.

**3D track rendered underground.** The replay anchored its track on the first fix's `alt_m`, which is
only a true MSL for protocols that report one. CRSF and LTM send altitude relative to the arming point,
so the track was placed at sea level — buried by the local terrain. Verified on the reporter's flight
(DB #142, CRSF, Codlea): `alt_m` runs -2…143 m against ~550 m of terrain. The anchor now comes from
terrain at the start point, the same reference the live path captures at the arm edge; a missing terrain
sample keeps the old behaviour rather than inventing a height.

The geoid fallback ground read the same raw `alt_m` and would have skewed the offset by the full local
elevation whenever the Copernicus lookup came back empty. It now uses the resolved anchor.

**Aircraft always disarmed in replay.** `armingFlags` was read from `state_flags`, which only blackbox
imports populate — the live recorder stores NULL, so every replayed live flight looked disarmed on any
protocol. Recovered from the recording itself: the recorder brackets a flight between arm and disarm, so
a sample carrying a flight mode was taken while armed.

Both work on flights already in the database. MSP, MAVLink and SmartPort report true MSL and are
untouched.

Which protocols are relative is decided in one place (`helpers/altReference.ts`) by matching the stored
protocol label — no migration, works retroactively, at the cost of making that label a data contract.
A real column back-filled from the same match is noted for the next schema change.

**Checks:** `npm run check` 556 files, 0 errors. `npm run build` clean.
**Verified by the maintainer:** CRSF track sits on the terrain, arming state shows during replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
