### PR TITLE
fix(serial): survive USB-CDC write stalls — strict MSP window on the FC's own USB port

### DIFF
--- a/src-tauri/src/msp/transport.rs
+++ b/src-tauri/src/msp/transport.rs
@@ -61,15 +61,28 @@ impl MspTransport {
         self.inner
     }
 
-    /// Write a pre-encoded MSP frame, raw-logging it and flagging a lost connection on write failure.
+    /// Write a pre-encoded MSP frame, raw-logging it on success. A write TIMEOUT is a retryable
+    /// stall, not a lost device: on Windows the short scheduler read timeout applies to writes too
+    /// (`WriteTotalTimeoutConstant`), and a USB-CDC FC that NAKs its OUT endpoint while producing
+    /// telemetry trips it (ERROR_SEM_TIMEOUT, os error 121 — field case TBS Lucid H7 Wing). The
+    /// frame is dropped (a telemetry poll simply retries next cycle; the FC's MSP parser resyncs on
+    /// the next '$' if part of the frame made it out) and the session lives on. Any OTHER write
+    /// error still means the device is gone and flags the connection lost.
     fn write_frame(&mut self, frame: Vec<u8>) -> Result<(), String> {
-        if let Err(e) = self.inner.write_bytes(&frame) {
-            // Failed write = device gone (same as msp_request).
-            self.mark_lost(format!("write failed: {}", e));
-            return Err(format!("MSP send failed: {}", e));
+        match self.inner.write_bytes(&frame) {
+            Ok(()) => {
+                log_to_sink(&self.raw_sink, DIR_OUT, &frame);
+                Ok(())
+            }
+            Err(crate::transport::TransportError::Timeout) => {
+                log::debug!("MSP write timed out — frame dropped (device busy, not gone)");
+                Err("MSP write timeout (frame dropped)".to_string())
+            }
+            Err(e) => {
+                self.mark_lost(format!("write failed: {}", e));
+                Err(format!("MSP send failed: {}", e))
+            }
         }
-        log_to_sink(&self.raw_sink, DIR_OUT, &frame);
-        Ok(())
     }
 }
 
