### PR TITLE
fix(nav-rail): scroll instead of clipping when the rail is taller than the window

### DIFF
--- a/src/lib/components/NavRail.svelte
+++ b/src/lib/components/NavRail.svelte
@@ -70,6 +70,24 @@
     gap: 0;
     z-index: 100;
     transition: left 0.3s ease;
+    /* Bound the rail to the space between the toolbar and the status bar and let it scroll, instead
+       of overflowing and being silently clipped by `.ui-root`'s `overflow: hidden`.
+       With every tab enabled the open rail is 42 + 4 + 10x38 + 9x2 = 444px, so it needs ~539 logical
+       pixels of height; at a UI scale of 1.5 that is 808 real pixels and at 2.0 it is 1078, and any
+       window shorter than that silently drops the last icons off the bottom edge with no scrollbar
+       and no other indication that they exist.
+       Expressed in the chrome's own logical pixels: `.ui-scale` is exactly `100vh / --ui-scale` tall,
+       so this stays correct at every UI scale without depending on which ancestor is the offset
+       parent (65px = toolbar 53 + 12 gap, 30px = status bar 24 + 6 gap). The scrollbar is hidden so
+       the rail keeps its exact 42px width and current look; it scrolls by wheel/drag. */
+    max-height: calc(100vh / var(--ui-scale, 1) - 65px - 30px);
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-width: none;
+  }
+
+  .nav-rail::-webkit-scrollbar {
+    display: none;
   }
 
   .nav-rail.open {


### PR DESCRIPTION

### The bug

With every tab enabled the open nav rail is 444px tall — hamburger 42, margin 4, ten tabs at 38, nine gaps at 2 — so it needs about 539 logical pixels between the toolbar and the status bar.

`.ui-root` sets `overflow: hidden`. On any window shorter than that, the last icons are simply cut off. No scrollbar, no fade, no indication they exist. Settings is the bottom entry in the list, which is the one you would want to reach when the UI is misbehaving.

The bound is in logical pixels, so the real viewport height required scales with the UI scale setting:

| UI scale | viewport height needed |
|---|---|
| 100% | ~539px |
| 125% | ~674px |
| 150% | ~808px |
| 200% | ~1078px |

I hit this on a phone in landscape, where the viewport is short enough to lose several icons at the default scale. The table is why it is not phone-specific: 150% on a 768px-tall laptop panel gets there too.

### The fix

Bound the rail to the space it actually has and let it scroll.

```css
max-height: calc(100vh / var(--ui-scale, 1) - 65px - 30px);
overflow-y: auto;
overflow-x: hidden;
scrollbar-width: none;
```

The bound is expressed as `100vh / var(--ui-scale)` minus the toolbar (53 + 12 gap) and the status bar (24 + 6 gap). That is exactly the height of `.ui-scale` itself, so it stays correct at every UI scale without depending on which ancestor happens to be the offset parent — which matters here because the rail is `position: absolute` inside a grid area.

The scrollbar is hidden (`scrollbar-width: none` plus the `::-webkit-scrollbar` rule) so the rail keeps its exact 42px width and its current appearance. It still scrolls by wheel and by drag.

### Scope

One file, CSS only. Nothing changes for windows that were already tall enough — `max-height` with `overflow: auto` is inert until the content exceeds it.

### Testing

The clipping was reproduced on a short viewport (a phone in landscape, on the Android build I have been working on), and the rail reaches its bottom entries with this change in.

Being straight about the limit: the desktop rows in the table above are computed from the CSS, not measured at each scale setting. The mechanism is the same either way — the bound and the content are both in logical pixels, so the scale factor cancels — but I have not sat in front of a GTK build at 150% to watch it.

`npm run build` and `npm run check` are clean.