### PR TITLE
fix(panel): use the full map height when the window is too short

### DIFF
--- a/src/lib/components/panel/PanelShell.svelte
+++ b/src/lib/components/panel/PanelShell.svelte
@@ -138,7 +138,10 @@
   }
 
   /* Bounding height shared by compact/advanced (and as a cap for info): full panel area,
-     i.e. below the toolbar, above the bottom dock + status bar. 100% = the (scaled) .app. */
+     i.e. below the toolbar, above the bottom dock + status bar. 100% = the (scaled) .app.
+     `--panel-bottom-reserve` is the dock height normally, but 0px on windows too short for the
+     capped panel to reach the nav rail's full height — the panel then overlays the dock
+     (see +page.svelte). Fallback for hosts without the var (PanelPlayground). */
   .ps-info,
   .ps-compact,
   .ps-advanced {
@@ -146,14 +149,14 @@
   }
   .ps-compact,
   .ps-advanced {
-    height: calc(100% - 53px - var(--grid-bottom-height) - 24px - 12px);
+    height: calc(100% - 53px - var(--panel-bottom-reserve, var(--grid-bottom-height)) - 24px - 12px);
   }
 
   .ps-info {
     width: max-content;
     max-width: 360px;
     height: auto;
-    max-height: calc(100% - 53px - var(--grid-bottom-height) - 24px - 12px);
+    max-height: calc(100% - 53px - var(--panel-bottom-reserve, var(--grid-bottom-height)) - 24px - 12px);
   }
   /* Widths are driven by the *field* size (the thin-framed working box), which the panel layouts
      were tuned against: 380px main field, 500px detail field. Panel width = field + the column's

--- a/src/lib/components/panel/PanelShell.svelte
+++ b/src/lib/components/panel/PanelShell.svelte
@@ -139,9 +139,9 @@
 
   /* Bounding height shared by compact/advanced (and as a cap for info): full panel area,
      i.e. below the toolbar, above the bottom dock + status bar. 100% = the (scaled) .app.
-     `--panel-bottom-reserve` is the dock height normally, but 0px on windows too short for the
-     capped panel to reach the nav rail's full height — the panel then overlays the dock
-     (see +page.svelte). Fallback for hosts without the var (PanelPlayground). */
+     `--panel-bottom-reserve` is the dock height normally, but shrinks to the rail's 6px status-bar
+     gap on windows too short for the capped panel to reach the nav rail's full height — the panel
+     then overlays the dock (see +page.svelte). Fallback for hosts without the var (PanelPlayground). */
   .ps-info,
   .ps-compact,
   .ps-advanced {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -216,6 +216,17 @@
   // (`.layer-map`) stays unzoomed/native. See docs/archive/UI_SCALING.md.
   let uiScale = $state(1);
 
+  // Fully populated nav rail in logical px: hamburger 44 + 4 top margin + 9 tabs ×40 + 8 gaps ×2
+  // (DEV excluded). A fixed reference on purpose — the live rail height varies with connection state.
+  const NAV_RAIL_FULL_HEIGHT = 424;
+  // Bottom reserve for the floating panels (PanelShell). Panels normally stop above the bottom
+  // widget dock, but once that cap would make them shorter than the nav rail, they may overlay the
+  // dock instead — the rail already scrolls past it, so the panel just follows. Logical px
+  // throughout, so the switch adapts to the UI scale.
+  const panelBottomReserve = $derived(
+    winH / uiScale - 53 - bottomDockH - 24 - 12 < NAV_RAIL_FULL_HEIGHT ? '0px' : gridBottomHeight
+  );
+
   // Floating-window rect (must match FloatingVideoWindow's own computation) — used
   // to place the map inside the window's frame when the view is swapped. The window
   // lives in the zoomed `.ui-scale` layer but the map is unzoomed, so the visual rect
@@ -2556,6 +2567,7 @@
   class="app"
   style:--grid-bottom-height={gridBottomHeight}
   style:--grid-side-width={gridSideWidth}
+  style:--panel-bottom-reserve={panelBottomReserve}
 >
   <!-- ======= TOOLBAR ======= -->
   <div class="zone-toolbar">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -222,9 +222,10 @@
   // Bottom reserve for the floating panels (PanelShell). Panels normally stop above the bottom
   // widget dock, but once that cap would make them shorter than the nav rail, they may overlay the
   // dock instead — the rail already scrolls past it, so the panel just follows. Logical px
-  // throughout, so the switch adapts to the UI scale.
+  // throughout, so the switch adapts to the UI scale. The 6px keeps the rail's visual gap above
+  // the status bar instead of sitting flush on it.
   const panelBottomReserve = $derived(
-    winH / uiScale - 53 - bottomDockH - 24 - 12 < NAV_RAIL_FULL_HEIGHT ? '0px' : gridBottomHeight
+    winH / uiScale - 53 - bottomDockH - 24 - 12 < NAV_RAIL_FULL_HEIGHT ? '6px' : gridBottomHeight
   );
 
   // Floating-window rect (must match FloatingVideoWindow's own computation) — used


### PR DESCRIPTION
Follow-up to #46. The nav rail got permission to outgrow the bottom dock — the panels are still capped above it, so on a short window (small screen, or a high UI scale) a panel shrinks toward uselessness while the map area below it sits behind widgets.

## Behaviour

Every PanelShell variant computes its height as `100% - toolbar - bottom dock - status bar - margin`. Once that capped height would fall **below the fully populated nav rail** (hamburger 44 + 9 tabs ×40 + 8 gaps ×2 + top margin 4 = **424 logical px**, DEV button excluded), the dock reserve drops to `0px` and the panel runs down to the status bar, overlaying the bottom widget dock.

- The rail height is a **fixed reference**, not a live measurement — the visible tab count varies with connection state (Control/RC/Radar tabs are conditional), and the switch point shouldn't move when a tab appears.
- Everything is computed in **logical pixels** (`window height / UI scale`, measured dock height), so the behaviour adapts to the UI scale on its own: the panel switches exactly when it would become shorter than the rail, at 100% just like at 150%.
- No visual change on any normally sized window — the reserve equals `--grid-bottom-height` until the threshold is crossed.

## Deliberately out of scope

- **No zone collapsing** — the grid, toolbar and status bar stay exactly as they are.
- **Side dock untouched** — it scales itself and must not overlay the map controls; whoever is short on space should place fewer widgets there.
- Z-order needed no work: panels already sit above the widget docks (z 150), which is why the overlay is purely a height change.

## Implementation

A `--panel-bottom-reserve` variable on `.app` (dock height normally, `0px` under the threshold, derived in `+page.svelte`); `PanelShell.svelte` reads it with the old `var(--grid-bottom-height)` as fallback for hosts that don't set it (PanelPlayground). Two files, 18 lines.

## Testing

- `npm run check` — 557 files, 0 errors, 0 warnings
- `npm run build` — clean
- Manual: shrink the window height (or raise the UI scale) until the panel would drop below the rail height → the panel extends over the bottom dock; grow it back → the cap returns. The `info` variant (UAV Info) keeps its intrinsic height and only gains the larger cap.
