### PR TITLE
fix(crsf): fall back to GPS altitude while no baro frame has been decoded

### DIFF
--- a/src-tauri/src/passive_telemetry/decoders/crsf.rs
+++ b/src-tauri/src/passive_telemetry/decoders/crsf.rs
@@ -223,6 +223,11 @@ struct State {
     baro_alt: f64,
     vario: f64,
     seen_altitude: bool,
+    /// A BARO_ALT (0x09) frame has actually been decoded. Presence, not value: INAV only sends the
+    /// frame since 9.0 (with a baro), so on 8.x `baro_alt` would stay a placeholder 0.0 forever while
+    /// VARIO keeps triggering altitude events — issue #30. Publish falls back to the GPS altitude
+    /// until the first real baro frame; a genuine baro reading of 0.0 is left untouched.
+    seen_baro: bool,
 
     voltage: f64,
     current: f64,
@@ -372,6 +377,7 @@ impl CrsfDecoder {
             }
             Decoded::BaroAlt { alt_m, .. } => {
                 s.baro_alt = *alt_m;
+                s.seen_baro = true;
                 s.seen_altitude = true;
                 s.fresh_altitude = true;
             }
@@ -503,7 +509,13 @@ impl CrsfDecoder {
         }
 
         if f_alt {
-            let alt = AltitudeData { altitude: s.baro_alt, vario: s.vario };
+            // No baro frame ever decoded → the GPS frame's altitude is the only altitude this link
+            // carries (INAV ≤ 8.x never sends 0x09; see `seen_baro`). Same arming-relative reference
+            // as the baro value for INAV, so the consumers don't care which one fed it. When 0x09 IS
+            // present, behaviour is bit-identical to before — a link that sends the frame (Crossfire,
+            // mLRS, ELRS + INAV 9) cannot be affected by this fallback.
+            let alt_m = if s.seen_baro { s.baro_alt } else { s.gps_alt };
+            let alt = AltitudeData { altitude: alt_m, vario: s.vario };
             let _ = app.emit("telemetry-altitude", &alt);
             if let Some(rec) = recorder {
                 if let Ok(mut r) = rec.lock() { r.on_altitude(&alt); }


### PR DESCRIPTION
Fixes #30.

**Root cause.** The CRSF decoder published the altitude event as a hard 0.0 whenever VARIO frames
arrived without BARO_ALTITUDE (0x09) — vario alone triggers the event, and `baro_alt` is only filled
by the 0x09 frame. INAV sends that frame **only since 9.0** (commit `67fb0859`, first shipped
2026-01-17) and gates it on a detected baro; VARIO goes out far earlier (baro *or* fixed-wing + GPS).
Confirmed on the reporter's setup: **INAV 8.0.1 + ELRS 3.5.x** — the FC never emits the frame, the
link is innocent. So the ALT widget sat at 0.0 live, and every recording stored a genuine zero into
`baro_alt_m`, which replay then rightly preferred over the good GPS altitude in `alt_m` → flat 3D
tracks.

**Fix.** A `seen_baro` flag flips the moment a 0x09 frame is actually **decoded** — presence, not
value. Until then the altitude event carries the GPS frame's altitude, which INAV fills
arming-relative (verified against a real INAV 9.1 recording: both CRSF altitudes share the same
reference), so the existing ground-anchor machinery applies unchanged. A genuine baro reading of 0.0
stays 0.0, and any link that does send 0x09 (Crossfire, mLRS, ELRS + INAV 9) never enters the
fallback branch — behaviour there is bit-identical to before.

**Deliberately not done:** rescuing existing recordings (their `baro_alt_m` holds real stored zeros).
No migration effort pre-release; the fix applies to new recordings.

**Checks:** `cargo check` + `cargo test --no-run` clean. Frontend untouched.

**Verification plan:** release build from this branch goes to the reporter; merge on their
confirmation that the ALT widget and new recordings show altitude on INAV 8.x.
