### PR TITLE
fix(telemetry): match INAV's flight-mode reporting in the relay encoders

### DIFF
--- a/src-tauri/src/flightmode/mod.rs
+++ b/src-tauri/src/flightmode/mod.rs
@@ -47,7 +47,9 @@ const AUTO_TUNE: u32 = 1 << 10;
 const NAV_WP: u32 = 1 << 11;
 const NAV_COURSE_HOLD: u32 = 1 << 12;
 const FLAPERON: u32 = 1 << 13;
+const TURTLE: u32 = 1 << 15;
 const SOARING: u32 = 1 << 16;
+const ANGLEHOLD: u32 = 1 << 17;
 const NAV_FW_AUTOLAND: u32 = 1 << 18;
 
 /// Classify the normalized INAV flight-mode bitmask into the canonical model.
@@ -74,6 +76,10 @@ pub fn classify_inav(flags: u32) -> FlightModeState {
         "horizon"
     } else if flags & MANUAL != 0 {
         "manual"
+    } else if flags & TURTLE != 0 {
+        "turtle"
+    } else if flags & ANGLEHOLD != 0 {
+        "anglehold"
     } else {
         "acro"
     };

--- a/src-tauri/src/passive_telemetry/decoders/crsf.rs
+++ b/src-tauri/src/passive_telemetry/decoders/crsf.rs
@@ -182,12 +182,16 @@ fn classify_crsf_mode(text: &str) -> (bool, u32, FlightModeState) {
         _ => 0,
     };
     let primary = match text {
-        "ANGL" | "ANGH" | "AH" => "angle",
+        // "AH" = alt hold (self-levelled); "ANGH" = INAV's angle-hold MODE — not althold.
+        "ANGL" | "AH" => "angle",
+        "ANGH" => "anglehold",
         "HOR" => "horizon",
         "HOLD" | "LOTR" => "poshold",
         "CRUZ" | "CRSH" => "cruise",
         "WP" => "mission",
         "RTH" | "WRTH" => "rth",
+        "LAND" => "rth", // INAV FW autoland (RTH landing phase) — mirrors the LTM mode-15 mapping
+        "TURT" => "turtle",
         "MANU" => "manual",
         "!FS!" => "failsafe",
         "ACRO" | "OK" | "WAIT" | "!ERR" => "acro",
@@ -196,8 +200,11 @@ fn classify_crsf_mode(text: &str) -> (bool, u32, FlightModeState) {
         }
     };
     let mut modifiers = Vec::new();
-    if matches!(text, "ANGH" | "AH") {
+    if text == "AH" {
         modifiers.push("althold".to_string());
+    }
+    if text == "LAND" {
+        modifiers.push("autoland".to_string());
     }
     (armed, disable_bits, FlightModeState { primary: primary.to_string(), modifiers })
 }

--- a/src-tauri/src/passive_telemetry/decoders/frsky.rs
+++ b/src-tauri/src/passive_telemetry/decoders/frsky.rs
@@ -65,6 +65,8 @@ const F_AUTO_TUNE: u32 = 1 << 10;
 const F_NAV_WP: u32 = 1 << 11;
 const F_NAV_COURSE_HOLD: u32 = 1 << 12;
 const F_FLAPERON: u32 = 1 << 13;
+const F_TURTLE: u32 = 1 << 15;
+const F_ANGLEHOLD: u32 = 1 << 17;
 const F_NAV_FW_AUTOLAND: u32 = 1 << 18;
 
 /// INAV arming_flags bit 2 = ARMED (what the recorder + frontend look for).
@@ -75,7 +77,7 @@ const ARMED_FLAG: u32 = 0x04;
 /// +1 = arming enabled (ready), +2 = arming disabled (not ready), +4 = ARMED. We surface the "not ready"
 /// state as a synthetic disabled bit (shared with CRSF) so the toolbar shows ready vs not-ready — 0 when
 /// ready or armed.
