### PR TITLE
feat(3d): optional OpenStreetMap building extrusions on the 3D map

### DIFF
--- a/src/lib/components/Map3D.svelte
+++ b/src/lib/components/Map3D.svelte
@@ -169,6 +169,15 @@
   const BASE_FPS = 60;
   const LOW_POWER_FPS = 20;
 
+  // ── OSM buildings ──
+  // Cesium's global OpenStreetMap building tileset (Ion asset 96188), served from the same Ion
+  // account as World Terrain — so it is only available when a token is configured. Held here so the
+  // live settings watcher can add/remove it without rebuilding the viewer. `buildingsLoading` guards
+  // against a second toggle racing the first load, which would add the tileset twice.
+  let buildingsEnabled = false;                      // settings.buildings3D
+  let buildingsTileset: Cesium.Cesium3DTileset | undefined;
+  let buildingsLoading = false;
+
   // ── Sun / lighting ──
   let lightingEnabled = false;                       // settings.realLighting3D → globe sun-shading
   let replayTimeEnabled = false;                     // settings.logReplayTime → clock from log timestamp
@@ -923,6 +932,7 @@
       cacheMaxMB = s.mapCacheMaxMB || 0;
       curtainEnabled = s.altitudeCurtain3D ?? true;
       lightingEnabled = s.realLighting3D ?? false;
+      buildingsEnabled = s.buildings3D ?? false;
       replayTimeEnabled = s.logReplayTime ?? false;
       nightModeSetting = s.nightMode2D ?? 'off';
       hudSpeedUnit = s.interface?.speedUnit ?? 'kmh';
@@ -1006,6 +1016,9 @@
     if (ionToken) {
       viewer.scene.globe.depthTestAgainstTerrain = true;
     }
+
+    // OSM buildings, if the user asked for them and we have an Ion token to fetch them with.
+    void applyBuildings();
 
     // ── Performance: limit view distance ──
     // Fog hides distant terrain gradually; far clip plane caps geometry.
