### PR TITLE
fix(dialog): show uppercase file extensions in the Linux file picker

### DIFF
--- a/src/lib/components/logbook/BatteryManager.svelte
+++ b/src/lib/components/logbook/BatteryManager.svelte
@@ -12,6 +12,7 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
   import { get } from 'svelte/store';
+  import { anyCase } from '$lib/helpers/fileFilters';
   import { save, open as openFileDialog } from '@tauri-apps/plugin-dialog';
   import { settings } from '$lib/stores/settings';
   import {
@@ -429,7 +430,7 @@
   // ── Import (.kbatt) ─────────────────────────────────────────────────
   async function handleImport() {
     try {
-      const path = await openFileDialog({ title: $t('batteryMgr.importTitle'), multiple: false, filters: [{ name: 'Battery', extensions: ['kbatt'] }] });
+      const path = await openFileDialog({ title: $t('batteryMgr.importTitle'), multiple: false, filters: [{ name: 'Battery', extensions: anyCase(['kbatt']) }] });
       if (!path || typeof path !== 'string') return;
       const file = await batteryFileRead(path);
       importFile = file;

--- a/src/lib/components/logbook/VehicleManager.svelte
+++ b/src/lib/components/logbook/VehicleManager.svelte
@@ -12,6 +12,7 @@
 -->
 <script lang="ts">
   import { t } from 'svelte-i18n';
+  import { anyCase } from '$lib/helpers/fileFilters';
   import { get } from 'svelte/store';
   import { save, open as openFileDialog } from '@tauri-apps/plugin-dialog';
   import { settings } from '$lib/stores/settings';
@@ -402,7 +403,7 @@
   // ── Import (.kvehicle) ──────────────────────────────────────────────
   async function handleImport() {
     try {
-      const path = await openFileDialog({ title: $t('vehicleMgr.importTitle'), multiple: false, filters: [{ name: 'Vehicle', extensions: ['kvehicle'] }] });
+      const path = await openFileDialog({ title: $t('vehicleMgr.importTitle'), multiple: false, filters: [{ name: 'Vehicle', extensions: anyCase(['kvehicle']) }] });
       if (!path || typeof path !== 'string') return;
       importFile = await vehicleFileRead(path);
       editing = false;

--- a/src/lib/components/mission/ArduMissionPanel.svelte
+++ b/src/lib/components/mission/ArduMissionPanel.svelte
@@ -27,6 +27,7 @@
   import { onMissionDownloadProgress, onMissionUploadProgress } from '$lib/stores/mission';
   import { cmdName, cmdShort, cmdHasLocation, cmdDef, cmdValidForVehicle, cmdValidForPx4, enumLabel, type VehicleClass } from '$lib/helpers/arduCommandCatalog';
   import { buildArduWaypointMenu } from '$lib/helpers/arduWaypointMenu';
+  import { anyCase } from '$lib/helpers/fileFilters';
   import { contextMenu } from '$lib/actions/contextMenu';
   import { arduWpDetailLines } from '$lib/helpers/missionWpDetails';
   import { frameMissionOnMap } from '$lib/stores/mapCamera';
@@ -155,7 +156,7 @@
       const path = await open({
         title: $t('mission.openMissionTitle'),
         multiple: false,
-        filters: [{ name: 'Waypoints', extensions: ['waypoints', 'txt'] }],
+        filters: [{ name: 'Waypoints', extensions: anyCase(['waypoints', 'txt']) }],
       });
       if (!path) return;
       const content = await invoke<string>('read_text_file', { path: typeof path === 'string' ? path : path });

--- a/src/lib/components/mission/InavMissionPanel.svelte
+++ b/src/lib/components/mission/InavMissionPanel.svelte
@@ -40,6 +40,7 @@
   import { missionDbSave, missionDbUpdate, missionDbGet, missionDbFindByHash, missionDbGeocode } from '$lib/stores/flightlog';
   import { locale } from 'svelte-i18n';
   import { isFlyByHome } from '$lib/helpers/missionGeometry';
+  import { anyCase } from '$lib/helpers/fileFilters';
   import { contextMenu } from '$lib/actions/contextMenu';
   import { buildWaypointMenu } from '$lib/helpers/waypointMenu';
   import { connection } from '$lib/stores/connection';
@@ -277,7 +278,7 @@
 
   async function handleOpenFile() {
     try {
-      const path = await open({ title: $t('mission.openMissionTitle'), multiple: false, filters: [{ name: 'Mission', extensions: ['mission'] }] });
+      const path = await open({ title: $t('mission.openMissionTitle'), multiple: false, filters: [{ name: 'Mission', extensions: anyCase(['mission']) }] });
       if (!path) return;
       const m = await missionLoadFile(typeof path === 'string' ? path : path);
       statusMessage = $t('mission.loaded', { values: { count: m.waypoints.length } });

--- a/src/lib/components/mission/MissionManager.svelte
+++ b/src/lib/components/mission/MissionManager.svelte
@@ -36,6 +36,7 @@
   } from '$lib/stores/autopilotContext';
   import { missionManagerSelectedId, requestOpenFlightId } from '$lib/stores/missionManager';
   import { buildMissionInput, findLibraryMissionId } from '$lib/helpers/missionLibrary';
+  import { anyCase } from '$lib/helpers/fileFilters';
   import { buildArduMissionInput, findArduLibraryMissionId } from '$lib/helpers/missionLibraryArdu';
   import { convertAltitude, convertDistance, formatConverted } from '$lib/utils/units';
   import PanelShell, { type PanelVariant } from '$lib/components/panel/PanelShell.svelte';
@@ -362,7 +363,7 @@
 
   async function handleImportButton() {
     try {
-      const path = await open({ title: $t('missionMgr.openTitle'), multiple: false, filters: [{ name: 'Mission', extensions: ['mission', 'waypoints', 'txt'] }] });
+      const path = await open({ title: $t('missionMgr.openTitle'), multiple: false, filters: [{ name: 'Mission', extensions: anyCase(['mission', 'waypoints', 'txt']) }] });
       if (!path || typeof path !== 'string') return;
       const stem = path.replace(/^.*[\\/]/, '').replace(/\.[^.]+$/, '');
       const lower = path.toLowerCase();

--- a/src/lib/helpers/fileFilters.ts
+++ b/src/lib/helpers/fileFilters.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+// File-dialog extension filters.
+//
+// Linux file pickers match extensions case-sensitively: the GTK3 backend compiles each filter into
+// a `GPatternSpec` (`*.txt`) and the XDG desktop portal uses plain globs — neither offers a
+// case-fold flag, and GLib's matcher understands only `*` and `?`, so a `*.[tT][xX][tT]` character
+// class doesn't work either. A lowercase-only list therefore hides the uppercase `.TXT` blackbox
+// logs that Configurator and FAT-formatted cards produce (issue #41). Windows and macOS match
+// case-insensitively, where the extra patterns are simply redundant.
+
+/** Expand extensions to their lower- and uppercase spellings, preserving order and deduplicating. */
+export function anyCase(extensions: string[]): string[] {
+  const out: string[] = [];
+  for (const ext of extensions) {
+    for (const variant of [ext.toLowerCase(), ext.toUpperCase()]) {
+      if (!out.includes(variant)) out.push(variant);
+    }
+  }
+  return out;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -61,6 +61,7 @@
   import * as logbookCtrl from '$lib/controllers/logbookController';
   import * as widgetCtrl from '$lib/controllers/widgetController';
   import { isValidGpsCoordinate, isArmed } from '$lib/helpers/telemetry';
+  import { anyCase } from '$lib/helpers/fileFilters';
   import { liveTrack, appendLivePoint, clearLiveTrack } from '$lib/stores/liveTrack';
   import { toTelemetryData } from '$lib/adapters/telemetryAdapter';
   import { activeWpNumber, replayWpTotal } from '$lib/stores/navStatus';
@@ -1312,7 +1313,7 @@
         filters: [
           {
             name: $t('logbook.allLogsFilter'),
-            extensions: ['txt', 'bbl', 'bfl', 'bin', 'kflight', 'rawmsp', 'tlog'],
+            extensions: anyCase(['txt', 'bbl', 'bfl', 'bin', 'kflight', 'rawmsp', 'tlog']),
           },
         ],
       });


### PR DESCRIPTION
Fixes #41 — reported by @RiiPiii with an unusually precise repro (rename `LOG00058.TXT` → `.txt` and the file appears), which pinned the cause immediately.

## Why it happens

`tauri-plugin-dialog` hands our extension list straight to `rfd`, and both Linux backends turn it into a **case-sensitive** pattern:

| Platform | Pattern built | Matching |
|---|---|---|
| Linux GTK3 | `gtk_file_filter_add_pattern("*.txt")` | GLib `GPatternSpec` — case-sensitive |
| Linux XDG portal | `FileFilter::glob("*.txt")` | case-sensitive globs |
| Windows | `*.txt;` spec string | case-insensitive natively |
| macOS | `allowedFileTypes` | case-insensitive natively |

No layer in that chain exposes a case-fold option, and GLib's matcher understands only `*` and `?` — so smuggling in a `*.[tT][xX][tT]` character class doesn't work either, the class would be matched literally. (GTK4's `gtk_file_filter_add_suffix()` *is* case-insensitive, but Tauri v2 runs on GTK3/WebKitGTK.) Listing both spellings is the only option.

## The change

New `anyCase()` helper in `src/lib/helpers/fileFilters.ts` expands a filter list to its lower- and uppercase spellings, carrying the explanation above so it doesn't get "cleaned up" later.

Applied to **every** open dialog that filters by extension, not just the reported one — the same trap sat in all of them:

- Logbook import (`txt`, `bbl`, `bfl`, `bin`, `kflight`, `rawmsp`, `tlog`) — the reported case
- ArduPilot mission open, Mission Manager import, INAV mission open
- Vehicle import (`.kvehicle`), Battery import (`.kbatt`)

Save dialogs are untouched — we supply the file name there. The two directory pickers have no filters.

## Scope check

Everything behind the picker already coped with uppercase, so no further changes were needed: `dispatchImport` lowercases the extension before choosing an importer, the Rust raw importer does the same, and the drag-and-drop handler matches with `/i` — which is why drag-and-drop was never affected (and is a working stopgap for anyone on rc1 today).

## Verification

- `npm run check` — 0 errors, 0 warnings (558 files)
- `npm run build` — clean
- No new user-visible strings, so no i18n changes
- Linux behaviour needs a field test with real `.TXT` blackbox logs
