### PR TITLE
feat(control): FC-confirmed Guided target marker + expected loiter ring

### DIFF
--- a/src-tauri/src/commands/control.rs
+++ b/src-tauri/src/commands/control.rs
@@ -240,6 +240,15 @@ pub fn mav_set_param(name: String, value: f32, state: State<'_, AppState>) -> Re
     control::set_param(&cmd_tx, fc_sysid, &name, value)
 }
 
+/// Read a single FC parameter by name (best-effort; `None` when the FC doesn't report it within the
+/// params_rt timeout). Used for the Guided loiter-radius ring (`WP_LOITER_RAD` / `NAV_LOITER_RAD`).
+#[tauri::command(async)]
+pub fn mav_read_param(name: String, state: State<'_, AppState>) -> Result<Option<f32>, String> {
+    let (cmd_tx, fc_sysid) = mav_handle(&state)?;
+    let map = crate::mavlink_proto::params_rt::read_params(&cmd_tx, fc_sysid, &[name.as_str()]);
+    Ok(map.get(&name).copied())
+}
+
 /// Set the Guided target course/heading for a fixed-wing via `MAV_CMD_GUIDED_CHANGE_HEADING` — the
 /// plane flies this bearing continuously (not an orbit). `heading` is degrees (0–359). We command
 /// course-over-ground (HEADING_TYPE 0), which is the direction the aircraft actually tracks.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,7 +94,7 @@ use commands::mission::{
 use commands::control::{
     mav_set_mode, mav_arm, mav_takeoff, mav_land, mav_rtl, mav_rc_release, mav_reposition,
     mav_change_speed, mav_mission_start, mav_mission_pause, mav_mission_set_current,
-    mav_set_home_here, mav_abort_landing, mav_set_param,
+    mav_set_home_here, mav_abort_landing, mav_set_param, mav_read_param,
     mav_guided_change_heading, mav_guided_clear_heading, mav_condition_yaw,
     mav_vtol_transition,
 };
@@ -526,6 +526,7 @@ pub fn run() {
             mav_set_home_here,
             mav_abort_landing,
             mav_set_param,
+            mav_read_param,
             mav_guided_change_heading,
             mav_guided_clear_heading,
             mav_condition_yaw,

--- a/src-tauri/src/mavlink_proto/handler.rs
+++ b/src-tauri/src/mavlink_proto/handler.rs
@@ -495,6 +495,18 @@ struct HomeEvent {
     alt: f64,
 }
 
+/// The FC's active navigation target (`guided-target` event), from POSITION_TARGET_GLOBAL_INT —
+/// GCS_Common fills it from the vehicle's `get_target_location()` (ArduPlane: `next_WP_loc`, Copter:
+/// `flightmode->get_wp`). Only meaningful as the *guided* target while the FC is in its guided mode;
+/// in AUTO/RTL the same message carries the current mission WP / home, so the frontend gates on the
+/// active mode. `alt` is AMSL (GCS_Common sends frame GLOBAL).
+#[derive(serde::Serialize)]
+struct GuidedTargetEvent {
+    lat: f64,
+    lon: f64,
+    alt: f64,
+}
+
 /// Accumulated analog/battery state — MAVLink splits data across SYS_STATUS,
 /// BATTERY_STATUS, and RC_CHANNELS. We merge and emit a complete AnalogData.
 #[derive(Default)]
@@ -592,6 +604,18 @@ fn dispatch_message(header: &MavHeader, message: &MavMessage, fc_variant: &str, 
                 alt: home.altitude as f64 / 1000.0, // mm AMSL → m
             };
             let _ = app_handle.emit("home-position", &data);
+        }
+
+        // ── POSITION_TARGET_GLOBAL_INT → guided-target ──────────────
+        // Requested at 1 Hz (SET_MESSAGE_INTERVAL) — keeps the map's Guided marker on the FC's
+        // actual loiter/goto point, including targets set by another GCS. See GuidedTargetEvent.
+        MavMessage::POSITION_TARGET_GLOBAL_INT(pt) => {
+            let data = GuidedTargetEvent {
+                lat: pt.lat_int as f64 / 1e7,
+                lon: pt.lon_int as f64 / 1e7,
+                alt: pt.alt as f64, // m AMSL
+            };
+            let _ = app_handle.emit("guided-target", &data);
         }
 
         // ── MISSION_CURRENT → telemetry-nav-status (active waypoint) ─