-fn decode_modes(value: u32) -> (bool, u32, u32) {
+pub(crate) fn decode_modes(value: u32) -> (bool, u32, u32) {
     let ones = value % 10;
     let armed = ones & 4 != 0;
     let arm_disable_bits = if ones & 2 != 0 { ARM_DISABLE_BLOCKED } else { 0 };
@@ -101,8 +103,10 @@ fn decode_modes(value: u32) -> (bool, u32, u32) {
     if tenk & 4 != 0 { f |= F_FAILSAFE; }
     else if tenk & 2 != 0 { f |= F_AUTO_TUNE; }
     if hundk & 1 != 0 { f |= F_NAV_FW_AUTOLAND; }
+    if hundk & 2 != 0 { f |= F_TURTLE; }
     if hundk & 8 != 0 { f |= F_NAV_POSHOLD; } // POSHOLD (airplane)
     if mil & 1 != 0 { f |= F_NAV_RTH; } // WP-mission RTH
+    if mil & 2 != 0 { f |= F_ANGLEHOLD; }
     (armed, arm_disable_bits, f)
 }
 

--- a/src-tauri/src/scheduler/telemetry.rs
+++ b/src-tauri/src/scheduler/telemetry.rs
@@ -444,13 +444,14 @@ fn parse_active_modes(payload: &[u8], box_ids: &[u8]) -> u32 {
         for bit in 0..8usize {
             if byte & (1 << bit) != 0 {
                 let bit_index = byte_idx * 8 + bit;
-                // Translate bit index → permanent box ID using the MSP_BOXIDS mapping
-                let permanent_id = if bit_index < box_ids.len() {
-                    box_ids[bit_index] as usize
-                } else {
-                    // Fallback: no mapping available, treat index as permanent ID
-                    bit_index
-                };
+                // Translate bit index → permanent box ID using the MSP_BOXIDS mapping. Without the
+                // mapping (BOXIDS not received yet) a bit index is NOT a permanent ID — the old
+                // index-as-ID fallback produced confidently wrong modes (whatever box the pilot
+                // configured at that position), so we report no mode instead until BOXIDS arrives.
+                if bit_index >= box_ids.len() {
+                    continue;
+                }
+                let permanent_id = box_ids[bit_index] as usize;
                 active_box_ids.push(permanent_id);
                 if let Some(flag) = box_id_to_flight_mode_bit(permanent_id) {
                     flags |= flag;
@@ -458,7 +459,7 @@ fn parse_active_modes(payload: &[u8], box_ids: &[u8]) -> u32 {
             }
         }
     }
-    eprintln!("[MSP-MODES] payload_len={}, modes_bytes={}, active_box_ids={:?}, flags=0x{:05X}",
+    log::debug!("[MSP-MODES] payload_len={}, modes_bytes={}, active_box_ids={:?}, flags=0x{:05X}",
         payload.len(), modes_bytes.len(), active_box_ids, flags);
 
     // Mirror INAV firmware logic from processRcModes():
@@ -478,7 +479,7 @@ fn parse_active_modes(payload: &[u8], box_ids: &[u8]) -> u32 {
     let has_stab = flags & (ANGLE | HORIZON | MANUAL) != 0;
     if has_nav && !has_stab {
         flags |= ANGLE;
-        eprintln!("[MSP-MODES] Implicit ANGLE from NAV mode, flags=0x{:05X}", flags);
+        log::debug!("[MSP-MODES] Implicit ANGLE from NAV mode, flags=0x{:05X}", flags);
     }
 
     flags
@@ -500,12 +501,12 @@ fn box_active(payload: &[u8], box_ids: &[u8], target: usize) -> bool {
         for bit in 0..8usize {
             if byte & (1 << bit) != 0 {
                 let bit_index = byte_idx * 8 + bit;
-                let pid = if bit_index < box_ids.len() {
-                    box_ids[bit_index] as usize
-                } else {
-                    bit_index
-                };
-                if pid == target {
+                // Same rule as parse_active_modes: no BOXIDS mapping → no claim (a raw bit index is
+                // not a permanent ID, and a false OVERRIDE positive would start RC streaming).
+                if bit_index >= box_ids.len() {
+                    continue;
+                }
+                if box_ids[bit_index] as usize == target {
                     return true;
                 }
             }
@@ -871,5 +872,27 @@ mod tests {
             }
             _ => panic!("Expected SensorStatus"),
         }
+    }
+
+    #[test]
+    fn test_parse_active_modes_requires_boxids() {
+        // MSPV2_INAV_STATUS payload: 13 header bytes + activeModes bytes + mixerProfile.
+        let mut payload = vec![0u8; 13];
+        payload.push(0b0000_1010); // bit index 1 + 3 set
+        payload.push(0); // mixerProfile
+        // Without the BOXIDS mapping a bit index is not a permanent ID → no modes, never guessed ones.
+        assert_eq!(parse_active_modes(&payload, &[]), 0);
+        // With the mapping: index 1 → box 1 (ANGLE), index 3 → box 10 (NAV RTH).
+        let box_ids = [0u8, 1, 2, 10];
+        assert_eq!(parse_active_modes(&payload, &box_ids), (1 << 0) | (1 << 4));
+    }
+
+    #[test]
+    fn test_box_active_requires_boxids() {
+        let mut payload = vec![0u8; 13];
+        payload.push(0b0000_0100); // bit index 2 set
+        payload.push(0);
+        assert!(!box_active(&payload, &[], BOX_MSP_RC_OVERRIDE));
+        assert!(box_active(&payload, &[0, 1, 50], BOX_MSP_RC_OVERRIDE));
     }
 }

--- a/src-tauri/src/telemetry_forward/encoders/crsf.rs
+++ b/src-tauri/src/telemetry_forward/encoders/crsf.rs
@@ -27,7 +27,12 @@ const FM_MANUAL: u32 = 1 << 8;
 const FM_FAILSAFE: u32 = 1 << 9;
 const FM_NAV_WP: u32 = 1 << 11;
 const FM_NAV_COURSE_HOLD: u32 = 1 << 12;
+const FM_TURTLE: u32 = 1 << 15;
+const FM_ANGLEHOLD: u32 = 1 << 17;
+const FM_NAV_FW_AUTOLAND: u32 = 1 << 18;
 const ARMED_FLAG: u32 = 0x04;
+/// INAV armingFlag_e: ARMING_DISABLED_* reasons live in bits 6..30 (mirrors `helpers/arming.ts`).
+const ARMING_DISABLED_MASK: u32 = !0x3F;
 
 #[derive(Default)]
 pub struct CrsfEncoder;
@@ -75,7 +80,7 @@ impl Encoder for CrsfEncoder {
             frame(FT_BATTERY, &p, &mut out);
         }
         if let Some(s) = cache.status.as_ref() {
-            let text = crsf_mode_string(s.flight_mode_flags, s.arming_flags & ARMED_FLAG != 0);
+            let text = crsf_mode_string(s.flight_mode_flags, s.arming_flags);
             let mut p = text.as_bytes().to_vec();
             p.push(0); // null terminator
             frame(FT_FLIGHT_MODE, &p, &mut out);
@@ -97,33 +102,86 @@ fn frame(ty: u8, payload: &[u8], out: &mut Vec<u8>) {
     out.push(crc);
 }
 
-/// Inverse of `decoders::crsf::classify_crsf_mode`: pick the dominant INAV CRSF mode string. Disarmed →
-/// "OK" (the disarmed sentinel).
-fn crsf_mode_string(flags: u32, armed: bool) -> &'static str {
-    if !armed {
-        return "OK";
+/// Pick the INAV CRSF mode string. The chain is INAV's `crsfFrameFlightMode()` (`telemetry/crsf.c`)
+/// verbatim — same tests, same order, same vocabulary ("AH" = alt hold, "ANGH" = angle-hold mode, "CRSH"
+/// = course hold vs "CRUZ" = cruise) — minus the states we cannot derive from the unified flags: HRST/GEO
+/// (RC-box / geozone state), WRTH (WP-mission RTH), LOTR (needs the airplane platform bit), and the
+/// disarmed "WAIT" GPS sentinel. Disarmed reports "OK" when ready, "!ERR" when arming is blocked.
+fn crsf_mode_string(flags: u32, arming_flags: u32) -> &'static str {
+    if arming_flags & ARMED_FLAG == 0 {
+        return if arming_flags & ARMING_DISABLED_MASK != 0 { "!ERR" } else { "OK" };
     }
-    if flags & FM_FAILSAFE != 0 {
+    if flags & FM_NAV_FW_AUTOLAND != 0 {
+        "LAND"
+    } else if flags & FM_FAILSAFE != 0 {
         "!FS!"
-    } else if flags & FM_NAV_RTH != 0 {
-        "RTH"
-    } else if flags & FM_NAV_WP != 0 {
-        "WP"
-    } else if flags & FM_NAV_COURSE_HOLD != 0 {
-        "CRUZ"
-    } else if flags & FM_NAV_POSHOLD != 0 {
-        "HOLD"
     } else if flags & FM_MANUAL != 0 {
         "MANU"
+    } else if flags & FM_TURTLE != 0 {
+        "TURT"
+    } else if flags & FM_NAV_RTH != 0 {
+        "RTH"
+    } else if flags & FM_NAV_POSHOLD != 0 {
+        "HOLD"
+    } else if flags & FM_NAV_COURSE_HOLD != 0 && flags & FM_NAV_ALTHOLD != 0 {
+        "CRUZ"
+    } else if flags & FM_NAV_COURSE_HOLD != 0 {
+        "CRSH"
+    } else if flags & FM_NAV_WP != 0 {
+        "WP"
+    } else if flags & FM_NAV_ALTHOLD != 0 {
+        "AH"
+    } else if flags & FM_ANGLE != 0 {
+        "ANGL"
     } else if flags & FM_HORIZON != 0 {
         "HOR"
-    } else if flags & FM_ANGLE != 0 {
-        if flags & FM_NAV_ALTHOLD != 0 {
-            "ANGH"
-        } else {
-            "ANGL"
-        }
+    } else if flags & FM_ANGLEHOLD != 0 {
+        "ANGH"
     } else {
         "ACRO"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ready + armed (no ARMING_DISABLED_* bits set).
+    const ARMED: u32 = ARMED_FLAG;
+    /// A representative ARMING_DISABLED_* reason (compass not calibrated).
+    const BLOCKED: u32 = 1 << 12;
+
+    /// The collapse must match INAV's `crsfFrameFlightMode()` chain (`telemetry/crsf.c`).
+    #[test]
+    fn mode_string_matches_inav_chain() {
+        let cases: &[(u32, &str)] = &[
+            (FM_NAV_FW_AUTOLAND | FM_NAV_RTH, "LAND"),        // autoland outranks even failsafe
+            (FM_FAILSAFE | FM_NAV_RTH, "!FS!"),
+            (FM_MANUAL | FM_NAV_RTH, "MANU"),
+            (FM_TURTLE, "TURT"),
+            (FM_NAV_RTH | FM_NAV_WP, "RTH"),
+            (FM_NAV_POSHOLD | FM_NAV_ALTHOLD | FM_ANGLE, "HOLD"),
+            (FM_NAV_COURSE_HOLD | FM_NAV_ALTHOLD, "CRUZ"),    // cruise = course hold + alt hold
+            (FM_NAV_COURSE_HOLD, "CRSH"),                     // course hold alone
+            (FM_NAV_WP | FM_NAV_ALTHOLD, "WP"),
+            (FM_NAV_ALTHOLD | FM_ANGLE, "AH"),                // angle+althold
+            (FM_NAV_ALTHOLD | FM_HORIZON, "AH"),              // horizon+althold
+            (FM_NAV_ALTHOLD | FM_ANGLEHOLD, "AH"),            // anglehold+althold
+            (FM_ANGLE, "ANGL"),
+            (FM_HORIZON, "HOR"),
+            (FM_ANGLEHOLD, "ANGH"),                           // anglehold alone — NOT althold vocabulary
+            (0, "ACRO"),
+        ];
+        for &(flags, expected) in cases {
+            assert_eq!(crsf_mode_string(flags, ARMED), expected, "flags=0x{flags:X}");
+        }
+    }
+
+    #[test]
+    fn disarmed_reports_readiness() {
+        assert_eq!(crsf_mode_string(0, 0), "OK");
+        assert_eq!(crsf_mode_string(0, BLOCKED), "!ERR");
+        // INAV checks ARMED first — an armed craft never reports !ERR.
+        assert_eq!(crsf_mode_string(0, ARMED | BLOCKED), "ACRO");
     }
 }

--- a/src-tauri/src/telemetry_forward/encoders/ltm.rs
+++ b/src-tauri/src/telemetry_forward/encoders/ltm.rs
@@ -21,6 +21,7 @@ const FM_HEADING: u32 = 1 << 2;
 const FM_NAV_ALTHOLD: u32 = 1 << 3;
 const FM_NAV_RTH: u32 = 1 << 4;
 const FM_NAV_POSHOLD: u32 = 1 << 5;
+const FM_HEADFREE: u32 = 1 << 6;
 const FM_NAV_LAUNCH: u32 = 1 << 7;
 const FM_MANUAL: u32 = 1 << 8;
 const FM_FAILSAFE: u32 = 1 << 9;
@@ -123,34 +124,67 @@ fn s_frame(cache: &TelemetryCache) -> Vec<u8> {
     frame(b'S', &p)
 }
 
-/// Collapse the unified flight-mode bitfield into a single LTM mode number (`ltm_modes_e`). Inverse of
-/// `decoders::ltm::classify_ltm_mode`; ordered most-dominant first since LTM carries only one mode.
+/// Collapse the unified flight-mode bitfield into a single LTM mode number (`ltm_modes_e`). The chain is
+/// INAV's `ltm_sframe()` (`telemetry/ltm.c`) verbatim — same tests, same order — so a combined-mode flight
+/// reports exactly what INAV itself would send over LTM (e.g. launch during cruise = cruise, autoland
+/// during RTH = RTH).
 fn ltm_mode_from_flags(f: u32) -> u8 {
-    if f & FM_NAV_FW_AUTOLAND != 0 {
-        15 // RTH autoland
-    } else if f & FM_NAV_RTH != 0 {
-        13 // RTH
+    if f & FM_MANUAL != 0 {
+        0 // manual
     } else if f & FM_NAV_WP != 0 {
         10 // mission / waypoint
-    } else if f & FM_NAV_LAUNCH != 0 {
-        20 // launch
+    } else if f & FM_NAV_RTH != 0 {
+        13 // RTH
     } else if f & FM_NAV_POSHOLD != 0 {
         9 // GPS hold
     } else if f & FM_NAV_COURSE_HOLD != 0 {
         18 // cruise
-    } else if f & FM_NAV_ALTHOLD != 0 {
-        8 // alt hold (LTM: angle+althold)
+    } else if f & FM_NAV_LAUNCH != 0 {
+        20 // launch
     } else if f & FM_AUTO_TUNE != 0 {
         21 // autotune
-    } else if f & FM_MANUAL != 0 {
-        0 // manual
-    } else if f & FM_HEADING != 0 {
+    } else if f & FM_NAV_ALTHOLD != 0 {
+        8 // alt hold
+    } else if f & (FM_HEADFREE | FM_HEADING) != 0 {
         11 // heading hold
-    } else if f & FM_HORIZON != 0 {
-        3 // horizon
     } else if f & FM_ANGLE != 0 {
         2 // angle
+    } else if f & FM_HORIZON != 0 {
+        3 // horizon
+    } else if f & FM_NAV_FW_AUTOLAND != 0 {
+        15 // land
     } else {
-        4 // acro / rate fallback
+        1 // rate
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The collapse must match INAV's `ltm_sframe()` chain (`telemetry/ltm.c`) for combined modes.
+    #[test]
+    fn collapse_matches_inav_chain() {
+        let cases: &[(u32, u8)] = &[
+            (FM_MANUAL | FM_NAV_RTH, 0),                              // manual wins over everything
+            (FM_NAV_WP | FM_NAV_RTH, 10),                             // WP-mission RTH reports the mission
+            (FM_NAV_FW_AUTOLAND | FM_NAV_RTH | FM_ANGLE, 13),         // autoland during RTH reports RTH
+            (FM_NAV_LAUNCH | FM_NAV_COURSE_HOLD | FM_NAV_ALTHOLD, 18), // launch during cruise = cruise
+            (FM_NAV_POSHOLD | FM_NAV_COURSE_HOLD, 9),
+            (FM_NAV_LAUNCH | FM_ANGLE, 20),
+            (FM_AUTO_TUNE | FM_NAV_ALTHOLD, 21),                      // autotune before althold
+            (FM_ANGLE | FM_NAV_ALTHOLD, 8),                           // angle+althold = althold
+            (FM_HORIZON | FM_NAV_ALTHOLD, 8),                         // horizon+althold = althold
+            ((1 << 17) | FM_NAV_ALTHOLD, 8),                          // anglehold+althold = althold
+            (FM_HEADFREE, 11),                                        // headfree maps to headhold too
+            (FM_HEADING | FM_ANGLE, 11),
+            (FM_ANGLE | FM_HORIZON, 2),                               // angle before horizon
+            (FM_HORIZON, 3),
+            (FM_NAV_FW_AUTOLAND, 15),                                 // land, only without any nav mode
+            (0, 1),                                                   // INAV sends RATE (1), not ACRO (4)
+        ];
+        for &(flags, expected) in cases {
+            assert_eq!(ltm_mode_from_flags(flags), expected, "flags=0x{flags:X}");
+        }
     }
 }

--- a/src-tauri/src/telemetry_forward/encoders/smartport.rs
+++ b/src-tauri/src/telemetry_forward/encoders/smartport.rs
@@ -34,14 +34,19 @@ const FM_HEADING: u32 = 1 << 2;
 const FM_NAV_ALTHOLD: u32 = 1 << 3;
 const FM_NAV_RTH: u32 = 1 << 4;
 const FM_NAV_POSHOLD: u32 = 1 << 5;
+const FM_HEADFREE: u32 = 1 << 6;
 const FM_MANUAL: u32 = 1 << 8;
 const FM_FAILSAFE: u32 = 1 << 9;
 const FM_AUTO_TUNE: u32 = 1 << 10;
 const FM_NAV_WP: u32 = 1 << 11;
 const FM_NAV_COURSE_HOLD: u32 = 1 << 12;
 const FM_FLAPERON: u32 = 1 << 13;
+const FM_TURTLE: u32 = 1 << 15;
+const FM_ANGLEHOLD: u32 = 1 << 17;
 const FM_NAV_FW_AUTOLAND: u32 = 1 << 18;
 const ARMED_FLAG: u32 = 0x04;
+/// INAV armingFlag_e: ARMING_DISABLED_* reasons live in bits 6..30 (mirrors `helpers/arming.ts`).
+const ARMING_DISABLED_MASK: u32 = !0x3F;
 
 #[derive(Default)]
 pub struct SmartportEncoder;
@@ -84,7 +89,7 @@ impl Encoder for SmartportEncoder {
             frame(ID_ASPD, (asp.airspeed / 0.514444).round() as u32, &mut out); // m/s → knots
         }
         if let Some(s) = cache.status.as_ref() {
-            frame(ID_MODES, encode_modes(s.flight_mode_flags, s.arming_flags & ARMED_FLAG != 0), &mut out);
+            frame(ID_MODES, encode_modes(s.flight_mode_flags, s.arming_flags), &mut out);
         }
         out
     }
@@ -142,28 +147,100 @@ fn latlong_value(deg: f64, is_lon: bool) -> u32 {
     v
 }
 
-/// Inverse of `decoders::frsky::decode_modes`: pack the unified flight-mode flags + armed into INAV's
-/// decimal-column format (`frskyGetFlightMode`).
-fn encode_modes(flags: u32, armed: bool) -> u32 {
-    let mut tens = 0u32;
-    if flags & FM_ANGLE != 0 { tens |= 1; }
-    if flags & FM_HORIZON != 0 { tens |= 2; }
-    if flags & FM_MANUAL != 0 { tens |= 4; }
-    let mut huns = 0u32;
-    if flags & FM_HEADING != 0 { huns |= 1; }
-    if flags & FM_NAV_ALTHOLD != 0 { huns |= 2; }
-    if flags & FM_NAV_POSHOLD != 0 { huns |= 4; }
-    let mut thous = 0u32;
-    if flags & FM_NAV_RTH != 0 { thous |= 1; }
-    if flags & FM_NAV_WP != 0 { thous |= 2; }
-    if flags & FM_NAV_COURSE_HOLD != 0 { thous |= 8; }
-    let mut tenk = 0u32;
-    if flags & FM_FLAPERON != 0 { tenk |= 1; }
-    if flags & FM_AUTO_TUNE != 0 { tenk |= 2; }
-    if flags & FM_FAILSAFE != 0 { tenk |= 4; }
-    let mut hundk = 0u32;
-    if flags & FM_NAV_FW_AUTOLAND != 0 { hundk |= 1; }
+/// Inverse of `decoders::frsky::decode_modes`: pack the unified flight-mode flags + arming state into
+/// INAV's decimal-column format — `frskyGetFlightMode()` (`telemetry/smartport.c`) verbatim, including
+/// the else-chains that keep every column a single decimal digit (our old independent ORs could push the
+/// thousands column past 9 and corrupt the neighbours). Not derivable from the unified flags: the
+/// POSHOLD-airplane split (hundreds vs the 800000 "LOTR" column — we always use the hundreds column,
+/// which every decoder reads as plain POSHOLD) and WP-mission RTH (millions column — we always use the
+/// thousands column).
+fn encode_modes(flags: u32, arming_flags: u32) -> u32 {
+    let mut v: u32 = 0;
+    // ones column: readiness + armed
+    if arming_flags & ARMING_DISABLED_MASK == 0 { v += 1; } else { v += 2; }
+    if arming_flags & ARMED_FLAG != 0 { v += 4; }
+    // tens column
+    if flags & FM_ANGLE != 0 { v += 10; }
+    if flags & FM_HORIZON != 0 { v += 20; }
+    if flags & FM_MANUAL != 0 { v += 40; }
+    // hundreds column
+    if flags & FM_HEADING != 0 { v += 100; }
+    if flags & FM_NAV_ALTHOLD != 0 { v += 200; }
+    if flags & FM_NAV_POSHOLD != 0 { v += 400; }
+    // thousands column
+    if flags & FM_NAV_RTH != 0 { v += 1000; }
+    if flags & FM_NAV_COURSE_HOLD != 0 {
+        v += 8000;
+    } else if flags & FM_NAV_WP != 0 {
+        v += 2000;
+    } else if flags & FM_HEADFREE != 0 {
+        v += 4000;
+    }
+    // ten-thousands column
+    if flags & FM_FLAPERON != 0 { v += 10_000; }
+    if flags & FM_FAILSAFE != 0 {
+        v += 40_000;
+    } else if flags & FM_AUTO_TUNE != 0 {
+        v += 20_000;
+    }
+    // hundred-thousands column
+    if flags & FM_NAV_FW_AUTOLAND != 0 { v += 100_000; }
+    if flags & FM_TURTLE != 0 { v += 200_000; }
+    // millions column
+    if flags & FM_ANGLEHOLD != 0 { v += 2_000_000; }
+    v
+}
 
-    let units = if armed { 4 } else { 0 };
-    units + tens * 10 + huns * 100 + thous * 1000 + tenk * 10_000 + hundk * 100_000
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::passive_telemetry::decoders::frsky::decode_modes;
+
+    /// Ready-to-arm + armed → ones column 5, like INAV.
+    const ARMED: u32 = ARMED_FLAG;
+
+    /// Every decimal column must stay a single digit even with every encodable flag set at once —
+    /// the INAV else-chains guarantee it (the old independent ORs could carry into the neighbour
+    /// column: RTH+WP+CRUZ made the thousands column 11).
+    #[test]
+    fn digits_never_overflow() {
+        let all = FM_ANGLE | FM_HORIZON | FM_HEADING | FM_NAV_ALTHOLD | FM_NAV_RTH | FM_NAV_POSHOLD
+            | FM_HEADFREE | FM_MANUAL | FM_FAILSAFE | FM_AUTO_TUNE | FM_NAV_WP | FM_NAV_COURSE_HOLD
+            | FM_FLAPERON | FM_TURTLE | FM_ANGLEHOLD | FM_NAV_FW_AUTOLAND;
+        // ones=5 tens=7 huns=7 thous=9 (RTH+course; WP/headfree suppressed) tenk=5 (flaperon+failsafe;
+        // autotune suppressed) hundk=3 mil=2
+        assert_eq!(encode_modes(all, ARMED), 2_359_775);
+    }
+
+    /// encode → decode must reproduce the flags exactly (cases chosen within INAV's lossless set).
+    #[test]
+    fn roundtrip_through_frsky_decoder() {
+        let cases: &[u32] = &[
+            FM_NAV_RTH | FM_NAV_FW_AUTOLAND | FM_ANGLE | FM_NAV_ALTHOLD, // RTH + autoland
+            FM_NAV_POSHOLD | FM_NAV_ALTHOLD | FM_ANGLE,
+            FM_NAV_COURSE_HOLD | FM_NAV_ALTHOLD | FM_ANGLE,              // cruise
+            FM_HEADFREE | FM_ANGLE,
+            FM_ANGLEHOLD | FM_NAV_ALTHOLD,
+            FM_TURTLE,
+            FM_MANUAL,
+            0,
+        ];
+        for &flags in cases {
+            let (armed, disable_bits, decoded) = decode_modes(encode_modes(flags, ARMED));
+            assert!(armed, "flags=0x{flags:X}");
+            assert_eq!(disable_bits, 0, "flags=0x{flags:X}");
+            assert_eq!(decoded, flags, "flags=0x{flags:X}");
+        }
+    }
+
+    /// The ones column carries readiness: 1 = ready, 2 = arming blocked (any ARMING_DISABLED_* bit).
+    #[test]
+    fn arming_state_columns() {
+        let (armed, disable, _) = decode_modes(encode_modes(0, 0));
+        assert!(!armed);
+        assert_eq!(disable, 0);
+        let (armed, disable, _) = decode_modes(encode_modes(0, 1 << 12)); // compass not calibrated
+        assert!(!armed);
+        assert_ne!(disable, 0);
+    }
 }

--- a/src/lib/helpers/flightModeRegistry.ts
+++ b/src/lib/helpers/flightModeRegistry.ts
@@ -61,6 +61,8 @@ export const MODE_REGISTRY: Record<string, ModeDef> = {
   cruise:       { label: 'Cruise',       category: 'cruise' },
   angle:        { label: 'Angle',        category: 'stabilized' },
   horizon:      { label: 'Horizon',      category: 'stabilized' },
+  anglehold:    { label: 'AngleHold',    category: 'stabilized' },
+  turtle:       { label: 'Turtle',       category: 'other' },
   manual:       { label: 'Manual',       category: 'manual' },
   acro:         { label: 'Acro',         category: 'acro' },
 


### PR DESCRIPTION
The relay encoders (LTM / CRSF / S.Port) now collapse combined flight modes exactly like INAV's own telemetry encoders — the chains are taken verbatim from `telemetry/ltm.c`, `telemetry/crsf.c` and `telemetry/smartport.c`. Combined modes (Angle+AltHold, Horizon+AltHold, AngleHold+AltHold, launch during cruise, autoland during RTH) now report identically to a real INAV FC on the same link type.

- **CRSF vocabulary**: "AH" for alt hold (previously mislabelled "ANGH", which is INAV's angle-hold *mode*), CRSH/CRUZ distinction, LAND/TURT, "!ERR" when disarmed with arming blocked
- **S.Port**: INAV's exact decimal-column packing — incl. the else-chains that stop RTH+WP+course-hold overflowing the thousands column, the readiness ones-digit, and the HEADFREE/TURTLE/ANGLEHOLD columns (decoder reads the new columns too)
- **New unified modes** `anglehold` + `turtle` end-to-end (classify → registry → widget/track colors)
- **MSP**: no more flight-mode guessing while MSP_BOXIDS hasn't arrived — a bit index is not a permanent box id; same guard for the RC-override box check
- 8 new unit tests pin the collapses against the INAV chains and round-trip S.Port encode→decode

Checks: `cargo check` clean, `cargo test` 94 passed, `npm run check` 0/0.