### PR TITLE
fix(mavlink): identify QuadPlanes and multirotors correctly

### DIFF
--- a/src-tauri/src/flightlog/raw_import.rs
+++ b/src-tauri/src/flightlog/raw_import.rs
@@ -286,35 +286,6 @@ fn update_from_msp(code: u16, payload: &[u8], s: &mut Snap, armed: &mut bool, id
 
 // ── MAVLink (.tlog) ──────────────────────────────────────────────────────────
 
-/// Map a vehicle's autopilot + type to (fc_variant, platform_type) — mirrors the live MAVLink handshake
-/// (handshake.rs). The variant string drives the Plane-vs-Copter flight-mode table, so getting it right
-/// is what makes the imported flight's mode resolve (and the replay model match).
-fn ardu_type_info(autopilot: MavAutopilot, t: MavType) -> (String, u8) {
-    let variant = match autopilot {
-        MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA => match t {
-            MavType::MAV_TYPE_FIXED_WING => "ArduPlane",
-            MavType::MAV_TYPE_GROUND_ROVER => "ArduRover",
-            MavType::MAV_TYPE_SUBMARINE => "ArduSub",
-            _ => "ArduCopter",
-        }
-        .to_string(),
-        MavAutopilot::MAV_AUTOPILOT_PX4 => "PX4".to_string(),
-        other => format!("{:?}", other),
-    };
-    let platform = match t {
-        MavType::MAV_TYPE_FIXED_WING => 1,
-        MavType::MAV_TYPE_QUADROTOR
-        | MavType::MAV_TYPE_HEXAROTOR
-        | MavType::MAV_TYPE_OCTOROTOR
-        | MavType::MAV_TYPE_TRICOPTER => 2,
-        MavType::MAV_TYPE_HELICOPTER => 3,
-        MavType::MAV_TYPE_GROUND_ROVER => 10,
-        MavType::MAV_TYPE_SUBMARINE => 12,
-        _ => 0,
-    };
-    (variant, platform)
-}
-
 /// Decode a MAVLink tlog: a sequence of `[u64 BE µs][raw frame]`. Returns (samples, identity).
 fn decode_tlog(bytes: &[u8]) -> (Vec<Sample>, Identity) {
     let mut parser = MavParser::new();
@@ -360,7 +331,8 @@ fn decode_tlog(bytes: &[u8]) -> (Vec<Sample>, Identity) {
                     consume = fc_id == Some(id);
                     if consume {
                         // Vehicle identity → drives the mode table + flight model.
-                        let (v, p) = ardu_type_info(hb.autopilot, hb.mavtype);
+                        let (v, p) =
+                            crate::mavlink_proto::vehicle::identify(hb.autopilot, hb.mavtype);
                         variant = v;
                         platform = p;
                     }

--- a/src-tauri/src/mavlink_proto/handshake.rs
+++ b/src-tauri/src/mavlink_proto/handshake.rs
@@ -8,7 +8,7 @@
 use std::time::{Duration, Instant};
 
 use ::mavlink::ardupilotmega::{
-    MavAutopilot, MavCmd, MavMessage, MavType,
+    MavAutopilot, MavCmd, MavMessage,
     COMMAND_LONG_DATA,
 };
 use ::mavlink::Message;
@@ -133,41 +133,15 @@ pub fn perform_handshake(transport: &mut dyn ByteTransport) -> Result<(FcInfo, u
                             frame.header.system_id, frame.header.component_id, hb.autopilot,
                         );
 
-                        // Map autopilot (+ vehicle type) to fc_variant string. For ArduPilot the
-                        // variant is per-vehicle ("ArduPlane"/"ArduCopter"/...) because the frontend
-                        // picks the flight-mode name table from this string (Plane vs Copter mode
-                        // numbers differ entirely) — a generic "ArduPilot" would wrongly use Copter.
-                        fc_info.fc_variant = match hb.autopilot {
-                            MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA => match hb.mavtype {
-                                // Note: QuadPlane (VTOL_* types) also runs ArduPlane and uses the
-                                // Plane mode table — it currently falls back to "ArduCopter" naming;
-                                // refine the VTOL types here if QuadPlane support is needed.
-                                MavType::MAV_TYPE_FIXED_WING => "ArduPlane".into(),
-                                MavType::MAV_TYPE_GROUND_ROVER => "ArduRover".into(),
-                                MavType::MAV_TYPE_SUBMARINE => "ArduSub".into(),
-                                _ => "ArduCopter".into(),
-                            },
-                            MavAutopilot::MAV_AUTOPILOT_PX4 => "PX4".into(),
-                            MavAutopilot::MAV_AUTOPILOT_GENERIC => "Generic".into(),
-                            other => format!("{:?}", other),
-                        };
+                        // Shared with the tlog importer — see `vehicle::identify`.
+                        let (variant, platform_type) =
+                            crate::mavlink_proto::vehicle::identify(hb.autopilot, hb.mavtype);
+                        fc_info.fc_variant = variant;
+                        fc_info.platform_type = platform_type;
 
                         // Raw MAV_TYPE — the frontend uses it to detect QuadPlane (VTOL_* range), which
                         // the per-vehicle fc_variant string can't express (QuadPlane reports ArduPlane).
                         fc_info.mav_type = hb.mavtype as u8;
-
-                        // Map vehicle type to platform_type
-                        fc_info.platform_type = match hb.mavtype {
-                            MavType::MAV_TYPE_FIXED_WING => 1,
-                            MavType::MAV_TYPE_QUADROTOR
-                            | MavType::MAV_TYPE_HEXAROTOR
-                            | MavType::MAV_TYPE_OCTOROTOR
-                            | MavType::MAV_TYPE_TRICOPTER => 2,
-                            MavType::MAV_TYPE_HELICOPTER => 3,
-                            MavType::MAV_TYPE_GROUND_ROVER => 10,
-                            MavType::MAV_TYPE_SUBMARINE => 12,
-                            _ => 0,
-                        };
 
                         // Store custom_mode for later flight mode decoding
                         fc_info.mixer_preset = hb.custom_mode as i16;

--- a/src-tauri/src/mavlink_proto/mod.rs
+++ b/src-tauri/src/mavlink_proto/mod.rs
@@ -14,6 +14,7 @@ pub mod params;
 pub mod params_rt;
 pub mod parser;
 pub mod streamrates;
+pub mod vehicle;
 
 // MAVLink debug-stats tracker (Debug Monitor). Compiled into all builds now (was a release no-op stub)
 // so a release `--debug` run populates the MAVLink tab. Methods early-return on

--- a/src-tauri/src/mavlink_proto/vehicle.rs
+++ b/src-tauri/src/mavlink_proto/vehicle.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+//! HEARTBEAT `autopilot` + `mavtype` → (fc_variant, platform_type), shared by the live handshake and
+//! the tlog importer. It lived in both and drifted, so the same vehicle was identified differently
+//! live and after import.
+//!
+//! `fc_variant` is not a label: `flightmode::classify_ardupilot` picks the mode table from it (looks
+//! for "plane", else Copter), and the tables disagree on nearly every number — mode 19 is QLOITER on
+//! a Plane and AVOID_ADSB on a Copter. A wrong variant yields a plausible wrong mode name, not a
+//! missing one.
+
+use ::mavlink::ardupilotmega::{MavAutopilot, MavType};
+
+/// INAV's `flyingPlatformType_e`, reused for every firmware. Mirrors `helpers/uavIcons.ts`.
+pub mod platform {
+    pub const MULTIROTOR: u8 = 0;
+    pub const AIRPLANE: u8 = 1;
+    pub const HELICOPTER: u8 = 2;
+    pub const TRICOPTER: u8 = 3;
+    pub const ROVER: u8 = 4;
+    pub const BOAT: u8 = 5;
+    /// Real but unmodelled (submarine, airship, unknown) — renders as the generic arrow.
+    pub const OTHER: u8 = 6;
+    pub const VTOL: u8 = 7;
+}
+
+/// MAV_TYPE 19–25. Matched numerically because the names have already been renamed upstream once
+/// (`VTOL_DUOROTOR` → `VTOL_TAILSITTER_DUOROTOR`) and `VTOL_RESERVED5` exists so more can be added
+/// inside the range — a dialect bump must not drop a new VTOL type into the Copter fallback.
+fn is_vtol(t: MavType) -> bool {
+    matches!(t as u8, 19..=25)
+}
+
+/// A QuadPlane runs ArduPlane and uses the Plane mode table. Some report `MAV_TYPE_FIXED_WING` (those
+/// the `Q_ENABLE` probe in `commands/connection.rs` catches), but ArduPlane reports the specific VTOL
+/// type when the frame class says so — and those never reached the probe, because it only runs for
+/// fixed-wing. That was issue #40.
+fn ardupilot_variant(t: MavType) -> &'static str {
+    match t {
+        MavType::MAV_TYPE_FIXED_WING => "ArduPlane",
+        _ if is_vtol(t) => "ArduPlane",
+        // A boat is a Rover frame and uses the Rover mode table.
+        MavType::MAV_TYPE_GROUND_ROVER | MavType::MAV_TYPE_SURFACE_BOAT => "ArduRover",
+        MavType::MAV_TYPE_SUBMARINE => "ArduSub",
+        // Antenna trackers and blimps land here too: own firmware, but Kite has no mode table for
+        // either, so a distinct variant string would promise support that does not exist.
+        _ => "ArduCopter",
+    }
+}
+
+fn platform_for(t: MavType) -> u8 {
+    match t {
+        MavType::MAV_TYPE_FIXED_WING => platform::AIRPLANE,
+        _ if is_vtol(t) => platform::VTOL,
+        // COAXIAL is a coaxial multirotor (a Copter frame class), not a helicopter.
+        MavType::MAV_TYPE_QUADROTOR
+        | MavType::MAV_TYPE_COAXIAL
+        | MavType::MAV_TYPE_HEXAROTOR
+        | MavType::MAV_TYPE_OCTOROTOR
+        | MavType::MAV_TYPE_DODECAROTOR
+        | MavType::MAV_TYPE_DECAROTOR
+        | MavType::MAV_TYPE_GENERIC_MULTIROTOR => platform::MULTIROTOR,
+        MavType::MAV_TYPE_TRICOPTER => platform::TRICOPTER,
+        MavType::MAV_TYPE_HELICOPTER => platform::HELICOPTER,
+        MavType::MAV_TYPE_GROUND_ROVER => platform::ROVER,
+        MavType::MAV_TYPE_SURFACE_BOAT => platform::BOAT,
+        _ => platform::OTHER,
+    }
+}
+
+pub fn identify(autopilot: MavAutopilot, t: MavType) -> (String, u8) {
+    let variant = match autopilot {
+        MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA => ardupilot_variant(t).to_string(),
+        MavAutopilot::MAV_AUTOPILOT_PX4 => "PX4".to_string(),
+        MavAutopilot::MAV_AUTOPILOT_GENERIC => "Generic".to_string(),
+        other => format!("{:?}", other),
+    };
+    (variant, platform_for(t))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quadplane_vtol_types_are_arduplane() {
+        for t in [
+            MavType::MAV_TYPE_VTOL_TAILSITTER_DUOROTOR,
+            MavType::MAV_TYPE_VTOL_TAILSITTER_QUADROTOR,
+            MavType::MAV_TYPE_VTOL_TILTROTOR,
+            MavType::MAV_TYPE_VTOL_FIXEDROTOR,
+            MavType::MAV_TYPE_VTOL_TAILSITTER,
+            MavType::MAV_TYPE_VTOL_TILTWING,
+            MavType::MAV_TYPE_VTOL_RESERVED5,
+        ] {
+            let (variant, platform) = identify(MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA, t);
+            assert_eq!(variant, "ArduPlane", "{t:?}");
+            assert_eq!(platform, platform::VTOL, "{t:?}");
+        }
+    }
+
+    /// Issue #40 end to end: the reported tiltrotor sat in custom_mode 19 and Kite showed "Avoid ADSB".
+    #[test]
+    fn vtol_mode_19_resolves_as_qloiter_not_avoid_adsb() {
+        let (variant, _) = identify(
+            MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA,
+            MavType::MAV_TYPE_VTOL_TILTROTOR,
+        );
+        assert_eq!(crate::flightmode::classify_mavlink(19, &variant).primary, "qloiter");
+    }
+
+    /// Multirotors used to map to platform 2, which is *Helicopter* in the enum — so every ArduPilot
+    /// and PX4 copter was labelled a helicopter and fell through to the generic arrow.
+    #[test]
+    fn multirotors_are_multirotors() {
+        for t in [
+            MavType::MAV_TYPE_QUADROTOR,
+            MavType::MAV_TYPE_COAXIAL,
+            MavType::MAV_TYPE_HEXAROTOR,
+            MavType::MAV_TYPE_OCTOROTOR,
+            MavType::MAV_TYPE_DODECAROTOR,
+            MavType::MAV_TYPE_DECAROTOR,
+            MavType::MAV_TYPE_GENERIC_MULTIROTOR,
+        ] {
+            let (variant, platform) = identify(MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA, t);
+            assert_eq!(variant, "ArduCopter", "{t:?}");
+            assert_eq!(platform, platform::MULTIROTOR, "{t:?}");
+        }
+        let ap = MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA;
+        assert_eq!(identify(ap, MavType::MAV_TYPE_TRICOPTER).1, platform::TRICOPTER);
+        assert_eq!(identify(ap, MavType::MAV_TYPE_HELICOPTER).1, platform::HELICOPTER);
+    }
+
+    /// Rover/sub used to emit platform 10 / 12, which are not in the enum — the logbook showed
+    /// "Unknown (10)". A boat was identified as ArduCopter.
+    #[test]
+    fn surface_vehicles_use_the_rover_table_and_real_platform_types() {
+        let ap = MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA;
+        assert_eq!(identify(ap, MavType::MAV_TYPE_SURFACE_BOAT), ("ArduRover".into(), platform::BOAT));
+        assert_eq!(identify(ap, MavType::MAV_TYPE_GROUND_ROVER), ("ArduRover".into(), platform::ROVER));
+        assert_eq!(identify(ap, MavType::MAV_TYPE_SUBMARINE), ("ArduSub".into(), platform::OTHER));
+    }
+
+    #[test]
+    fn fixed_wing_and_px4_are_unchanged() {
+        let ap = MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA;
+        assert_eq!(identify(ap, MavType::MAV_TYPE_FIXED_WING), ("ArduPlane".into(), platform::AIRPLANE));
+
+        let px4 = MavAutopilot::MAV_AUTOPILOT_PX4;
+        assert_eq!(identify(px4, MavType::MAV_TYPE_QUADROTOR), ("PX4".into(), platform::MULTIROTOR));
+        // PX4 packs the mode identically for every airframe, so a VTOL keeps the plain "PX4" variant.
+        assert_eq!(identify(px4, MavType::MAV_TYPE_VTOL_TILTROTOR), ("PX4".into(), platform::VTOL));
+    }
+}


### PR DESCRIPTION
Fixes #40.

## The report

A HeeWing T2 Cruza on ArduPlane shows up as a quadcopter with mode names that don't exist on the aircraft. A `.tlog` from the reporter's setup (MAVLink over LTE, Raspberry Pi + PPP + UDP) makes the cause unambiguous — its FC heartbeat, unchanged across all 139 of them:

```
type=21 MAV_TYPE_VTOL_TILTROTOR   autopilot=3 ARDUPILOTMEGA
base_mode=0x51   custom_mode=19
```

## Root cause 1 — the VTOL family fell into the ArduCopter fallback

The vehicle-type match listed `FIXED_WING`, `GROUND_ROVER` and `SUBMARINE` and swept everything else into `_ => "ArduCopter"`. `MAV_TYPE_VTOL_TILTROTOR` is 21, so it landed there.

That string is not a label. `flightmode::classify_ardupilot` picks the mode table from it — "plane" in the name means the Plane table, otherwise Copter — and the two tables disagree on nearly every number:

| custom_mode 19 | Plane table | Copter table |
|---|---|---|
| | **QLOITER** | AVOID_ADSB |

So the aircraft was in QLOITER and Kite displayed "Avoid ADSB". A wrong variant doesn't produce a missing mode name, it produces a *plausible wrong one*, which is why this read as a general mode-decoding fault rather than a vehicle-type one.

The existing QuadPlane detection couldn't catch it: it probes the `Q_ENABLE` parameter, and only for vehicles that report `MAV_TYPE_FIXED_WING`. That path exists because **QuadPlanes don't report consistently** — the one in #40 announces its specific VTOL type, while the QuadPlane in the tlog from two days ago sent `FIXED_WING` 1782 times and was classified correctly. The probe never ran for the first kind.

## Root cause 2 — the platform type was wrong for nearly every vehicle

Found while checking whether anything else was misassigned. The platform mapping was emitting values from no particular enum. Against `flyingPlatformType_e` (`helpers/uavIcons.ts`), which is what the label table and the model picker read:

| Vehicle | Emitted | Meant | Result |
|---|---|---|---|
| Quad / hexa / octo / tri | 2 | 0 Multirotor | labelled **"Helicopter"**, drawn as the generic arrow |
| Helicopter | 3 | 2 Helicopter | labelled "Tricopter" |
| Ground rover | 10 | 4 Rover | **"Unknown (10)"** |
| Submarine | 12 | — | **"Unknown (12)"** |
| anything unlisted | 0 | — | drawn as a **quadrotor** — this is what #40 shows |

So it wasn't only the QuadPlane: every ArduPilot and PX4 multirotor has been labelled a helicopter and rendered as a generic arrow instead of a quad.

## What changed

Both mappings lived twice — once in the live handshake, once in the tlog importer — and had already drifted. They now share `mavlink_proto::vehicle`, so a vehicle is identified identically live and after import.

- **VTOL family (MAV_TYPE 19–25)** → `ArduPlane` + platform `VTOL`. Matched as a numeric range, not by naming the seven variants: the names have already been renamed upstream once (`VTOL_DUOROTOR` → `VTOL_TAILSITTER_DUOROTOR`) and `VTOL_RESERVED5` exists so more can be added inside the range. A dialect bump must not silently drop a new VTOL type back into the Copter fallback.
- **Platform types** corrected to the actual enum, and the multirotor list gained `COAXIAL` (a Copter frame class, not a helicopter), `DODECAROTOR`, `DECAROTOR` and `GENERIC_MULTIROTOR`.
- **`SURFACE_BOAT`** → `ArduRover`. A boat is a Rover frame and uses the Rover mode table; it was ArduCopter.
- The unlisted fallback is now `Other` (generic arrow) rather than `Multirotor`, so an unknown airframe is drawn honestly instead of getting rotors.

Antenna trackers and blimps still resolve to `ArduCopter`. They run their own firmware, but Kite has no mode table for either, so a distinct variant string would promise support that doesn't exist. Noted, not fixed.

## Testing

5 new unit tests in `vehicle.rs`, including the end-to-end assertion that a tiltrotor's `custom_mode` 19 resolves to `qloiter` and not `avoid_adsb`.

- `cargo check` — 0 errors
- `cargo test` — 101 passed, 1 ignored
- `npm run check` — 557 files, 0 errors, 0 warnings

The reporter's log covers 57 s in which the aircraft was never armed (`base_mode` 0x51, no `SAFETY_ARMED`), so it produces no importable flight — correct behaviour, and the reason it can't serve as an import repro. The identity chain is fully verifiable from the heartbeat regardless.

## Notes

- Flights **already recorded** keep their stored platform type; this only affects new connections and new imports. The field stays editable per flight in the logbook.
- The Dataflash (`.bin`) importer has its own mapping from the firmware banner string and was already correct — it's the one that shows the MAVLink side was the outlier. It does record a QuadPlane as `Airplane` rather than `VTOL`, since the banner just says "ArduPlane"; left alone here.
