### PR TITLE
fix(toolbar): use the shared isLinux helper for the title-bar double-click

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -9,7 +9,7 @@
   import Button from '$lib/components/panel/Button.svelte';
   import SegmentedToggle from '$lib/components/panel/SegmentedToggle.svelte';
   import WindowControls from '$lib/components/WindowControls.svelte';
-  import { isMacOS } from '$lib/platform';
+  import { isMacOS, isLinux } from '$lib/platform';
   import ConnectionStatusBox from '$lib/components/ConnectionStatusBox.svelte';
   import ArmingIndicator from '$lib/components/ArmingIndicator.svelte';
   import BatteryIndicator from '$lib/components/BatteryIndicator.svelte';
@@ -224,7 +224,8 @@
 
   // Double-click the title bar to maximize/restore. Windows/macOS drag regions already do this
   // natively, so only Linux/GTK needs the manual handler (otherwise it would toggle twice).
-  const isLinux = typeof navigator !== 'undefined' && navigator.userAgent.includes('Linux');
+  // `isLinux` is the shared helper from $lib/platform, not a local user-agent test: every other
+  // platform check in the app already goes through that module, and its test is the stricter one.
   function onTitlebarDblClick(e: MouseEvent) {
     if (!isLinux) return;
     // Ignore double-clicks that land on interactive controls (buttons, selects, the window buttons).


### PR DESCRIPTION
`Toolbar.svelte` carried its own platform test for the manual maximize/restore handler:

```ts
const isLinux = typeof navigator !== 'undefined' && navigator.userAgent.includes('Linux');
```

`$lib/platform` already exports an `isLinux` that every other platform check in the app goes through, and the two are not equivalent:

```ts
export const isLinux = /Linux/i.test(ua) && !/Android/i.test(ua);
```

The shared one is case-insensitive and deliberately excludes user agents that also report Android. The local copy was the only remaining `navigator.userAgent` test outside `platform.ts`, so this was two definitions of "this is the GTK WebView" sitting next to each other, free to drift.

This imports the shared helper and deletes the local constant.

### Behaviour

Unchanged on all three desktop targets. WebKitGTK's user agent matches both tests; WebView2 and WKWebView match neither. The difference only shows up on a WebView whose UA says Linux but which is not GTK — which is exactly the case the shared helper was written to handle, and the reason it should be the one definition.

### Testing

`npm run build` and `npm run check` are clean. Two lines; no logic beyond the import.
