### PR TITLE
fix(home): recover the real FC home on a mid-flight reconnect

### DIFF
--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -569,6 +569,11 @@ fn connect_mavlink(
     // fire-and-forget — the PARAM_VALUE reply is decoded by the handler thread once it starts.
     mavlink_proto::params::request_ekf_type(&mut *byte_transport, fc_sysid);
 
+    // One-shot HOME_POSITION request — recovers the real FC home on a mid-flight connect (MAVLink
+    // counterpart of the MSP_WP(0) read below in the MSP path). Unconditional: in Full-telemetry
+    // mode this is the ONLY source (no interval push), in reduced mode it beats the first 0.2 Hz tick.
+    mavlink_proto::params::request_home_position(&mut *byte_transport, fc_sysid);
+
     // ArduPilot: read Q_ENABLE to detect a QuadPlane (which reports MAV_TYPE_FIXED_WING, so the mission
     // vehicle class can't be told from the HEARTBEAT alone). Copter/Rover/Sub lack the param → no reply.
     if fc_info.fc_variant.starts_with("Ardu") {

--- a/src-tauri/src/mavlink_proto/params.rs
+++ b/src-tauri/src/mavlink_proto/params.rs
@@ -10,7 +10,7 @@
 // handler (emits `telemetry-ekf-type`). Fire-and-forget: if the reply is lost the UI just shows a
 // generic "EKF" label until the next connect.
 
-use ::mavlink::ardupilotmega::{MavMessage, PARAM_REQUEST_READ_DATA};
+use ::mavlink::ardupilotmega::{MavCmd, MavMessage, COMMAND_LONG_DATA, PARAM_REQUEST_READ_DATA};
 
 use crate::transport::ByteTransport;
 
@@ -54,4 +54,38 @@ pub fn request_ekf_type(transport: &mut dyn ByteTransport, fc_sysid: u8) {
 /// is the reliable QuadPlane signal, the same one Mission Planner uses.
 pub fn request_quadplane_flag(transport: &mut dyn ByteTransport, fc_sysid: u8) {
     request_param(transport, fc_sysid, "Q_ENABLE");
+}
+
+/// HOME_POSITION MAVLink message id (common #242).
+const MSG_ID_HOME_POSITION: f32 = 242.0;
+
+/// Request HOME_POSITION once (MAV_CMD_REQUEST_MESSAGE 512) — the MAVLink counterpart of the MSP
+/// path's one-shot MSP_WP(0) read, so a mid-flight connect / app restart recovers the real FC home
+/// immediately. This is what Mission Planner does (via the older GET_HOME_POSITION); it cannot be
+/// left to the 0.2 Hz SET_MESSAGE_INTERVAL push alone, because Full-telemetry mode resets that to
+/// the FC default and ArduPilot does not stream HOME_POSITION in any SRn group — home then only
+/// arrives on change. Fire-and-forget: the reply is decoded by the handler thread (emits
+/// `home-position`); the COMMAND_ACK is dispatched as a stray and dropped.
+pub fn request_home_position(transport: &mut dyn ByteTransport, fc_sysid: u8) {
+    let header = codec::gcs_header();
+    let mut seq = MavSequence::new();
+
+    let msg = MavMessage::COMMAND_LONG(COMMAND_LONG_DATA {
+        target_system: fc_sysid,
+        target_component: 1, // MAV_COMP_ID_AUTOPILOT1
+        command: MavCmd::MAV_CMD_REQUEST_MESSAGE,
+        confirmation: 0,
+        param1: MSG_ID_HOME_POSITION,
+        param2: 0.0,
+        param3: 0.0,
+        param4: 0.0,
+        param5: 0.0,
+        param6: 0.0,
+        param7: 0.0,
+    });
+    let frame = codec::serialize_v2(&header, &msg, &mut seq);
+    match transport.write_bytes(&frame) {
+        Ok(()) => eprintln!("[MAVLINK-PARAM] requested HOME_POSITION"),
+        Err(e) => log::warn!("Failed to request HOME_POSITION: {}", e),
+    }
 }

--- a/src/lib/adapters/telemetryAdapter.ts
+++ b/src/lib/adapters/telemetryAdapter.ts
@@ -92,6 +92,7 @@ export function toTelemetryData(r: TelemetryRecord, fcVariant = 'INAV'): Telemet
     // flight on the arm edge and finalises it on disarm, so every sample in a flight row was taken
     // while armed, and any sample carrying a flight mode proves telemetry was flowing at that moment.
     armingFlags: r.state_flags ?? (r.mode_primary ? ARMED_BIT : 0),
+    statusSeen: true, // replay rows always carry the recorded arming state
     cpuLoad: r.cpu_load ?? 0,
     sensorStatus: r.hw_health_status ?? 0,
     flightModeFlags: 0, // raw custom_mode is live-only (vehicle control); not replayed from the DB

--- a/src/lib/stores/telemetry.ts
+++ b/src/lib/stores/telemetry.ts
@@ -83,6 +83,13 @@ export interface TelemetryData {
 
   // Status
   armingFlags: number;
+  /** True once at least one status event (the frame carrying `armingFlags`) has arrived this
+   *  connection. Distinguishes "no status yet" from "status says disarmed" — both read as
+   *  `armingFlags === 0`. The arm-edge detector must seed from a frame that actually carries the
+   *  armed state: attitude/GPS arrive at 5–10 Hz and beat the 1 Hz status/HEARTBEAT after a
+   *  (re)connect, so seeding on any first frame reads a false `disarmed` and a mid-flight reconnect
+   *  then fires a bogus arm edge (which used to overwrite Home with the aircraft's position). */
+  statusSeen: boolean;
   cpuLoad: number;
   sensorStatus: number;
   /** Raw flight-mode flags. For MAVLink this is the FC's `custom_mode` (used by the vehicle-control
@@ -141,7 +148,7 @@ const defaultTelemetry: TelemetryData = {
   throttle: 0,
   batteries: [],
   link: { rssiPercent: null, rssiDbm: null, lq: null, snrDb: null },
-  armingFlags: 0, cpuLoad: 0, sensorStatus: 0, flightModeFlags: 0, mspRcOverride: false,
+  armingFlags: 0, statusSeen: false, cpuLoad: 0, sensorStatus: 0, flightModeFlags: 0, mspRcOverride: false,
   sensorGyro: 0, sensorAcc: 0, sensorMag: 0, sensorBaro: 0,
   sensorGps: 0, sensorRangefinder: 0, sensorPitot: 0, sensorOpflow: 0, sensorRcReceiver: 0, prearmHealthy: 0,
   ekfStatus: 0, ekfType: 0,
@@ -386,6 +393,7 @@ export async function startTelemetryListeners() {
       telemetry.update((t) => ({
         ...t,
         armingFlags: event.payload.arming_flags,
+        statusSeen: true,
         cpuLoad: event.payload.cpu_load,
         sensorStatus: event.payload.sensor_status,
         flightModeFlags: event.payload.flight_mode_flags,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -374,8 +374,11 @@
     liveTelem = t;
     // Accumulate the live flown track (RAM) for the Terrain Analyzer
     const armed = isArmed(t.armingFlags, t.lastUpdate);
-    // Baseline the armed state on the first real frame after (re)connect → no false edge on reconnect.
-    if (!armEdgeInit && t.lastUpdate > 0) { armEdgeInit = true; prevArmed = armed; }
+    // Baseline the armed state on the first frame that actually CARRIES it (statusSeen) → no false
+    // edge on reconnect. Gating on any first frame (lastUpdate) raced: attitude/GPS at 5–10 Hz beat
+    // the 1 Hz status after a reconnect, seeding prevArmed=false from a frame without arming info —
+    // the first real status then looked like an arm edge and moved Home to wherever the aircraft was.
+    if (!armEdgeInit && t.statusSeen) { armEdgeInit = true; prevArmed = armed; }
     if (armed && !prevArmed) {
       clearLiveTrack();
       // reset the flight-stats accumulator for the new flight
@@ -414,7 +417,10 @@
     // reference once from the current fix (mirrored into a manual home below → the widget points to it).
     if (armed && !prevArmed && t.fixType >= 2 && isValidGpsCoordinate(t.lat, t.lon)) {
       if (get(connection).status === 'connected') {
-        homePosition.set({ lat: t.lat, lon: t.lon, alt: t.altitude, set: true, source: 'fc' });
+        // altMsl, NOT t.altitude (relative): Home consumers treat alt as AMSL (the HOME_POSITION /
+        // MSP_WP0 paths store AMSL, Map3D places the "H" absolutely) — the relative alt (~0 at a
+        // ground arm) sank the 3D marker below the terrain by the local elevation.
+        homePosition.set({ lat: t.lat, lon: t.lon, alt: t.altMsl, set: true, source: 'fc' });
         launchPoint.set({ lat: t.lat, lng: t.lon });
       } else if (get(homePosition).source !== 'fc') {
         launchPoint.set({ lat: t.lat, lng: t.lon });


### PR DESCRIPTION
## Description

Fixes the tester-reported home-position bugs on ArduPilot (mid-flight reconnect):

- **Home jumped to the reconnect point**: the arm-edge detector seeded its baseline from the *first* telemetry frame after (re)connect. Attitude/GPS (5–10 Hz) beat the 1 Hz status/HEARTBEAT, so the seed read "disarmed" from a frame that cannot carry the armed state — the first real status frame then looked like an arm edge and moved Home to the aircraft's current position. The telemetry store now tracks `statusSeen` (set only by the event that carries `arming_flags`) and the detector seeds from that.
- **3D "H" marker far below the terrain**: the arm-edge fallback stored the *relative* altitude in a Home store whose consumers expect AMSL (HOME_POSITION / MSP_WP0 both deliver AMSL; Map3D places the marker absolutely). Now stores `altMsl`.
- **No recovery channel on MAVLink**: the MSP path always did a one-shot MSP_WP(0) home read at connect; the MAVLink path relied solely on the 0.2 Hz SET_MESSAGE_INTERVAL push — which Full-telemetry mode resets to the FC default, and ArduPilot does not stream HOME_POSITION in any SRn group. Connect now sends a one-shot `MAV_CMD_REQUEST_MESSAGE(HOME_POSITION)`, same as Mission Planner.

## Type of change

- [x] Bug fix

## Checklist

- [x] `npm run check` passes (557 files, 0 errors)
- [x] `cargo check` (in `src-tauri`) passes
- [ ] Field test by the reporter (mid-flight reconnect)
- [x] No unrelated changes

## Notes for reviewer

Low risk: the seed gate only *delays* the arm-edge baseline until the first status frame (≤1 s); a genuine ground arm behaves exactly as before, now with the correct AMSL altitude. The home request is fire-and-forget, its COMMAND_ACK is dropped as a stray.