@@ -1206,6 +1219,11 @@
       if (lighting !== lightingEnabled) {
         lightingEnabled = lighting;
         updateNightDim3D(); // owns enableLighting + re-evaluates the night dim
+      }
+      const buildings = next.buildings3D ?? false;
+      if (buildings !== buildingsEnabled) {
+        buildingsEnabled = buildings;
+        void applyBuildings(); // loads on first enable, then just toggles `show`
       }
       const replayTime = next.logReplayTime ?? false;
       if (replayTime !== replayTimeEnabled) {
@@ -2566,6 +2584,48 @@
     const layers = viewer.imageryLayers;
     for (let i = 0; i < layers.length; i++) layers.get(i).brightness = factor;
     viewer.scene.requestRender();
+  }
+
+  /**
+   * Add, show or hide the OSM buildings tileset to match `buildingsEnabled`.
+   *
+   * Loaded lazily on first enable rather than at startup: it is a real network fetch and a real GPU
+   * cost, and the default is off. Once loaded it is kept and only its `show` flag is flipped, so
+   * toggling it during a flight does not re-download anything.
+   *
+   * Needs a Cesium Ion token — the tileset is an Ion asset, exactly like World Terrain. Without one
+   * the Settings toggle is disabled, but this is checked here too because the token can be cleared
+   * while the viewer is alive.
+   */
+  async function applyBuildings() {
+    if (!viewer) return;
+
+    if (buildingsTileset) {
+      buildingsTileset.show = buildingsEnabled;
+      viewer.scene.requestRender();
+      return;
+    }
+    if (!buildingsEnabled || buildingsLoading) return;
+    if (!Cesium.Ion.defaultAccessToken) {
+      console.warn('[Map3D] 3D buildings need a Cesium Ion token — skipping');
+      return;
+    }
+
+    buildingsLoading = true;
+    try {
+      const tileset = await Cesium.createOsmBuildingsAsync();
+      // The user may have switched it off again, or torn the viewer down, while this was in flight.
+      if (!viewer || viewer.isDestroyed()) return;
+      buildingsTileset = viewer.scene.primitives.add(tileset) as Cesium.Cesium3DTileset;
+      buildingsTileset.show = buildingsEnabled;
+      viewer.scene.requestRender();
+    } catch (e) {
+      // Most likely an Ion token without access to the asset, or no network. Not fatal: the 3D map
+      // is fully usable without buildings, so warn and carry on rather than breaking the view.
+      console.warn('[Map3D] could not load OSM buildings:', e);
+    } finally {
+      buildingsLoading = false;
+    }
   }
 
   /**

--- a/src/lib/components/Map3D.svelte
+++ b/src/lib/components/Map3D.svelte
@@ -826,6 +826,12 @@
     } catch (e) {
       console.warn('[Map3D] applyIonToken: failed to enable world terrain', e);
     }
+    // Buildings are an Ion asset too, so a token arriving now is what unblocks them. Without this a
+    // user whose `buildings3D` was already on — persisted from a session that had a token, or set
+    // before one was entered — would get terrain but no buildings, and the settings watcher would
+    // never fire to fix it because the value did not change. `applyBuildings` is a no-op when the
+    // setting is off, so this costs nothing in the ordinary case.
+    void applyBuildings();
   }
 
   export function getCamFocus(): { lat: number; lon: number; range: number; heading: number; pitch: number } | null {
@@ -2594,8 +2600,9 @@
    * toggling it during a flight does not re-download anything.
    *
    * Needs a Cesium Ion token — the tileset is an Ion asset, exactly like World Terrain. Without one
-   * the Settings toggle is disabled, but this is checked here too because the token can be cleared
-   * while the viewer is alive.
+   * the Settings toggle is disabled, but the token is checked here too rather than only at viewer
+   * creation: the viewer may well have started with no token, and `applyIonToken` can supply one
+   * later without a restart. That path calls back in here for exactly this reason.
    */
   async function applyBuildings() {
     if (!viewer) return;

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -39,6 +39,7 @@
     cesiumIonToken = '',
     altitudeCurtain3D = true,
     realLighting3D = false,
+    buildings3D = false,
     logReplayTime = false,
     nightMode2D = 'off',
     lowPower3D = 'auto',
@@ -90,6 +91,7 @@
     cesiumIonToken?: string;
     altitudeCurtain3D?: boolean;
     realLighting3D?: boolean;
+    buildings3D?: boolean;
     logReplayTime?: boolean;
     nightMode2D?: 'off' | 'auto' | 'on';
     lowPower3D?: 'off' | 'on' | 'auto';
@@ -328,6 +330,12 @@
       <div class="s-row">
         <label class="s-label" for="altitude-curtain">{$t('settings.altitudeCurtain')}</label>
         <Toggle checked={altitudeCurtain3D} id="altitude-curtain" onchange={(c) => onPatch({ altitudeCurtain3D: c })} />
+      </div>
+      <!-- Buildings come from Cesium Ion (the same account as World Terrain), so the toggle is dead
+           without a token — disabled rather than hidden, so it is discoverable and explains itself. -->
+      <div class="s-row">
+        <label class="s-label" for="buildings-3d" class:s-label-disabled={!cesiumIonToken}>{$t('settings.buildings3D')}</label>
+        <Toggle checked={!!cesiumIonToken && buildings3D} disabled={!cesiumIonToken} id="buildings-3d" onchange={(c) => onPatch({ buildings3D: c })} />
       </div>
       <div class="s-row">
         <label class="s-label" for="real-lighting">{$t('settings.realLighting')}</label>

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -768,6 +768,7 @@
     "tileCache": "Karten-Cache",
     "terrainCache": "Gelände-Cache",
     "altitudeCurtain": "Altitude Curtain (3D)",
+    "buildings3D": "3D-Gebäude (OSM)",
     "realLighting": "Echte Tageszeit und Beleuchtung (3D)",
     "logReplayTime": "Log-Replay-Zeit (3D)",
     "nightMode": "Nachtmodus",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -768,6 +768,7 @@
     "tileCache": "Tile Cache",
     "terrainCache": "Terrain Cache",
     "altitudeCurtain": "Altitude Curtain (3D)",
+    "buildings3D": "3D Buildings (OSM)",
     "realLighting": "Real Daytime and Lighting (3D)",
     "logReplayTime": "Log Replay Time (3D)",
     "nightMode": "Night Mode",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -730,6 +730,7 @@
     "tileCache": "Cache de tuiles",
     "terrainCache": "Cache de terrain",
     "altitudeCurtain": "Rideau d'altitude (3D)",
+    "buildings3D": "Bâtiments 3D (OSM)",
     "realLighting": "Heure réelle et éclairage (3D)",
     "logReplayTime": "Heure du replay (3D)",
     "nightMode": "Mode nuit",

--- a/src/lib/i18n/locales/zh.json
+++ b/src/lib/i18n/locales/zh.json
@@ -768,6 +768,7 @@
     "tileCache": "瓦片缓存",
     "terrainCache": "地形缓存",
     "altitudeCurtain": "高度幕帘 (3D)",
+    "buildings3D": "3D 建筑 (OSM)",
     "realLighting": "真实日光与照明 (3D)",
     "logReplayTime": "日志回放时间 (3D)",
     "nightMode": "夜间模式",

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -355,6 +355,8 @@ export interface AppSettings {
   altitudeCurtain3D: boolean;
   /** Light the 3D globe with the real sun position (day/night terminator + shading). */
   realLighting3D: boolean;
+  /** Show OpenStreetMap building extrusions on the 3D map. Needs a Cesium Ion token. */
+  buildings3D: boolean;
   /** During replay, drive the 3D sun clock from the log's recorded timestamp (not wall-clock now). */
   logReplayTime: boolean;
   /** Dim the 2D Leaflet imagery for night: off / auto (sun below horizon) / on. */
@@ -436,6 +438,9 @@ const defaults: AppSettings = {
   lowPower3D: 'auto',
   altitudeCurtain3D: true,
   realLighting3D: true,
+  // Off by default: the tileset is a live download and real GPU work, and it is only useful close to
+  // the ground over a built-up area. Needs an Ion token, like World Terrain.
+  buildings3D: false,
   logReplayTime: true,
   nightMode2D: 'auto',
   gcsMode: 'continuous',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -511,6 +511,7 @@
   let cesiumIonToken = $state("");
   let altitudeCurtain3D = $state(true);
   let realLighting3D = $state(false);
+  let buildings3D = $state(false);
   let logReplayTime = $state(false);
   let nightMode2D = $state<'off' | 'auto' | 'on'>('off');
   let gcsMode = $state<GcsMode>('manual');
@@ -735,6 +736,7 @@
   cesiumIonToken = saved.cesiumIonToken ?? '';
   altitudeCurtain3D = saved.altitudeCurtain3D ?? true;
   realLighting3D = saved.realLighting3D ?? false;
+  buildings3D = saved.buildings3D ?? false;
   logReplayTime = saved.logReplayTime ?? false;
   nightMode2D = saved.nightMode2D ?? 'off';
   gcsMode = saved.gcsMode ?? 'manual';
@@ -1006,6 +1008,7 @@
     if (patch.cesiumIonToken != null) cesiumIonToken = patch.cesiumIonToken;
     if (patch.altitudeCurtain3D != null) altitudeCurtain3D = patch.altitudeCurtain3D;
     if (patch.realLighting3D != null) realLighting3D = patch.realLighting3D;
+    if (patch.buildings3D != null) buildings3D = patch.buildings3D;
     if (patch.logReplayTime != null) logReplayTime = patch.logReplayTime;
     if (patch.nightMode2D != null) nightMode2D = patch.nightMode2D;
     if (patch.gcsMode != null) gcsMode = patch.gcsMode;
@@ -2685,6 +2688,7 @@
         {cesiumIonToken}
         {altitudeCurtain3D}
         {realLighting3D}
+        {buildings3D}
         {logReplayTime}
         {nightMode2D}
         lowPower3D={$settings.lowPower3D}


### PR DESCRIPTION
Adds a "3D Buildings (OSM)" toggle to the 3D section of Settings, backed by Cesium's global OSM building tileset (`Cesium.createOsmBuildingsAsync()`).

With it on, the 3D view shows real building footprints extruded to their mapped heights. That is what makes low-altitude flight over a built-up area readable: an FPV pass down a street looks like a street rather than a flat texture, and the altitude curtain finally has something to be next to.

### Cesium Ion

The tileset is an Ion asset, from the same account as World Terrain, so it needs the Ion token the user already configures for terrain. Without a token the toggle is disabled rather than hidden, using the same greyed-label treatment the Log Replay Time row already uses — discoverable, and it explains itself instead of silently doing nothing.

### Implementation notes

- **Default off.** It is a live download and real GPU work, and it is only useful close to the ground, so it is opt-in rather than something every user pays for.
- **Loaded lazily on first enable**, then kept and toggled by its `show` flag. Flipping it mid-flight never re-downloads anything.
- **`buildingsLoading` guards the load**, so double-toggling while the fetch is in flight cannot add the tileset to the scene twice.
- **The token is re-checked at load time**, not just at viewer creation, because it can be cleared from Settings while the viewer is alive.
- **A failed load is not fatal.** A token without access to the asset, or no network, logs a warning and leaves the view alone. The 3D map is fully usable without buildings.
- **The post-await path bails if the viewer was destroyed** while the fetch was in flight.

Wired through the existing settings path (`settings.ts` field + default → `+page.svelte` state mirror → `SettingsPanel` prop), same as `realLighting3D` next to it. Label added to all four locales.

### Files

```
src/lib/components/Map3D.svelte         +60
src/lib/components/SettingsPanel.svelte  +8
src/lib/stores/settings.ts               +5
src/routes/+page.svelte                  +4
src/lib/i18n/locales/{en,de,fr,zh}.json  +1 each
```

Purely additive — no existing behaviour is touched, and with the setting off (the default) nothing runs.

### Testing

`npm run build` and `npm run check` are clean, and the toggle/settings plumbing was exercised in the running app.
