### PR TITLE
ci: bound the apt steps — a hung mirror fails in minutes, not hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,17 @@ jobs:
         uses: actions/checkout@v5
 
       # --- Linux system dependencies for Tauri ---
+      # Bounded on purpose: the ubuntu runners' Azure apt mirror sporadically hangs mid-fetch, and
+      # apt has no timeout of its own — jobs sat at "install dependencies" for hours (three times,
+      # 2026-08-18/19). With per-request timeouts + retries a dead mirror fails in minutes and the
+      # job can simply be re-run; timeout-minutes is the backstop.
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          APT_OPTS='-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30'
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,10 +103,16 @@ jobs:
       APPIMAGE_EXTRACT_AND_RUN: 1
     steps:
       - uses: actions/checkout@v5
+      # Bounded on purpose: the ubuntu runners' Azure apt mirror sporadically hangs mid-fetch, and
+      # apt has no timeout of its own — jobs sat at "install dependencies" for hours (three times,
+      # 2026-08-18/19). With per-request timeouts + retries a dead mirror fails in minutes and the
+      # job can simply be re-run; timeout-minutes is the backstop.
       - name: Install system dependencies
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          APT_OPTS='-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30'
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
@@ -154,10 +160,16 @@ jobs:
       APPIMAGE_EXTRACT_AND_RUN: 1
     steps:
       - uses: actions/checkout@v5
+      # Bounded on purpose: the ubuntu runners' Azure apt mirror sporadically hangs mid-fetch, and
+      # apt has no timeout of its own — jobs sat at "install dependencies" for hours (three times,
+      # 2026-08-18/19). With per-request timeouts + retries a dead mirror fails in minutes and the
+      # job can simply be re-run; timeout-minutes is the backstop.
       - name: Install system dependencies
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          APT_OPTS='-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30'
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \


### PR DESCRIPTION
The ubuntu runners' Azure apt mirror sporadically stalls mid-fetch, and apt has no timeout of its own — the Linux jobs sat at "install dependencies" for hours, three times across two days (release build twice, PR checks once), each time blocking the required-checks gate.

- `Acquire::http/https::Timeout=30` + `Acquire::Retries=3` on `apt-get update` and `install`: a dead mirror now fails the step within minutes with a clear error, and "Re-run failed jobs" works immediately.
- `timeout-minutes: 10` on the step as backstop (normal runs take 1–2 min).
- Applied to all three apt steps: `ci.yml` check matrix + both Linux release jobs (x64/arm64).

No change to what gets installed.