### PR TITLE
fix(serial): raise DTR/RTS on open — USB-CDC devices gate their TX on it

### DIFF
--- a/src-tauri/src/transport/serial.rs
+++ b/src-tauri/src/transport/serial.rs
@@ -414,10 +414,19 @@ impl SerialConnection {
                         eprintln!("[serial] {} opened on attempt {}/{}", port_name, attempt, OPEN_RETRY_ATTEMPTS);
                         log::info!("Serial port {} opened on attempt {}/{}", port_name, attempt, OPEN_RETRY_ATTEMPTS);
                     }
-                    return Ok(Self {
+                    let mut conn = Self {
                         port_name: port_name.to_string(),
                         port,
-                    });
+                    };
+                    // Raise DTR/RTS like every standard tool does on open (INAV Configurator, Mission
+                    // Planner, terminals). USB-CDC devices gate their device→host stream on DTR
+                    // (`tud_cdc_n_connected()`), so after a bare open() the device never sends a byte
+                    // and the link looks dead in exactly one direction. Best-effort: some virtual
+                    // ports (BT-SPP) don't implement the lines — log and continue.
+                    if let Err(e) = conn.set_control_signals(true, true) {
+                        log::warn!("Serial {}: raising DTR/RTS failed (continuing): {}", port_name, e);
+                    }
+                    return Ok(conn);
                 }
                 Err(e) => {
                     last_err = e.to_string();


### PR DESCRIPTION
`SerialConnection::open()` did a bare `serialport` open; the Rust crate does not assert DTR by itself. USB-CDC firmware commonly gates its device→host stream on DTR (`tud_cdc_n_connected()`), so against a virtual COM port — found with a Kite-Link USB-OTG node — the connection failed asymmetrically: requests reached the device, every response was dropped before the wire. INAV Configurator / Mission Planner / terminals work because they raise DTR on open.

- The raise sits inside `open()` itself → FC connect, passive listen and FormationFlight all inherit it; the ADS-B source's existing explicit call stays as a harmless no-op
- Best-effort: virtual ports without control lines (BT-SPP) log a warning and continue
- DTR+RTS are asserted **together** — on ESP32 auto-reset circuits that is the neutral combination (no reset/bootloader hold)

Checks: `cargo check` clean, `cargo test` 86 passed.