### PR TITLE
fix(control): raise the Change Altitude limit to 5000 m

### DIFF
--- a/src/lib/components/control/MavCommandPanel.svelte
+++ b/src/lib/components/control/MavCommandPanel.svelte
@@ -217,7 +217,7 @@
           <span class="cc-sec-title">{$t('control.section.adjust')}</span>
           {#if hasAltitude && inGuided}
             <div class="cc-adjust">
-              <NumberStepper bind:value={changeAltVal} min={1} max={1000} step={5} unit="m" />
+              <NumberStepper bind:value={changeAltVal} min={1} max={5000} step={5} unit="m" />
               <Button variant="standard" size="sm" disabled={busy('changeAlt')} onclick={() => changeAlt(changeAltVal)}>{$t('control.action.changeAlt')}</Button>
             </div>
           {/if}


### PR DESCRIPTION
User request via chat: the 1000 m cap on the Vehicle Control panel's Change Altitude input blocked legitimate high-altitude fixed-wing use. Now 5000 m; takeoff altitude keeps its 1000 m cap.