@@ -79,16 +92,10 @@ impl Transport for MspTransport {
     }
 
     fn msp_request_timeout(&mut self, code: u16, payload: &[u8], timeout_ms: u64) -> Result<MspMessage, String> {
-        // Encode and send MSP v2 frame
-        let frame = MspCodec::encode_v2(code, payload);
-        if let Err(e) = self.inner.write_bytes(&frame) {
-            // A failed write means the device is gone (the local port handle is invalid) — fatal,
-            // distinct from a no-reply timeout on the air link.
-            self.mark_lost(format!("write failed: {}", e));
-            return Err(format!("MSP write failed: {}", e));
-        }
-        // Raw-log the outgoing frame (ADR-049).
-        log_to_sink(&self.raw_sink, DIR_OUT, &frame);
+        // Encode and send MSP v2 frame. `write_frame` raw-logs it (ADR-049) and classifies write
+        // errors: a write timeout is a dropped frame (device busy), anything else flags the
+        // connection lost.
+        self.write_frame(MspCodec::encode_v2(code, payload))?;
 
         // Read until we get the matching response or timeout
         let mut buf = [0u8; 512];
@@ -185,5 +192,9 @@ impl Transport for MspTransport {
 
     fn connection_lost_reason(&self) -> Option<String> {
         self.lost_reason.clone()
+    }
+
+    fn is_usb_cdc(&self) -> bool {
+        self.inner.is_usb_cdc()
     }
 }

--- a/src-tauri/src/msp/transport.rs
+++ b/src-tauri/src/msp/transport.rs
@@ -193,8 +193,4 @@ impl Transport for MspTransport {
     fn connection_lost_reason(&self) -> Option<String> {
         self.lost_reason.clone()
     }
-
-    fn is_usb_cdc(&self) -> bool {
-        self.inner.is_usb_cdc()
-    }
 }

--- a/src-tauri/src/msp/transport.rs
+++ b/src-tauri/src/msp/transport.rs
@@ -24,6 +24,10 @@ pub struct MspTransport {
     parser: MspParser,
     /// Set once a fatal transport error (device gone) is seen — see `Transport::is_connection_lost`.
     connection_lost: bool,
+    /// The OS error text behind `connection_lost`, kept so the scheduler's teardown warning can name the
+    /// actual cause. Recorded here rather than at the call sites because the scheduler sends
+    /// fire-and-forget (`msp_send(..).is_ok()`) and would otherwise drop the write error on the floor.
+    lost_reason: Option<String>,
     /// Shared raw-serial log sink (ADR-049). Every outgoing frame ('o') and incoming read-chunk ('i')
     /// is captured here in mwptools' v2 format while the recorder has a logger open; otherwise a no-op.
     raw_sink: MspRawSink,
@@ -37,7 +41,17 @@ impl MspTransport {
             inner: transport,
             parser: MspParser::new(),
             connection_lost: false,
+            lost_reason: None,
             raw_sink,
+        }
+    }
+
+    /// Flag the transport as fatally lost and keep the first cause seen (later errors are follow-ups of
+    /// the same failure, so the first one is the informative one).
+    fn mark_lost(&mut self, reason: String) {
+        self.connection_lost = true;
+        if self.lost_reason.is_none() {
+            self.lost_reason = Some(reason);
         }
     }
 
@@ -50,7 +64,8 @@ impl MspTransport {
     /// Write a pre-encoded MSP frame, raw-logging it and flagging a lost connection on write failure.
     fn write_frame(&mut self, frame: Vec<u8>) -> Result<(), String> {
         if let Err(e) = self.inner.write_bytes(&frame) {
-            self.connection_lost = true; // failed write = device gone (same as msp_request)
+            // Failed write = device gone (same as msp_request).
+            self.mark_lost(format!("write failed: {}", e));
             return Err(format!("MSP send failed: {}", e));
         }
         log_to_sink(&self.raw_sink, DIR_OUT, &frame);
@@ -69,7 +84,7 @@ impl Transport for MspTransport {
         if let Err(e) = self.inner.write_bytes(&frame) {
             // A failed write means the device is gone (the local port handle is invalid) — fatal,
             // distinct from a no-reply timeout on the air link.
-            self.connection_lost = true;
+            self.mark_lost(format!("write failed: {}", e));
             return Err(format!("MSP write failed: {}", e));
         }
         // Raw-log the outgoing frame (ADR-049).
@@ -106,11 +121,12 @@ impl Transport for MspTransport {
                     // Retry until deadline
                 }
                 Err(crate::transport::TransportError::Disconnected) => {
-                    self.connection_lost = true; // device gone
+                    self.mark_lost("read: transport disconnected".to_string()); // device gone
                     return Err("Transport disconnected".to_string());
                 }
                 Err(e) => {
-                    self.connection_lost = true; // IO error on a removed device
+                    // IO error on a removed device.
+                    self.mark_lost(format!("read failed: {}", e));
                     return Err(format!("MSP read error: {}", e));
                 }
             }
@@ -144,11 +160,11 @@ impl Transport for MspTransport {
             }
             Err(crate::transport::TransportError::Timeout) => {}
             Err(crate::transport::TransportError::Disconnected) => {
-                self.connection_lost = true;
+                self.mark_lost("poll: transport disconnected".to_string());
                 return Err("Transport disconnected".to_string());
             }
             Err(e) => {
-                self.connection_lost = true;
+                self.mark_lost(format!("poll read failed: {}", e));
                 return Err(format!("MSP read error: {}", e));
             }
         }
@@ -165,5 +181,9 @@ impl Transport for MspTransport {
 
     fn is_connection_lost(&self) -> bool {
         self.connection_lost
+    }
+
+    fn connection_lost_reason(&self) -> Option<String> {
+        self.lost_reason.clone()
     }
 }

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -320,22 +320,12 @@ fn scheduler_loop(
     // independent of the dev-only Debug Monitor tracker above.
     let mut link_stats = LinkStats::new();
 
-    // Native USB CDC/VCP (the FC's own USB port): strict request→response — drain the reply before
-    // the next write. Field case (TBS Lucid H7 Wing, INAV 9.0.1): its CDC OUT endpoint NAKs while
-    // the FC is producing replies, so any overlap of "reply pending" and "next request written"
-    // stalls the write past the short port timeout (Windows applies it to writes too → os error
-    // 121), and the original full-window pipeline flooded the FC's TX buffer clean off the USB bus.
-    // window=1 verified by the reporter; UART bridges / TCP / BLE keep the pipeline — the slow air
-    // links are what it exists for.
-    let max_in_flight = if transport.is_usb_cdc() { 1 } else { MAX_IN_FLIGHT };
-
     log::info!(
-        "Scheduler started: {} telemetry slots (attitude={:.0}Hz, position={:.0}Hz, airspeed={}, window={})",
+        "Scheduler started: {} telemetry slots (attitude={:.0}Hz, position={:.0}Hz, airspeed={})",
         slots.len(),
         config.attitude_rate_hz,
         config.position_rate_hz,
         if config.airspeed_enabled { "on" } else { "off" },
-        max_in_flight,
     );
 
     // Stall watchdog: warn once at the default log level when the transport stays open but the FC/link
@@ -510,7 +500,7 @@ fn scheduler_loop(
             .count();
         if radar_msp_enabled.load(Ordering::Relaxed)
             && radar_last.elapsed() >= RADAR_MSP_INTERVAL
-            && tele_in_flight < max_in_flight
+            && tele_in_flight < MAX_IN_FLIGHT
             && writes_this_tick < MAX_WRITES_PER_TICK
             && !in_flight
                 .get(&crate::msp::MSP2_ADSB_VEHICLE_LIST)
@@ -556,7 +546,7 @@ fn scheduler_loop(
         // Two independent limits: how many replies may be outstanding (`MAX_IN_FLIGHT`, the pipeline
         // depth that keeps slow air links busy) and how many frames may be written before the next drain
         // (`MAX_WRITES_PER_TICK`, the soft lock). The tighter of the two wins.
-        let mut budget = max_in_flight
+        let mut budget = MAX_IN_FLIGHT
             .saturating_sub(tele_in_flight)
             .min(MAX_WRITES_PER_TICK.saturating_sub(writes_this_tick));
         let mut due: Vec<usize> = (0..slots.len())

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -328,7 +328,13 @@ fn scheduler_loop(
         // 0. Bail out if the device is gone (fatal transport error — e.g. USB unplugged). A mere
         //    response timeout (OTA stall) does NOT set this, so we never tear down on a stalled link.
         if transport.is_connection_lost() {
-            log::warn!("Scheduler: transport connection lost (device gone) — tearing down");
+            log::warn!(
+                "Scheduler: transport connection lost on {} — tearing down. Cause: {}",
+                transport.description(),
+                transport
+                    .connection_lost_reason()
+                    .unwrap_or_else(|| "unknown (no error recorded)".to_string()),
+            );
             if let Some(ref rec) = recorder {
                 if let Ok(mut r) = rec.lock() {
                     r.shutdown_lost();

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -320,12 +320,22 @@ fn scheduler_loop(
     // independent of the dev-only Debug Monitor tracker above.
     let mut link_stats = LinkStats::new();
 
+    // Native USB CDC/VCP (the FC's own USB port): strict request→response — drain the reply before
+    // the next write. Field case (TBS Lucid H7 Wing, INAV 9.0.1): its CDC OUT endpoint NAKs while
+    // the FC is producing replies, so any overlap of "reply pending" and "next request written"
+    // stalls the write past the short port timeout (Windows applies it to writes too → os error
+    // 121), and the original full-window pipeline flooded the FC's TX buffer clean off the USB bus.
+    // window=1 verified by the reporter; UART bridges / TCP / BLE keep the pipeline — the slow air
+    // links are what it exists for.
+    let max_in_flight = if transport.is_usb_cdc() { 1 } else { MAX_IN_FLIGHT };
+
     log::info!(
-        "Scheduler started: {} telemetry slots (attitude={:.0}Hz, position={:.0}Hz, airspeed={})",
+        "Scheduler started: {} telemetry slots (attitude={:.0}Hz, position={:.0}Hz, airspeed={}, window={})",
         slots.len(),
         config.attitude_rate_hz,
         config.position_rate_hz,
         if config.airspeed_enabled { "on" } else { "off" },
+        max_in_flight,
     );
 
     // Stall watchdog: warn once at the default log level when the transport stays open but the FC/link
@@ -500,7 +510,7 @@ fn scheduler_loop(
             .count();
         if radar_msp_enabled.load(Ordering::Relaxed)
             && radar_last.elapsed() >= RADAR_MSP_INTERVAL
-            && tele_in_flight < MAX_IN_FLIGHT
+            && tele_in_flight < max_in_flight
             && writes_this_tick < MAX_WRITES_PER_TICK
             && !in_flight
                 .get(&crate::msp::MSP2_ADSB_VEHICLE_LIST)
@@ -546,7 +556,7 @@ fn scheduler_loop(
         // Two independent limits: how many replies may be outstanding (`MAX_IN_FLIGHT`, the pipeline
         // depth that keeps slow air links busy) and how many frames may be written before the next drain
         // (`MAX_WRITES_PER_TICK`, the soft lock). The tighter of the two wins.
-        let mut budget = MAX_IN_FLIGHT
+        let mut budget = max_in_flight
             .saturating_sub(tele_in_flight)
             .min(MAX_WRITES_PER_TICK.saturating_sub(writes_this_tick));
         let mut due: Vec<usize> = (0..slots.len())

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -103,6 +103,16 @@ enum PendingKind {
 /// are exempt — they're the control path and always go out at max priority. Tune on-device; the INAV
 /// Configurator's implicit cap is ~100 Hz emission + per-code dedup.
 const MAX_IN_FLIGHT: usize = 8;
+
+/// Max MSP frames written per scheduler tick — the "soft lock", named after the INAV Configurator's
+/// queue (`js/serial_queue.js`), whose executor takes **exactly one** message per run behind a port
+/// lock released on write completion. We keep the pipeline: replies are still never waited for and up
+/// to `MAX_IN_FLIGHT` stay outstanding. What changes is that a drain (`poll_incoming`) now always runs
+/// *between* two writes instead of a whole tick's budget going out back to back, so replies are
+/// consumed as the FC produces them rather than piling up in its TX buffer. At the ~125 Hz tick rate
+/// (`SCHED_READ_TIMEOUT`) this still allows far more requests per second than any slot set asks for.
+/// RC frames are exempt — they're the control path and bypass this budget entirely.
+const MAX_WRITES_PER_TICK: usize = 1;
 /// Short transport read timeout so the pipelined drain/emit loop ticks ≈100 Hz (like Configurator's
 /// executor) instead of being quantized by the coarse idle read timeout.
 const SCHED_READ_TIMEOUT: Duration = Duration::from_millis(8);
@@ -346,6 +356,11 @@ fn scheduler_loop(
 
         let now = Instant::now();
 
+        // Soft lock: MSP frames written so far in this tick (see `MAX_WRITES_PER_TICK`). Shared by the
+        // one-shot, radar and telemetry paths so "one write at a time" holds across all three; the RC
+        // stream is deliberately outside it.
+        let mut writes_this_tick = 0usize;
+
         // 1. Commands (non-blocking): stop, or a one-shot UI MSP request → send it and track it in flight
         //    (its reply comes back through the drain, matched by code, and is forwarded on the channel).
         match cmd_rx.try_recv() {
@@ -367,6 +382,7 @@ fn scheduler_loop(
                 link_stats.on_tx(9 + payload.len());
                 match transport.msp_send(code, &payload) {
                     Ok(()) => {
+                        writes_this_tick += 1;
                         in_flight.entry(code).or_default().push_back(Pending {
                             sent_at: now,
                             deadline: now + Duration::from_millis(MSP_ONESHOT_TIMEOUT_MS),
@@ -485,6 +501,7 @@ fn scheduler_loop(
         if radar_msp_enabled.load(Ordering::Relaxed)
             && radar_last.elapsed() >= RADAR_MSP_INTERVAL
             && tele_in_flight < MAX_IN_FLIGHT
+            && writes_this_tick < MAX_WRITES_PER_TICK
             && !in_flight
                 .get(&crate::msp::MSP2_ADSB_VEHICLE_LIST)
                 .map_or(false, |q| !q.is_empty())
@@ -495,6 +512,7 @@ fn scheduler_loop(
             debug_tracker.on_request(code, 9);
             link_stats.on_tx(9);
             if transport.msp_send(code, &[]).is_ok() {
+                writes_this_tick += 1;
                 in_flight.entry(code).or_default().push_back(Pending {
                     sent_at: now,
                     deadline: reply_deadline(now, rtt_ewma),
@@ -525,7 +543,12 @@ fn scheduler_loop(
         //    code). If the window is full while slots are still due, that's the saturation signal for the
         //    AIMD throttle (section 4) — it eases rates down next window so the pain spreads proportionally
         //    instead of the low-priority slots starving at the cap.
-        let mut budget = MAX_IN_FLIGHT.saturating_sub(tele_in_flight);
+        // Two independent limits: how many replies may be outstanding (`MAX_IN_FLIGHT`, the pipeline
+        // depth that keeps slow air links busy) and how many frames may be written before the next drain
+        // (`MAX_WRITES_PER_TICK`, the soft lock). The tighter of the two wins.
+        let mut budget = MAX_IN_FLIGHT
+            .saturating_sub(tele_in_flight)
+            .min(MAX_WRITES_PER_TICK.saturating_sub(writes_this_tick));
         let mut due: Vec<usize> = (0..slots.len())
             .filter(|&i| slots[i].overdue(scale).is_some())
             .collect();
@@ -572,6 +595,12 @@ fn scheduler_loop(
                     debug_tracker.on_request(code, 9);
                     link_stats.on_tx(9);
                     if transport.msp_send(code, &[]).is_ok() {
+                        // Kept accurate even though this is the tick's last write path — a future send
+                        // added after this block must see a truthful count, not a stale one.
+                        #[allow(unused_assignments)]
+                        {
+                            writes_this_tick += 1;
+                        }
                         in_flight.entry(code).or_default().push_back(Pending {
                             sent_at: now,
                             deadline: reply_deadline(now, rtt_ewma),

--- a/src-tauri/src/transport/mod.rs
+++ b/src-tauri/src/transport/mod.rs
@@ -81,14 +81,6 @@ pub trait ByteTransport: Send {
 
     /// Human-readable description (for logging)
     fn description(&self) -> String;
-
-    /// True for a native USB CDC/VCP — the flight controller's own USB port, where the device's USB
-    /// stack sits between us and the MSP parser. Some CDC implementations NAK their OUT endpoint
-    /// while TX is pending, so the MSP scheduler runs strict request→response there instead of
-    /// pipelining. Default `false` (non-serial transports and USB↔UART bridges).
-    fn is_usb_cdc(&self) -> bool {
-        false
-    }
 }
 
 // ── Legacy Transport Trait ───────────────────────────────────────
@@ -155,12 +147,6 @@ pub trait Transport: Send {
     /// `ERROR_OPERATION_ABORTED` after a framing/overrun error). `None` before any failure.
     fn connection_lost_reason(&self) -> Option<String> {
         None
-    }
-
-    /// True for a native USB CDC/VCP link — see `ByteTransport::is_usb_cdc`. The scheduler narrows
-    /// its in-flight window to 1 on such links.
-    fn is_usb_cdc(&self) -> bool {
-        false
     }
 }
 

--- a/src-tauri/src/transport/mod.rs
+++ b/src-tauri/src/transport/mod.rs
@@ -81,6 +81,14 @@ pub trait ByteTransport: Send {
 
     /// Human-readable description (for logging)
     fn description(&self) -> String;
+
+    /// True for a native USB CDC/VCP — the flight controller's own USB port, where the device's USB
+    /// stack sits between us and the MSP parser. Some CDC implementations NAK their OUT endpoint
+    /// while TX is pending, so the MSP scheduler runs strict request→response there instead of
+    /// pipelining. Default `false` (non-serial transports and USB↔UART bridges).
+    fn is_usb_cdc(&self) -> bool {
+        false
+    }
 }
 
 // ── Legacy Transport Trait ───────────────────────────────────────
@@ -147,6 +155,12 @@ pub trait Transport: Send {
     /// `ERROR_OPERATION_ABORTED` after a framing/overrun error). `None` before any failure.
     fn connection_lost_reason(&self) -> Option<String> {
         None
+    }
+
+    /// True for a native USB CDC/VCP link — see `ByteTransport::is_usb_cdc`. The scheduler narrows
+    /// its in-flight window to 1 on such links.
+    fn is_usb_cdc(&self) -> bool {
+        false
     }
 }
 

--- a/src-tauri/src/transport/mod.rs
+++ b/src-tauri/src/transport/mod.rs
@@ -140,6 +140,14 @@ pub trait Transport: Send {
     fn is_connection_lost(&self) -> bool {
         false
     }
+
+    /// The OS error that caused `is_connection_lost` to flip, verbatim. The distinction it carries is the
+    /// one a log reader needs and cannot otherwise get: a removed device ("device is not connected") reads
+    /// completely differently from a recoverable comm error we currently treat as fatal anyway (Windows
+    /// `ERROR_OPERATION_ABORTED` after a framing/overrun error). `None` before any failure.
+    fn connection_lost_reason(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Information about an available port/device

--- a/src-tauri/src/transport/serial.rs
+++ b/src-tauri/src/transport/serial.rs
@@ -389,8 +389,11 @@ fn log_bt_spp_diagnostics(_target: &str) {}
 /// USB vendor IDs of USB↔UART **bridge** chips. A port behind one of these is a real UART on the far
 /// side — a telemetry radio, an FTDI cable, an ESP32 dev board — not a flight controller's own USB
 /// device. Everything else on USB that presents a serial port is a native CDC/VCP implemented by the
-/// target MCU's own USB stack (STM32 0x0483, RP2040 0x2E8A, AT32, …), which is the case the MSP
-/// scheduler narrows its in-flight window for.
+/// device's own USB stack (STM32 0x0483, RP2040 0x2E8A, Espressif 0x303A, …). Diagnostic only: a
+/// native CDC's OUT endpoint can NAK while its TX is busy (the Lucid H7 Wing write-stall case), so a
+/// tester's log should say which kind of port a session ran on. NOTE deliberately no behaviour is
+/// keyed off this — an ESP32 Kite-Link node is also a native CDC but bridges to a slow SiK air link,
+/// where narrowing the MSP pipeline would cripple the poll rate.
 const USB_UART_BRIDGE_VIDS: &[u16] = &[
     0x0403, // FTDI
     0x10C4, // Silicon Labs CP210x
@@ -420,8 +423,6 @@ fn is_native_usb_cdc(port_name: &str) -> bool {
 pub struct SerialConnection {
     port_name: String,
     port: Box<dyn serialport::SerialPort>,
-    /// Native USB CDC/VCP (FC's own USB port) — see `is_native_usb_cdc`. Decided once at open.
-    is_usb_cdc: bool,
 }
 
 // Safety: serialport::SerialPort requires Send, Box<dyn SerialPort> is Send
@@ -446,17 +447,12 @@ impl SerialConnection {
                         eprintln!("[serial] {} opened on attempt {}/{}", port_name, attempt, OPEN_RETRY_ATTEMPTS);
                         log::info!("Serial port {} opened on attempt {}/{}", port_name, attempt, OPEN_RETRY_ATTEMPTS);
                     }
-                    let is_usb_cdc = is_native_usb_cdc(port_name);
-                    if is_usb_cdc {
-                        log::info!(
-                            "Serial {}: native USB CDC/VCP — MSP scheduler will use the strict request→response window",
-                            port_name,
-                        );
+                    if is_native_usb_cdc(port_name) {
+                        log::info!("Serial {}: native USB CDC/VCP (not behind a USB↔UART bridge)", port_name);
                     }
                     let mut conn = Self {
                         port_name: port_name.to_string(),
                         port,
-                        is_usb_cdc,
                     };
                     // Raise DTR/RTS like every standard tool does on open (INAV Configurator, Mission
                     // Planner, terminals). USB-CDC devices gate their device→host stream on DTR
@@ -536,9 +532,5 @@ impl ByteTransport for SerialConnection {
 
     fn description(&self) -> String {
         format!("Serial({})", self.port_name)
-    }
-
-    fn is_usb_cdc(&self) -> bool {
-        self.is_usb_cdc
     }
 }

--- a/src-tauri/src/transport/serial.rs
+++ b/src-tauri/src/transport/serial.rs
@@ -386,10 +386,42 @@ fn log_bt_spp_diagnostics(target: &str) {
 #[cfg(not(target_os = "windows"))]
 fn log_bt_spp_diagnostics(_target: &str) {}
 
+/// USB vendor IDs of USB↔UART **bridge** chips. A port behind one of these is a real UART on the far
+/// side — a telemetry radio, an FTDI cable, an ESP32 dev board — not a flight controller's own USB
+/// device. Everything else on USB that presents a serial port is a native CDC/VCP implemented by the
+/// target MCU's own USB stack (STM32 0x0483, RP2040 0x2E8A, AT32, …), which is the case the MSP
+/// scheduler narrows its in-flight window for.
+const USB_UART_BRIDGE_VIDS: &[u16] = &[
+    0x0403, // FTDI
+    0x10C4, // Silicon Labs CP210x
+    0x067B, // Prolific PL2303
+    0x1A86, // WCH CH340/CH341
+    0x1A72, // Moxa
+    0x0557, // ATEN
+];
+
+/// True if `port_name` is a native USB CDC/VCP (the FC's own USB port) rather than a USB↔UART bridge
+/// or a non-USB port. Best-effort: if enumeration fails or the port isn't listed, returns false —
+/// the caller must treat "unknown" as "not a VCP" so nothing changes behaviour by accident.
+fn is_native_usb_cdc(port_name: &str) -> bool {
+    let Ok(ports) = serialport::available_ports() else {
+        return false;
+    };
+    let Some(p) = ports.iter().find(|p| p.port_name.eq_ignore_ascii_case(port_name)) else {
+        return false;
+    };
+    match &p.port_type {
+        serialport::SerialPortType::UsbPort(info) => !USB_UART_BRIDGE_VIDS.contains(&info.vid),
+        _ => false,
+    }
+}
+
 /// An active serial connection to a flight controller
 pub struct SerialConnection {
     port_name: String,
     port: Box<dyn serialport::SerialPort>,
+    /// Native USB CDC/VCP (FC's own USB port) — see `is_native_usb_cdc`. Decided once at open.
+    is_usb_cdc: bool,
 }
 
 // Safety: serialport::SerialPort requires Send, Box<dyn SerialPort> is Send
@@ -414,9 +446,17 @@ impl SerialConnection {
                         eprintln!("[serial] {} opened on attempt {}/{}", port_name, attempt, OPEN_RETRY_ATTEMPTS);
                         log::info!("Serial port {} opened on attempt {}/{}", port_name, attempt, OPEN_RETRY_ATTEMPTS);
                     }
+                    let is_usb_cdc = is_native_usb_cdc(port_name);
+                    if is_usb_cdc {
+                        log::info!(
+                            "Serial {}: native USB CDC/VCP — MSP scheduler will use the strict request→response window",
+                            port_name,
+                        );
+                    }
                     let mut conn = Self {
                         port_name: port_name.to_string(),
                         port,
+                        is_usb_cdc,
                     };
                     // Raise DTR/RTS like every standard tool does on open (INAV Configurator, Mission
                     // Planner, terminals). USB-CDC devices gate their device→host stream on DTR
@@ -478,12 +518,15 @@ impl ByteTransport for SerialConnection {
     }
 
     fn write_bytes(&mut self, data: &[u8]) -> Result<(), TransportError> {
-        self.port
-            .write_all(data)
-            .map_err(|e| TransportError::Io(format!("Serial write failed: {}", e)))?;
-        self.port
-            .flush()
-            .map_err(|e| TransportError::Io(format!("Serial flush failed: {}", e)))?;
+        // Preserve the io error KIND instead of collapsing everything into `Io`: on Windows the port
+        // timeout (`set_timeout`) applies to WRITES as well (`WriteTotalTimeoutConstant`), and the
+        // scheduler sets it to a few ms for its read cadence. A USB-CDC device that momentarily NAKs
+        // its OUT endpoint (busy producing telemetry) then fails the write with ERROR_SEM_TIMEOUT
+        // (os error 121) → `TimedOut` → `TransportError::Timeout`. That is a retryable stall of a
+        // present device, NOT a removed one — the MSP layer must be able to tell the two apart
+        // (field case: TBS Lucid H7 Wing, teardown 20 ms after scheduler start).
+        self.port.write_all(data).map_err(TransportError::from)?;
+        self.port.flush().map_err(TransportError::from)?;
         Ok(())
     }
 
@@ -493,5 +536,9 @@ impl ByteTransport for SerialConnection {
 
     fn description(&self) -> String {
         format!("Serial({})", self.port_name)
+    }
+
+    fn is_usb_cdc(&self) -> bool {
+        self.is_usb_cdc
     }
 }


### PR DESCRIPTION
## Description

Follow-up to #33 for the remaining Lucid H7 Wing disconnect (FC dropped off the USB bus / session torn down moments after connect, direct USB only — INAV Configurator unaffected). Root cause chain, proven by the reporter's two test builds + the new teardown logging:

- serialport's `set_timeout` applies to **reads and writes** on Windows (`WriteTotalTimeoutConstant`) — the scheduler's few-ms read cadence silently capped every write.
- This FC's USB-CDC OUT endpoint NAKs while it is producing replies, so any write overlapping a pending reply blocked past the cap and failed with `ERROR_SEM_TIMEOUT` (os error 121).
- Our "any write error = device gone" rule then tore the session down (and the original full pipeline window flooded the FC's TX buffer clean off the bus).

The strict request→response diagnostic build (drain reply, then write) ran clean at the reporter's — on that pattern the OUT endpoint is always free when we write.

## Changes

- `fix(serial)`: teardown warning now names the OS error (`Transport::connection_lost_reason`), including the previously-discarded write path — this is what surfaced error 121.
- `fix(scheduler)`: soft-lock — at most one MSP write between drains (Configurator's executor shape).
- `fix(serial)`: write **timeout** = dropped frame (poll retries next cycle), not a lost connection; all other write errors stay fatal. Strict in-flight window (1) on native USB CDC/VCP ports, detected by USB VID (not behind a known USB↔UART bridge). UART bridges / TCP / BLE keep the full pipeline.

## Type of change

- [x] Bug fix

## Checklist

- [x] `cargo check` + `cargo test` (86 passed) pass
- [x] Reporter verified the strict-window behaviour on the affected hardware (test build)
- [x] Local H7/F7 regression check over direct USB (perf + stability)
- [x] Air-link regression check (pipeline must stay intact over a UART bridge)
- [x] No unrelated changes

## Notes for reviewer

The window narrowing is deliberately VID-based and conservative: unknown/unlisted ports count as "not a VCP" and keep today's behaviour. At the ~125 Hz scheduler tick, window=1 still allows ~60–125 req/s against a ~20 req/s slot demand on USB.