--- a/src-tauri/src/mavlink_proto/parser.rs
+++ b/src-tauri/src/mavlink_proto/parser.rs
@@ -194,8 +194,23 @@ impl MavParser {
             return None;
         }
 
-        // Parse message payload into typed enum
-        match MavMessage::parse(*version, msg_id, payload) {
+        // Parse message payload into typed enum.
+        //
+        // POSITION_TARGET_GLOBAL_INT (87): ArduPilot sets the undefined upper bits of `type_mask`
+        // (POSITION_TARGET_TYPEMASK_LAST_BYTE, 0xF000 — "for future use" in GCS_Common), and the
+        // mavlink crate's strict bitflags reject the whole message (`InvalidFlag`, observed live:
+        // 0xFDF8). Clear the undefined bits (type_mask = u16 at payload offset 48) and retry —
+        // we only consume the position fields, never the mask.
+        let parsed = MavMessage::parse(*version, msg_id, payload).or_else(|e| {
+            if msg_id == 87 && payload_len >= 50 {
+                let mut fixed = payload.to_vec();
+                fixed[49] &= 0x0F;
+                MavMessage::parse(*version, msg_id, &fixed).map_err(|_| e)
+            } else {
+                Err(e)
+            }
+        });
+        match parsed {
             Ok(message) => {
                 // Reconstruct full frame: STX + header + payload + CRC
                 let stx = match version {

--- a/src-tauri/src/mavlink_proto/streamrates.rs
+++ b/src-tauri/src/mavlink_proto/streamrates.rs
@@ -34,6 +34,7 @@ const ID_BATTERY_STATUS: f32 = 147.0;
 const ID_EKF_STATUS_REPORT: f32 = 193.0;
 const ID_HOME_POSITION: f32 = 242.0;
 const ID_WIND: f32 = 168.0;
+const ID_POSITION_TARGET_GLOBAL_INT: f32 = 87.0;
 
 // Rate kinds for the wanted messages (resolved against the two settings at apply time).
 const R_ATTITUDE: u8 = 0;
@@ -58,6 +59,9 @@ const WANTED: &[(f32, u8)] = &[
     (ID_MISSION_CURRENT, R_FIXED_1HZ),
     (ID_EKF_STATUS_REPORT, R_FIXED_1HZ),
     (ID_HOME_POSITION, R_HOME_LOW),
+    // FC's active navigation target → the map's Guided marker (FC-confirmed, incl. external GCS
+    // changes). Small message; the frontend ignores it outside the guided mode.
+    (ID_POSITION_TARGET_GLOBAL_INT, R_FIXED_1HZ),
 ];
 
 // ── Ballast: high-rate messages no widget consumes — disabled (interval = -1) ────────────────

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -1089,7 +1089,7 @@
     if (!map || !$settings.airspace.enabled) return;
     if (get(editMode) || get(arduEditMode)) return; // editing waypoints (INAV or Ardu/PX4) → don't pop the airspace list
     if (activeSurveyPattern.isActive) return; // the survey pattern generator owns map clicks
-    if (get(guidedActive)) return; // Guided "fly here" owns the click → don't also pop the airspace list
+    if (guidedClickArmed()) return; // Guided "fly here" owns the click → don't also pop the airspace list
     // Toggle: if the list popup is already open, a second map click just dismisses it.
     if (aeroPopup && aeroPopup.isOpen()) {
       map.closePopup(aeroPopup);
@@ -1127,13 +1127,25 @@
   let guidedPopup: L.Popup | undefined;
   let guidedForm: ReturnType<typeof mount> | undefined;
 
+  /** Fly-Here click is armed when the Guided toggle is on OR the FC is already in its guided mode —
+   *  a mid-flight connect to a vehicle sitting in GUIDED must be commandable without first toggling
+   *  the panel button (which would re-send the mode change). */
+  function guidedClickArmed(): boolean {
+    return get(guidedActive) || get(activeMode)?.guided === true;
+  }
+
   function closeGuidedPopup() {
     if (guidedForm) { void unmount(guidedForm); guidedForm = undefined; }
     if (guidedPopup) { map?.closePopup(guidedPopup); guidedPopup = undefined; }
   }
 
   function onGuidedClick(e: L.LeafletMouseEvent) {
-    if (!map || !get(guidedActive)) return;
+    if (!map || !guidedClickArmed()) return;
+    // The mission editors and the survey generator own map clicks while active — before, arming
+    // Guided was always an explicit button press, now it can be implicit (FC already in guided),
+    // so these guards must be explicit here too.
+    if (get(editMode) || get(arduEditMode)) return;
+    if (activeSurveyPattern.isActive) return;
     // Ignore clicks that originate inside an open popup (e.g. the "Fly Here" button) — they must not
     // open a second target popup at the cursor.
     const tgt = e.originalEvent?.target as HTMLElement | undefined;

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -41,7 +41,7 @@
   import { autopilotSystem } from "$lib/stores/autopilotContext";
   import { arduMission, arduVehicleClass, arduEditMode } from "$lib/stores/missionArdupilot";
   import { activeSurveyPattern } from "$lib/stores/surveyPattern.svelte";
-  import { guidedActive, guidedTarget, repositionTo, type GuidedParams } from "$lib/controllers/vehicleControl";
+  import { guidedActive, guidedTarget, repositionTo, activeMode, guidedParams, fcLoiterRadius, type GuidedParams } from "$lib/controllers/vehicleControl";
   import GuidedTargetForm from "$lib/components/control/GuidedTargetForm.svelte";
   import { cmdHasLocation } from "$lib/helpers/arduCommandCatalog";
   import { connection } from "$lib/stores/connection";
@@ -503,6 +503,8 @@
 
   // Guided "Fly Here" / loiter-target marker (ArduPilot/PX4; reused by INAV guided post-1.0).
   let guidedTargetMarker: L.Marker | undefined;
+  // Dashed expected-loiter-track ring around the Guided target (fixed-wing only).
+  let guidedLoiterRing: L.Circle | undefined;
   // Geozone overlay (INAV ≥8.0 FC config).
   let geozoneLayer: L.LayerGroup | undefined;
   let unsubGeozone: (() => void) | undefined;
@@ -600,14 +602,21 @@
     return L.divIcon({ className: 'guided-target-divicon', html, iconSize: [20, 20], iconAnchor: [10, 24] });
   }
 
-  /** Show/move/hide the Guided loiter-target marker. Visible only while connected, Guided is active, and a
-   *  target has been set (a successful reposition); the controller clears the target on a mode change /
-   *  leaving Guided, and we also hide on disconnect. */
+  /** Show/move/hide the Guided target marker + the expected-loiter-track ring. Visible while connected
+   *  and the Guided interaction is armed OR the FC is actually in its guided mode (so a target set /
+   *  changed by another GCS still shows — the target itself is FC-confirmed via
+   *  POSITION_TARGET_GLOBAL_INT, see ingestFcGuidedTarget). Hidden on disconnect.
+   *
+   *  The ring (fixed-wing only) draws the loiter circle the aircraft will actually fly: the explicit
+   *  Fly-Here radius when one was set, else the FC's configured default (WP_LOITER_RAD /
+   *  NAV_LOITER_RAD). MP shows a meaningless dashed ring here — ours is the real expected track. */
   function updateGuidedTarget() {
     if (!map) return;
     const tgt = get(guidedTarget);
-    if (!tgt || get(connection).status !== 'connected' || !get(guidedActive)) {
+    const fcInGuided = get(activeMode)?.guided === true;
+    if (!tgt || get(connection).status !== 'connected' || !(get(guidedActive) || fcInGuided)) {
       if (guidedTargetMarker) { guidedTargetMarker.remove(); guidedTargetMarker = undefined; }
+      if (guidedLoiterRing) { guidedLoiterRing.remove(); guidedLoiterRing = undefined; }
       return;
     }
     const ll: L.LatLngExpression = [tgt.lat, tgt.lon];
@@ -616,6 +625,25 @@
       guidedTargetMarker.bindTooltip(get(t)('control.guidedTarget'), { direction: 'top', offset: [0, -18], opacity: 0.9 });
     } else {
       guidedTargetMarker.setLatLng(ll);
+    }
+    // Expected loiter track — fixed-wing only (a copter holds the point, no circle).
+    const cls = get(arduVehicleClass);
+    const fixedWing = cls === 'plane' || cls === 'quadplane';
+    const radius = get(guidedParams).loiterRadius ?? get(fcLoiterRadius);
+    if (fixedWing && radius != null && radius > 0) {
+      if (!guidedLoiterRing) {
+        guidedLoiterRing = L.circle(ll, {
+          radius,
+          color: '#59aa29', weight: 1.5, dashArray: '4 6', opacity: 0.85,
+          fill: false, interactive: false,
+        }).addTo(map);
+      } else {
+        guidedLoiterRing.setLatLng(ll);
+        guidedLoiterRing.setRadius(radius);
+      }
+    } else if (guidedLoiterRing) {
+      guidedLoiterRing.remove();
+      guidedLoiterRing = undefined;
     }
   }
 
@@ -1156,7 +1184,7 @@
   $effect(() => { if (!$guidedActive) closeGuidedPopup(); });
 
   // Guided loiter-target marker follows the guided state + the set target (and hides on disconnect).
-  $effect(() => { void $guidedActive; void $guidedTarget; void $connection; if (map) updateGuidedTarget(); });
+  $effect(() => { void $guidedActive; void $guidedTarget; void $connection; void $activeMode; void $guidedParams; void $fcLoiterRadius; if (map) updateGuidedTarget(); });
 
   // Redraw on enable-toggle, new data, or visibility change (data/visibility via subscriptions below).
   $effect(() => { void $settings.airspace.enabled; void $editMode; void $arduEditMode; void activeSurveyPattern.isActive; if (map) updateAirspace(); });

--- a/src/lib/controllers/vehicleControl.ts
+++ b/src/lib/controllers/vehicleControl.ts
@@ -73,8 +73,19 @@ export const guidedParams = writable<GuidedParams>({ alt: 50, speed: null, yaw: 
  *  Fly-Here radius is set. null = unknown / not applicable (multirotor). */
 export const fcLoiterRadius = writable<number | null>(null);
 
+// One param read per connection (the ingest path retriggers at 1 Hz and must not spam
+// PARAM_REQUEST_READ, e.g. on a copter where the FC never reports WP_LOITER_RAD).
+let loiterRadiusRequested = false;
+connection.subscribe((c) => {
+  if (c.status !== 'connected') {
+    loiterRadiusRequested = false;
+    fcLoiterRadius.set(null); // never carry a stale radius into the next session
+  }
+});
+
 /** Read the FC's default loiter radius for the ring (fixed-wing only — a copter holds the point). */
 async function refreshFcLoiterRadius(): Promise<void> {
+  loiterRadiusRequested = true;
   const cls = get(arduVehicleClass);
   if (cls !== 'plane' && cls !== 'quadplane') {
     fcLoiterRadius.set(null);
@@ -98,6 +109,9 @@ async function refreshFcLoiterRadius(): Promise<void> {
  */
 export function ingestFcGuidedTarget(lat: number, lon: number): void {
   if (get(activeMode)?.guided !== true) return;
+  // Connected mid-flight to a vehicle already in guided → the toggle was never pressed, so fetch
+  // the loiter radius for the ring here (once per connection).
+  if (!loiterRadiusRequested) void refreshFcLoiterRadius();
   const cur = get(guidedTarget);
   // ~0.1 m dedup so the 1 Hz push doesn't churn every subscriber with sub-metre jitter.
   if (cur && Math.abs(cur.lat - lat) < 1e-6 && Math.abs(cur.lon - lon) < 1e-6) return;

--- a/src/lib/controllers/vehicleControl.ts
+++ b/src/lib/controllers/vehicleControl.ts
@@ -68,6 +68,42 @@ export interface GuidedParams {
 /** Last-used Fly-Here values, remembered for the next click (session-scoped). */
 export const guidedParams = writable<GuidedParams>({ alt: 50, speed: null, yaw: null, loiterRadius: null });
 
+/** The FC's configured default loiter radius (m, magnitude — `WP_LOITER_RAD` / `NAV_LOITER_RAD`),
+ *  read once when Guided is activated. Drives the map's expected-loiter-track ring when no explicit
+ *  Fly-Here radius is set. null = unknown / not applicable (multirotor). */
+export const fcLoiterRadius = writable<number | null>(null);
+
+/** Read the FC's default loiter radius for the ring (fixed-wing only — a copter holds the point). */
+async function refreshFcLoiterRadius(): Promise<void> {
+  const cls = get(arduVehicleClass);
+  if (cls !== 'plane' && cls !== 'quadplane') {
+    fcLoiterRadius.set(null);
+    return;
+  }
+  const name = get(autopilotSystem) === 'px4' ? 'NAV_LOITER_RAD' : 'WP_LOITER_RAD';
+  try {
+    const v = await invoke<number | null>('mav_read_param', { name });
+    // Negative = counter-clockwise loiter; the ring only needs the magnitude.
+    fcLoiterRadius.set(v != null ? Math.abs(v) : null);
+  } catch {
+    fcLoiterRadius.set(null);
+  }
+}
+
+/**
+ * FC-confirmed navigation target (POSITION_TARGET_GLOBAL_INT, pushed at 1 Hz — see the `guided-target`
+ * listener in +page). Accepted only while the FC is in its guided mode: in AUTO/RTL the same message
+ * carries the current mission waypoint / home, which must not appear as a Guided marker. Keeps the
+ * marker on the FC's actual loiter/goto point — including targets set by another GCS.
+ */
+export function ingestFcGuidedTarget(lat: number, lon: number): void {
+  if (get(activeMode)?.guided !== true) return;
+  const cur = get(guidedTarget);
+  // ~0.1 m dedup so the 1 Hz push doesn't churn every subscriber with sub-metre jitter.
+  if (cur && Math.abs(cur.lat - lat) < 1e-6 && Math.abs(cur.lon - lon) < 1e-6) return;
+  guidedTarget.set({ lat, lon });
+}
+
 // ArduPlane's GUIDED_CHANGE_HEADING sets a *sticky* heading override that bypasses waypoint nav and
 // is only cleared by a mode change (current firmware does not clear it on DO_REPOSITION). We track it
 // so a subsequent "Fly Here" can explicitly clear it first, otherwise the reposition is ignored.
@@ -198,9 +234,11 @@ export function changeAlt(alt: number): Promise<boolean> {
 
 /** Set the fixed-wing loiter radius (metres) via PARAM_SET. The parameter name is firmware-specific:
  *  ArduPilot `WP_LOITER_RAD`, PX4 `NAV_LOITER_RAD`. */
-export function setLoiterRadius(radius: number): Promise<boolean> {
+export async function setLoiterRadius(radius: number): Promise<boolean> {
   const name = get(autopilotSystem) === 'px4' ? 'NAV_LOITER_RAD' : 'WP_LOITER_RAD';
-  return runCommand('setLoiterRadius', 'mav_set_param', { name, value: radius });
+  const ok = await runCommand('setLoiterRadius', 'mav_set_param', { name, value: radius });
+  if (ok) fcLoiterRadius.set(Math.abs(radius)); // keep the map's loiter ring in sync with the write
+  return ok;
 }
 
 /** Set the home position to the vehicle's current location (DO_SET_HOME). */
@@ -305,6 +343,17 @@ export async function setGuided(on: boolean): Promise<boolean> {
   const ok = await runCommand('guided', 'mav_set_mode', { main: mode.main, sub: mode.sub });
   guidedActive.set(ok);
   headingOverrideActive = false; // re-entering guided clears any heading slew
+  if (ok) {
+    // Seed the target marker at the mode-entry point right away — ArduPlane loiters around the spot
+    // where GUIDED was entered, so this IS the initial target (MP shows nothing here, which testers
+    // read as "nothing happened"). The FC's 1 Hz POSITION_TARGET_GLOBAL_INT push then confirms or
+    // corrects it (ingestFcGuidedTarget).
+    const tel = get(telemetry);
+    if (tel.fixType >= 2 && (tel.lat !== 0 || tel.lon !== 0)) {
+      guidedTarget.set({ lat: tel.lat, lon: tel.lon });
+    }
+    void refreshFcLoiterRadius(); // for the expected-loiter-track ring
+  }
   return ok;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -76,6 +76,7 @@
   import { buildMissionInput } from '$lib/helpers/missionLibrary';
   import { buildArduMissionInput } from '$lib/helpers/missionLibraryArdu';
   import { homePosition } from '$lib/stores/home';
+  import { ingestFcGuidedTarget } from '$lib/controllers/vehicleControl';
   import { MAP_PROVIDERS } from "$lib/config/mapProviders";
   import { tileCacheStats, setCacheMaxMB, clearCache } from "$lib/cache/tileCache";
   import { weatherTempDisplayFromC, weatherWindDisplayFromMs, weatherTempCFromDisplay, weatherWindMsFromDisplay, canonicalWeatherDescription } from "$lib/helpers/weather";
@@ -2426,6 +2427,11 @@
       if (unchanged) return;
       homePosition.set({ lat, lon, alt, set: true, source: 'fc' }); // authoritative → locked green "H"
       launchPoint.set({ lat, lng: lon }); // pin the planning reference to the real home
+    });
+    // FC-confirmed Guided target (POSITION_TARGET_GLOBAL_INT, 1 Hz) — the controller gates it on the
+    // FC actually being in its guided mode (in AUTO/RTL the same message carries the mission WP/home).
+    void listen<{ lat: number; lon: number; alt: number }>('guided-target', (event) => {
+      ingestFcGuidedTarget(event.payload.lat, event.payload.lon);
     });
   }
 


### PR DESCRIPTION
## Description

**Reworked after SITL review** — the original behaviour change (mode switch at the target instead of at the toggle) broke consistency with Mission Planner and was dropped entirely. Guided keeps its MP semantics: activating the mode switches immediately and ArduPlane loiters where it was entered.

What MP does *not* show at that moment, Kite now does:

- **FC-confirmed target marker.** The FC's active navigation target is read back via `POSITION_TARGET_GLOBAL_INT` (requested at 1 Hz via SET_MESSAGE_INTERVAL; GCS_Common fills it from the vehicle's `get_target_location` — ArduPlane `next_WP_loc`, Copter `flightmode->get_wp`). The green "G" marker sits on what the FC actually flies — the mode-entry loiter point, Fly-Here targets, and targets set or moved by **another GCS**. Gated on the FC being in its guided mode (in AUTO/RTL the same message carries the mission WP / home).
- **Instant feedback**: on Guided activation the marker is seeded at the aircraft position (= the mode-entry loiter point); the FC push confirms/corrects within a second.
- **Expected loiter ring** (fixed-wing only): a thin dashed circle around the target with the radius the aircraft will actually fly — the explicit Fly-Here radius when set, else the FC default (`WP_LOITER_RAD` / `NAV_LOITER_RAD`, read once via the new `mav_read_param`). MP's dashed ring is decorative; this one is the real expected track.

## Type of change

- [x] New feature

## Checklist

- [x] `npm run check` passes (557 files, 0 errors)
- [x] `cargo check` + `cargo test` (94 passed) pass
- [x] SITL test (ArduPlane: marker on mode entry, marker follows Fly-Here, ring = WP_LOITER_RAD, external target change via MP while Kite watches)
- [x] No unrelated changes

## Notes for reviewer

No flight-behaviour changes — everything sent to the FC is identical to master except one additional SET_MESSAGE_INTERVAL (msg 87 @ 1 Hz) and an on-demand PARAM_REQUEST_READ. Good SITL cross-check: set a guided target from Mission Planner while Kite is connected — Kite's marker should follow it.
