### PR TITLE
fix(map): white flickering tile seams at uiScale ≠ 1 on Linux (#52)

### DIFF
--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -2118,6 +2118,10 @@
     width: 100%;
     height: 100%;
     transition: none;
+    /* Override Leaflet's light default (#ddd): it shines through every antialiased tile seam as a
+       WHITE hairline (issue #52) and flashes bright while tiles load. Dark, so whatever still
+       peeks through reads as part of the imagery. */
+    background: #2e2e2e;
   }
 
   /* Heading-up: container size set via inline styles (JS),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -246,17 +246,29 @@
   // floating window frame, `widget` → the video-widget tile (its published rect). Every other surface
   // shows video. `main` (default) = the normal full-screen map.
   const mapInFrame = $derived($videoState.mapLocation !== 'main' && $videoState.status === 'live');
+  // Full-screen map box, rounded to whole px (issue #52): the CSS fallback `calc(53px * scale)`
+  // lands on fractions at uiScale 1.25/1.5 (66.25px / 79.5px), which is what leaked tile seams —
+  // see mapFrameStyle above for the mechanism. The map sliding ≤ half a px under the toolbar edge
+  // is invisible (chrome z1 covers map z0); Map.svelte's ResizeObserver re-invalidates on the
+  // resulting size change by itself.
+  const mapLayerStyle = $derived(`top:${Math.round(53 * uiScale)}px; bottom:${Math.round(24 * uiScale)}px;`);
   const mapFloating = $derived($videoState.mapLocation === 'floating');
   const mapInWidget = $derived($videoState.mapLocation === 'widget');
+  // Rounded to whole px, here and everywhere the unzoomed map layer is placed (issue #52): a
+  // fractional box origin (floatLeft × 1.25 …) puts every 256px tile edge on a subpixel boundary,
+  // and WebKitGTK antialiases each tile as its own composited layer — hairline seams between tiles,
+  // shimmering during heading-follow rotation. Chromium snaps layers to device pixels, which is why
+  // Windows never showed it. The frame drawn by the zoomed chrome may sit up to half a px off the
+  // rounded map rect — invisible, and .miniframe-ctl uses this same string so it stays aligned.
   const mapFrameStyle = $derived(
-    `left:${floatLeft * uiScale}px; top:${floatTop * uiScale}px; width:${floatW * uiScale}px; height:${floatH * uiScale}px;`,
+    `left:${Math.round(floatLeft * uiScale)}px; top:${Math.round(floatTop * uiScale)}px; width:${Math.round(floatW * uiScale)}px; height:${Math.round(floatH * uiScale)}px;`,
   );
   // The rect the in-frame map is positioned into (screen px): the floating frame, or the widget tile.
   const inFrameStyle = $derived(
     mapFloating
       ? mapFrameStyle
       : $videoState.widgetRect
-        ? `left:${$videoState.widgetRect.x}px; top:${$videoState.widgetRect.y}px; width:${$videoState.widgetRect.w}px; height:${$videoState.widgetRect.h}px;`
+        ? `left:${Math.round($videoState.widgetRect.x)}px; top:${Math.round($videoState.widgetRect.y)}px; width:${Math.round($videoState.widgetRect.w)}px; height:${Math.round($videoState.widgetRect.h)}px;`
         : '',
   );
 
@@ -2477,7 +2489,7 @@
   <div
     class="layer-map"
     class:in-frame={mapInFrame}
-    style={mapInFrame ? inFrameStyle : ''}
+    style={mapInFrame ? inFrameStyle : mapLayerStyle}
     onclick={minimizeLogbook}
   >
     {#if mapViewMode === '2d'}
@@ -3022,6 +3034,10 @@
      uses the inline rect (already *--ui-scale in mapFrameStyle). */
   .layer-map {
     position: absolute;
+    /* top/bottom only as the no-JS fallback: the inline `mapLayerStyle` overrides them with the
+       same values rounded to whole px — a fractional box origin (53px × 1.25 = 66.25px) put every
+       tile edge on a subpixel boundary and WebKitGTK rendered hairline seams between the tiles
+       (issue #52). */
     top: calc(53px * var(--ui-scale, 1));
     left: 0;
     right: 0;


### PR DESCRIPTION
## The problem (issue #52)

Thin white, partly flickering lines between the 2D-map tiles on Linux whenever the interface
zoom (Settings → uiScale) is 1.25/1.5 — worst during heading-follow replay. Clean at uiScale 1.0,
clean on Windows at every scale.

## Root cause (code-verified, not guessed)

The unzoomed map layer is placed with `top: calc(53px * var(--ui-scale))`. At 1.25 that is
**66.25px**, at 1.5 **79.5px** — the whole map box, and with it every 256px tile edge, sits on a
subpixel boundary. WebKitGTK composites each tile as its own layer and antialiases its edges
independently, so Leaflet's light default background (`#ddd`, never overridden on the main map)
shines through every hairline. During heading-follow rotation the tile positions change per frame,
which is the flicker. Chromium snaps composited layers to device pixels — hence Windows clean.
At uiScale 1.0 all values are integral, matching the clean repro exactly.

## The fix

- **Round the map layer's placement to whole px** everywhere it is set: the full-screen box
  (inline `mapLayerStyle`; the CSS `calc` stays as the no-JS fallback), the floating-frame rect
  (rounded *inside* `mapFrameStyle`, so the miniframe control overlay stays pixel-aligned with the
  map), and the widget-rect branch. No extra `invalidateSize` — Map.svelte's ResizeObserver fires
  on the resulting size change by itself.
- **`background: #2e2e2e` on the main map container**: rotation is inherently fractional, so
  whatever still peeks through a seam now reads as imagery instead of white; the bright
  tile-load flash goes dark too.

Checked against the analysis briefing: the heading-up cover square was already integral
(`clientWidth/Height` + `Math.ceil`) and the mission preview map already carries its own dark
override — neither needed a change. The half-pixel tile-overlap hack (plan step 3) stays
unimplemented; not needed after the two changes above.

## Verified

- Debian 13 / WebKitGTK 2.52.5: uiScale **1.25 + heading-follow replay** (the flicker case),
  **1.5 static**, **1.0** regression-free, mission preview map checked alongside.
- Windows untouched by construction: additive CSS plus rounding of values that are already
  integral at scale 1.

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
