### PR TITLE
fix(map): overlap tiles by half a px on WebKitGTK (#52 follow-up)

### DIFF
--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -36,6 +36,7 @@
   import { MAP_PROVIDERS, getProviderById, type MapProvider } from "$lib/config/mapProviders";
   import { cachedTileLayer } from "$lib/cache/CachedTileLayer";
   import { initTileCache } from "$lib/cache/tileCache";
+  import { isWebKitGtk } from "$lib/platform";
   import { homePosition, homeMarkerShown } from "$lib/stores/home";
   import { editMode, geoWaypoints, launchPoint, replayActive, toDeg } from "$lib/stores/mission";
   import { autopilotSystem } from "$lib/stores/autopilotContext";
@@ -2023,7 +2024,7 @@
 </script>
 
 <div class="map-wrapper">
-  <div bind:this={mapContainer} class="map" style="--map-rotation: 0deg"></div>
+  <div bind:this={mapContainer} class="map" class:tile-overlap={isWebKitGtk} style="--map-rotation: 0deg"></div>
 
   <div class="map-controls-corner">
     {#if !miniControls}
@@ -2122,6 +2123,14 @@
        WHITE hairline (issue #52) and flashes bright while tiles load. Dark, so whatever still
        peeks through reads as part of the imagery. */
     background: #2e2e2e;
+  }
+
+  /* WebKitGTK only: stretch every 256px tile by half a px so neighbors overlap — OS-level
+     fractional display scaling still puts tile edges on subpixel boundaries after the #52
+     rounding, and WebKitGTK antialiases the gap. !important beats Leaflet's inline size. */
+  :global(.map.tile-overlap img.leaflet-tile) {
+    width: 256.5px !important;
+    height: 256.5px !important;
   }
 
   /* Heading-up: container size set via inline styles (JS),


### PR DESCRIPTION
## Problem

The #58 fix rounds the app-side map geometry (uiScale offsets) to whole pixels, which cleaned up the seams at 100 % OS scaling. But with OS-level fractional display scaling (125/150 % in GNOME), tile edges still land on subpixel **device**-pixel boundaries — no CSS rounding can prevent that — and WebKitGTK antialiases each composited tile layer, leaving thin seams (field report after #58: lines got thinner but are still visible).

## Fix

Stretch every 256px tile to 256.5px so each neighbor overlaps the previous tile's antialiased edge — the seam has nothing left to shine through.

- Gated to WebKitGTK via the existing `isWebKitGtk` platform flag: **Windows/macOS are untouched by construction** (their compositors snap layers to device pixels, the problem never existed there, and tiles stay pixel-exact).
- Applies to base and overlay tiles alike; the 0.2 % stretch is invisible and scales along with Leaflet's zoom animation.
- MissionPreviewMap deliberately untouched (tiny, no reports).

## Testing

- `npm run check`: 0 errors
- Linux verification pending (100 % must stay clean, 125/150 % should lose the remaining seams)
