### PR TITLE
fix(3d): FPV replay sky flickering black near the ground

### DIFF
--- a/src/lib/components/Map3D.svelte
+++ b/src/lib/components/Map3D.svelte
@@ -270,6 +270,7 @@
   const FPV_FOV_MIN = 30;            // narrowest "lens" (deg, horizontal)
   const FPV_FOV_MAX = 120;           // widest "lens"
   const FPV_EYE_HEIGHT_M = 0.5;      // raise the eye slightly above the track to avoid trail clipping
+  const FPV_MIN_CLEARANCE_M = 1.5;   // never let the eye dip below the loaded terrain surface (#51)
   const FPV_TRACK_ALPHA = 0.4;       // flight track is dimmed so it doesn't fill the view
   let fpvFov = $state(60);           // horizontal field of view (deg), the FPV "zoom"
   let fpvWheelHandler: Cesium.ScreenSpaceEventHandler | undefined;
@@ -280,6 +281,7 @@
   const fpvScratchM3 = new Cesium.Matrix3();
   const fpvScratchDir = new Cesium.Cartesian3();
   const fpvScratchUp = new Cesium.Cartesian3();
+  const fpvScratchCarto = new Cesium.Cartographic();
 
   // Range (meters to target) for follow and orbit modes. Updated by zoom buttons and
   // mouse-wheel zoom. Separate from free mode which uses Cesium's native zoom.
@@ -4332,7 +4334,15 @@
     const rot = Cesium.Matrix3.fromQuaternion(quat, fpvScratchM3);
     const dir = Cesium.Matrix3.getColumn(rot, 0, fpvScratchDir); // nose / forward axis
     const up = Cesium.Matrix3.getColumn(rot, 2, fpvScratchUp);   // body up (so bank tilts the view)
-    const dest = Cesium.Cartesian3.fromDegrees(lon, lat, alt + FPV_EYE_HEIGHT_M);
+    // Cesium discards the sky for any frame whose camera sits below the LOADED tile mesh
+    // (GlobeTranslucencyState.isEnvironmentVisible) — logged altitudes do dip below it (#51).
+    // getHeight() is the surface that check consults; undefined = tiles not loaded, keep raw alt.
+    let eye = alt + FPV_EYE_HEIGHT_M;
+    const ground = viewer.scene.globe.getHeight(
+      Cesium.Cartographic.fromDegrees(lon, lat, 0, fpvScratchCarto),
+    );
+    if (ground !== undefined) eye = Math.max(eye, ground + FPV_MIN_CLEARANCE_M);
+    const dest = Cesium.Cartesian3.fromDegrees(lon, lat, eye);
     viewer.camera.setView({ destination: dest, orientation: { direction: dir, up } });
   }
 


### PR DESCRIPTION
Fixes #51.

Cesium discards the whole sky environment (skyAtmosphere/sun/moon) for any frame whose camera it classifies as underground (`GlobeTranslucencyState.isEnvironmentVisible`). The FPV camera was placed on the raw logged altitude, which dips below the **loaded** tile mesh near the ground — baro drift, GPS error, or a coarse-LOD tile sitting above the true surface. During replay that produced a black, flickering sky; hitting pause let finer tiles stream in under the parked camera, the surface dropped below the eye, and the sky came back — exactly the reported behavior.

The FPV eye height is now clamped to `globe.getHeight()` + 1.5 m, the same loaded-surface height the underground check consults, so the state is unreachable by construction. Where tiles aren't loaded yet (`getHeight()` undefined) the raw altitude is kept, matching the previous behavior. Chase/orbit/free cameras are untouched.

Verified on Windows: FPV replay from a low takeoff keeps a stable blue sky; camera controls unchanged.