### PR TITLE
fix(logbook): scale imported blackbox wind, detect fixed wings by nav PID

### DIFF
--- a/src-tauri/src/flightlog/ardupilot.rs
+++ b/src-tauri/src/flightlog/ardupilot.rs
@@ -719,6 +719,19 @@ where
             }
         }
 
+    // ── Opening-mode backfill ────────────────────────────────────────
+    // ArduPilot writes MODE only when the mode changes, so rows logged before the first one carry no
+    // mode and replayed as N/A — on a log-on-arm file that is the opening frames of the flight. The
+    // vehicle was in that mode all along; only the message had yet to be written.
+    if let Some(first_mode) = all_rows.iter().find_map(|r| r.custom_mode) {
+        for r in all_rows.iter_mut() {
+            if r.custom_mode.is_some() {
+                break;
+            }
+            r.custom_mode = Some(first_mode);
+        }
+    }
+
     if all_rows.is_empty() {
         return Err("ArduPilot import failed: no valid GPS rows found".into());
     }

--- a/src-tauri/src/flightlog/blackbox.rs
+++ b/src-tauri/src/flightlog/blackbox.rs
@@ -496,6 +496,9 @@ struct ColumnIndices {
     gps_epv: Option<usize>,
     active_wp_number: Option<usize>,
     active_flight_mode_flags: Option<usize>,
+    /// `flightModeFlags` — the RC *box* mask, decoded to names ("ARM|ANGLE"). Only read when
+    /// `activeFlightModeFlags` is missing; see `flight_mode_bits_from_names`.
+    flight_mode_boxes: Option<usize>,
     state_flags: Option<usize>,
     nav_state: Option<usize>,
     nav_flags: Option<usize>,
@@ -547,6 +550,7 @@ impl ColumnIndices {
             gps_epv: resolve_col(m, &["gps_epv"]),
             active_wp_number: resolve_col(m, &["activewpnumber", "active_wp_number"]),
             active_flight_mode_flags: resolve_col(m, &["activeflightmodeflags", "active_flight_mode_flags"]),
+            flight_mode_boxes: resolve_col(m, &["flightmodeflags", "flight_mode_flags"]),
             state_flags: resolve_col(m, &["stateflags", "state_flags"]),
             nav_state: resolve_col(m, &["navstate", "nav_state"]),
             nav_flags: resolve_col(m, &["navflags", "nav_flags"]),
@@ -600,6 +604,45 @@ fn read_u8(cols: Option<usize>, record: &StringRecord) -> Option<u8> {
     read_f64(cols, record).map(|v| v.round() as u8)
 }
 
+/// Normalized FLIGHT_MODE bits from `blackbox_decode`'s decoded box names ("ARM|ANGLE|MIXERPROFILE").
+///
+/// Used only for logs predating `activeFlightModeFlags` (INAV 8 and older), whose sole mode signal is
+/// `flightModeFlags` = `rcModeActivationMask`. The raw value there is a `boxId_e` **enum ordinal**
+/// mask, and those ordinals shift between releases — ordinal 53 is MIXERPROFILE in a 9.0 log but the
+/// permanent id the live path maps is NAVCRUISE — so the names the decoder already resolved are the
+/// version-robust way in. Names that are not flight modes (ARM, LIGHTS, MIXERPROFILE, …) contribute
+/// nothing, which is what leaves an armed craft with no mode box as acro.
+///
+/// Caveat this cannot fix: a box mask says which mode the pilot *selected*, not which one the FC
+/// actually entered — a NAV box without a GPS fix never engages, yet shows here.
+fn flight_mode_bits_from_names(names: &str) -> u32 {
+    let mut bits = 0u32;
+    for name in names.split('|') {
+        bits |= match name.trim() {
+            "ANGLE" => 1 << 0,
+            "HORIZON" => 1 << 1,
+            "HEADINGHOLD" => 1 << 2,
+            "NAVALTHOLD" => 1 << 3,
+            "NAVRTH" => 1 << 4,
+            "NAVPOSHOLD" => 1 << 5,
+            "HEADFREE" => 1 << 6,
+            "NAVLAUNCH" => 1 << 7,
+            "MANUAL" => 1 << 8,
+            "FAILSAFE" => 1 << 9,
+            "AUTOTUNE" => 1 << 10,
+            "NAVWP" => 1 << 11,
+            // Cruise = course hold + althold; the live box table folds both onto the same bit.
+            "NAVCOURSEHOLD" | "NAVCRUISE" => 1 << 12,
+            "FLAPERON" => 1 << 13,
+            "TURTLE" => 1 << 15,
+            "SOARING" => 1 << 16,
+            "ANGLEHOLD" => 1 << 17,
+            _ => 0,
+        };
+    }
+    bits
+}
+
 fn read_json_array(indices: &[usize], record: &StringRecord) -> Option<String> {
     if indices.is_empty() {
         return None;
@@ -650,7 +693,14 @@ fn build_telemetry_record_indexed(
     let lon = read_f64(cols.lon, record).map(|v| if v.abs() > 180.0 { v / 1e7 } else { v });
 
     // Canonical flight mode from the logged INAV flightModeFlags (same bit layout as classify_inav).
-    let mode_flags = read_i64(cols.active_flight_mode_flags, record);
+    // INAV 8 and older never logged that field — fall back to the decoded box names there, which is
+    // all those logs carry (see flight_mode_bits_from_names).
+    let mode_flags = read_i64(cols.active_flight_mode_flags, record).or_else(|| {
+        cols.flight_mode_boxes
+            .and_then(|i| record.get(i))
+            .filter(|names| !names.trim().is_empty())
+            .map(|names| flight_mode_bits_from_names(names) as i64)
+    });
     let (mode_primary, mode_modifiers) = match mode_flags {
         Some(f) => {
             let fm = crate::flightmode::classify_inav(f as u32);

--- a/src-tauri/src/flightlog/blackbox.rs
+++ b/src-tauri/src/flightlog/blackbox.rs
@@ -643,6 +643,51 @@ fn flight_mode_bits_from_names(names: &str) -> u32 {
     bits
 }
 
+/// INAV `stateFlags_t` bits from `blackbox_decode`'s decoded names ("GPS_FIX_HOME|GPS_FIX|…").
+///
+/// The decoder renders this field as names by default, so the numeric read always failed and every
+/// imported row stored a null — the column was write-only in practice. Bit positions are
+/// `runtime_config.h`, confirmed against 574k decoded rows by pairing the name output with the same
+/// logs decoded under `--unit-flags raw` (zero disagreements).
+fn state_flag_bits_from_names(names: &str) -> u32 {
+    let mut bits = 0u32;
+    for name in names.split('|') {
+        bits |= match name.trim() {
+            "GPS_FIX_HOME" => 1 << 0,
+            "GPS_FIX" => 1 << 1,
+            "CALIBRATE_MAG" => 1 << 2,
+            "SMALL_ANGLE" => 1 << 3,
+            "FIXED_WING_LEGACY" => 1 << 4,
+            "ANTI_WINDUP" => 1 << 5,
+            "FLAPERON_AVAILABLE" => 1 << 6,
+            "NAV_MOTOR_STOP_OR_IDLE" => 1 << 7,
+            "COMPASS_CALIBRATED" => 1 << 8,
+            "ACCELEROMETER_CALIBRATED" => 1 << 9,
+            "GPS_ESTIMATED_FIX" => 1 << 10,
+            "NAV_CRUISE_BRAKING" => 1 << 11,
+            "NAV_CRUISE_BRAKING_BOOST" => 1 << 12,
+            "NAV_CRUISE_BRAKING_LOCKED" => 1 << 13,
+            "NAV_EXTRA_ARMING_SAFETY_BYPASSED" => 1 << 14,
+            "AIRMODE_ACTIVE" => 1 << 15,
+            "ESC_SENSOR_ENABLED" => 1 << 16,
+            "AIRPLANE" => 1 << 17,
+            "MULTIROTOR" => 1 << 18,
+            "ROVER" => 1 << 19,
+            "BOAT" => 1 << 20,
+            "ALTITUDE_CONTROL" => 1 << 21,
+            "MOVE_FORWARD_ONLY" => 1 << 22,
+            "SET_REVERSIBLE_MOTORS_FORWARD" => 1 << 23,
+            "FW_HEADING_USE_YAW" => 1 << 24,
+            "ANTI_WINDUP_DEACTIVATED" => 1 << 25,
+            "LANDING_DETECTED" => 1 << 26,
+            "IN_FLIGHT_EMERG_REARM" => 1 << 27,
+            "TAILSITTER" => 1 << 28,
+            _ => 0,
+        };
+    }
+    bits
+}
+
 fn read_json_array(indices: &[usize], record: &StringRecord) -> Option<String> {
     if indices.is_empty() {
         return None;
@@ -740,7 +785,13 @@ fn build_telemetry_record_indexed(
         gps_epv: read_f64(cols.gps_epv, record),
         active_wp_number: read_i32(cols.active_wp_number, record),
         active_flight_mode_flags: mode_flags,
-        state_flags: read_i64(cols.state_flags, record),
+        // Decoded to names by default, so the numeric read never resolved (see the helper).
+        state_flags: read_i64(cols.state_flags, record).or_else(|| {
+            cols.state_flags
+                .and_then(|i| record.get(i))
+                .filter(|names| !names.trim().is_empty())
+                .map(|names| state_flag_bits_from_names(names) as i64)
+        }),
         nav_state: read_i32(cols.nav_state, record),
         nav_flags: read_i64(cols.nav_flags, record),
         rx_signal_received: read_u8(cols.rx_signal_received, record),

--- a/src-tauri/src/flightlog/blackbox.rs
+++ b/src-tauri/src/flightlog/blackbox.rs
@@ -696,9 +696,11 @@ fn build_telemetry_record_indexed(
         rx_signal_received: read_u8(cols.rx_signal_received, record),
         hw_health_status: read_i64(cols.hw_health_status, record),
         baro_temperature: read_f64(cols.baro_temperature, record),
-        wind_n_ms: read_f64(cols.wind_n, record),
-        wind_e_ms: read_f64(cols.wind_e, record),
-        wind_d_ms: read_f64(cols.wind_d, record),
+        // INAV's wind estimator keeps its vectors in cm/s (wind_estimator.c) → m/s, matching the
+        // live MSP2_INAV_WIND path which already scales the same way.
+        wind_n_ms: read_f64(cols.wind_n, record).map(|v| v / 100.0),
+        wind_e_ms: read_f64(cols.wind_e, record).map(|v| v / 100.0),
+        wind_d_ms: read_f64(cols.wind_d, record).map(|v| v / 100.0),
         rc_data_json: read_json_array(&cols.rc_data, record),
         rc_command_json: read_json_array(&cols.rc_command, record),
         // navPos[0,1] are local-frame NE offsets in cm — NOT useful as geographic coords.
@@ -814,18 +816,30 @@ fn extract_header_metadata_for_log(file_data: &[u8], log_index: Option<u32>) -> 
     }
 }
 
-/// Heuristic platform type for INAV blackbox: there is no explicit platform header, but the
-/// logged field set differs by airframe — fixed-wing logs a single `motor[0]` plus `servo[...]`
-/// control surfaces, while multirotors log several `motor[N]`. We read the highest motor index
-/// (and servo presence) from the `H Field ... name:` definition lines.
+/// Platform type for INAV blackbox: there is no explicit platform header, but the navigation PID
+/// fields are logged under mutually exclusive conditions (blackbox.c):
+///   `fwAlt*`/`fwPos*` → `STATE(FIXED_WING_LEGACY) && BLACKBOX_FEATURE_NAV_PID`
+///   `mcPos*`/`mcVel*`/`mcSurface*` → `!STATE(FIXED_WING_LEGACY) && BLACKBOX_FEATURE_NAV_PID`
+/// so either group settles it outright. With nav-PID logging switched off neither appears and the
+/// motor/servo shape is all that is left — a weak signal, because a fixed wing may well run several
+/// motors (differential thrust, twin): counting motors alone declared every such log a multirotor.
 /// Returns 0 = multirotor (default / unknown), 1 = airplane. Display-only; no functional impact.
 fn parse_platform_type(text: &str) -> u8 {
+    const FIXED_WING_NAV_FIELDS: [&str; 2] = ["fwAlt", "fwPos"];
+    const MULTIROTOR_NAV_FIELDS: [&str; 3] = ["mcPos", "mcVel", "mcSurface"];
+
     let mut max_motor: i32 = -1;
     let mut has_servo = false;
     for line in text.lines() {
         let l = line.trim();
         if !l.starts_with("H Field") {
             continue;
+        }
+        if FIXED_WING_NAV_FIELDS.iter().any(|f| l.contains(f)) {
+            return 1;
+        }
+        if MULTIROTOR_NAV_FIELDS.iter().any(|f| l.contains(f)) {
+            return 0;
         }
         if l.contains("servo[") {
             has_servo = true;

--- a/src-tauri/src/flightlog/db.rs
+++ b/src-tauri/src/flightlog/db.rs
@@ -2001,6 +2001,19 @@ pub fn get_flight_track(
     conn: &Connection,
     flight_id: i64,
 ) -> SqlResult<Vec<TelemetryRecord>> {
+    // Flights recorded before the unified flight-mode model (f8e5699, 2026-06-14) stored the raw
+    // mode flags but no canonical mode, and replay them as N/A. An import can be repeated, a live
+    // recording cannot, so the mode is derived here from the flags that are already in the row.
+    // `active_flight_mode_flags` holds INAV's bitmask or MAVLink's custom_mode depending on the
+    // source, which is what the variant selects between.
+    let fc_variant: Option<String> = conn
+        .query_row(
+            "SELECT fc_variant FROM flights WHERE id = ?1",
+            params![flight_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+
     let mut stmt = conn.prepare(
         "SELECT id, flight_id, timestamp_ms, lat, lon, alt_m, speed_ms,
                 heading, vario_ms, voltage, current_a, mah_drawn, rssi, battery_percentage,
@@ -2019,6 +2032,18 @@ pub fn get_flight_track(
     )?;
 
     let rows = stmt.query_map(params![flight_id], |row| {
+        let mode_flags: Option<i64> = row.get(26)?;
+        let stored_primary: Option<String> = row.get(41)?;
+        let stored_modifiers: Option<String> = row.get(42)?;
+        let derived = match (&stored_primary, mode_flags, fc_variant.as_deref()) {
+            (None, Some(flags), Some(variant)) => Some(if variant.eq_ignore_ascii_case("INAV") {
+                crate::flightmode::classify_inav(flags as u32)
+            } else {
+                crate::flightmode::classify_mavlink(flags as u32, variant)
+            }),
+            _ => None,
+        };
+
         Ok(TelemetryRecord {
             id: row.get(0)?,
             flight_id: row.get(1)?,
@@ -2061,8 +2086,13 @@ pub fn get_flight_track(
             nav_lat: row.get(38)?,
             nav_lon: row.get(39)?,
             nav_alt_m: row.get(40)?,
-            mode_primary: row.get(41)?,
-            mode_modifiers: row.get(42)?,
+            mode_primary: stored_primary.or_else(|| derived.as_ref().map(|m| m.primary.clone())),
+            mode_modifiers: stored_modifiers.or_else(|| {
+                derived
+                    .as_ref()
+                    .filter(|m| !m.modifiers.is_empty())
+                    .map(|m| m.modifiers.join(","))
+            }),
             link_snr: row.get(43)?,
             link_rssi_dbm: row.get(44)?,
             airspeed_ms: row.get(45)?,

--- a/src/lib/adapters/telemetryAdapter.ts
+++ b/src/lib/adapters/telemetryAdapter.ts
@@ -86,12 +86,14 @@ export function toTelemetryData(r: TelemetryRecord, fcVariant = 'INAV'): Telemet
     },
 
     // Status
-    // `state_flags` is INAV's stateFlags bitfield and only blackbox imports populate it — the live
-    // recorder has no source for it (`recorder.rs`) and stores NULL, which left every replayed live
-    // flight looking permanently disarmed. Recover it from the recording itself: the recorder opens a
-    // flight on the arm edge and finalises it on disarm, so every sample in a flight row was taken
-    // while armed, and any sample carrying a flight mode proves telemetry was flowing at that moment.
-    armingFlags: r.state_flags ?? (r.mode_primary ? ARMED_BIT : 0),
+    // Derived, never read from `state_flags`: that column holds INAV's stateFlags, a different
+    // bitfield whose bit 2 is CALIBRATE_MAG, not armingFlags' ARMED — feeding it in here would read
+    // an armed flight as disarmed. Nothing records armingFlags: the live recorder has no source for
+    // it (`recorder.rs`) and a blackbox log never carries it. Recover it from the recording instead:
+    // the recorder opens a flight on the arm edge and finalises it on disarm, so every sample in a
+    // flight row was taken while armed, and any sample carrying a flight mode proves telemetry was
+    // flowing at that moment.
+    armingFlags: r.mode_primary ? ARMED_BIT : 0,
     statusSeen: true, // replay rows always carry the recorded arming state
     cpuLoad: r.cpu_load ?? 0,
     sensorStatus: r.hw_health_status ?? 0,

--- a/src/lib/components/FpvHud.svelte
+++ b/src/lib/components/FpvHud.svelte
@@ -21,6 +21,7 @@
     roll = 0,      // deg, + = right wing down
     speed = 0,     // already in display unit
     speedUnit = 'm/s',
+    speedDigits = 0, // decimals for the speed readout (m/s needs one, the coarser units don't)
     speedLabel = 'SPD', // 'SPD' (ground speed) or 'ASPD' (airspeed, when available)
     altitude = 0,  // already in display unit
     altitudeUnit = 'm',
@@ -34,6 +35,7 @@
     roll?: number;
     speed?: number;
     speedUnit?: string;
+    speedDigits?: number;
     speedLabel?: string;
     altitude?: number;
     altitudeUnit?: string;
@@ -104,7 +106,8 @@
     }),
   );
 
-  const fmt = (n: number) => (Math.abs(n) >= 100 ? Math.round(n).toString() : n.toFixed(0));
+  const fmt = (n: number, digits = 0) =>
+    Math.abs(n) >= 100 ? Math.round(n).toString() : n.toFixed(digits);
 
   // ── Flight-path marker (velocity vector) ────────────────────────────
   // Conformal (same projection + FOV scaling as the pitch ladder), body-frame / pilot's view: vertical
@@ -200,7 +203,7 @@
   <g>
     <text class="hud-text small dim" x={CX - 430} y={CY - 34} text-anchor="middle">{speedLabel} {speedUnit}</text>
     <rect class="hud-box" x={CX - 490} y={CY - 18} width="120" height="36" />
-    <text class="hud-text big" x={CX - 430} y={CY} text-anchor="middle" dominant-baseline="central">{fmt(speed)}</text>
+    <text class="hud-text big" x={CX - 430} y={CY} text-anchor="middle" dominant-baseline="central">{fmt(speed, speedDigits)}</text>
   </g>
 
   <!-- Altitude (right) -->

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -81,7 +81,7 @@
   import { t } from "svelte-i18n";
   import { contactColor, ffContactColor, contactVisibleOnMap, relevanceFactor } from "$lib/helpers/radarMap";
   import { pickShape, buildContactIconHtml } from "$lib/helpers/radarIcons";
-  import { convertAltitude, convertSpeed, convertDistance, convertVerticalSpeed, formatConverted } from "$lib/utils/units";
+  import { convertAltitude, convertSpeed, convertDistance, convertVerticalSpeed, formatConverted, speedDigits } from "$lib/utils/units";
 
   let {
     playbackTrack = [],
@@ -296,7 +296,7 @@
     const ui = get(settings).interface;
     const name = v.callsign?.trim() || v.id;
     const alt = v.altM == null ? '—' : formatConverted(convertAltitude(v.altM, ui.altitudeUnit), 0);
-    const spd = v.groundSpeedMs == null ? '—' : formatConverted(convertSpeed(v.groundSpeedMs, ui.speedUnit), 0);
+    const spd = v.groundSpeedMs == null ? '—' : formatConverted(convertSpeed(v.groundSpeedMs, ui.speedUnit), speedDigits(ui.speedUnit));
     const dist = v.distanceM == null
       ? '—'
       : formatConverted(convertDistance(v.distanceM, ui.distanceUnit), v.distanceM < 10000 ? 1 : 0);

--- a/src/lib/components/Map3D.svelte
+++ b/src/lib/components/Map3D.svelte
@@ -67,7 +67,7 @@
   import { sunAltitudeDeg, cesiumLikeBrightness } from "$lib/utils/sun";
   import { ensureUserLocation, resolveUserLocation, userGeoLocation } from "$lib/helpers/userLocation";
   import FpvHud from "$lib/components/FpvHud.svelte";
-  import { convertSpeed, convertAltitude, convertDistance, convertVerticalSpeed, formatConverted } from "$lib/utils/units";
+  import { convertSpeed, convertAltitude, convertDistance, convertVerticalSpeed, formatConverted, speedDigits } from "$lib/utils/units";
   import { haversineDistance, bearing, destinationPoint } from "$lib/utils/geo";
   import type { SpeedUnit, AltitudeUnit, RadarMapSettings, GcsMode } from "$lib/stores/settings";
   import { radarVehicles, radarSelection, type RadarSnapshot } from "$lib/stores/radarTracking";
@@ -1618,7 +1618,7 @@
     }
     const ui = get(settings).interface;
     const alt = formatConverted(convertAltitude(rec.altM, ui.altitudeUnit), 0);
-    const spd = rec.groundSpeedMs == null ? '—' : formatConverted(convertSpeed(rec.groundSpeedMs, ui.speedUnit), 0);
+    const spd = rec.groundSpeedMs == null ? '—' : formatConverted(convertSpeed(rec.groundSpeedMs, ui.speedUnit), speedDigits(ui.speedUnit));
     let vs = '';
     if (rec.verticalSpeedMs != null && Math.abs(rec.verticalSpeedMs) >= 0.5) {
       const a = formatConverted(convertVerticalSpeed(Math.abs(rec.verticalSpeedMs), ui.verticalSpeedUnit), 1);
@@ -4530,6 +4530,7 @@
       roll={hud.roll}
       speed={sp.value}
       speedUnit={sp.unit}
+      speedDigits={speedDigits(hudSpeedUnit)}
       speedLabel={hud.speedIsAir ? 'ASPD' : 'SPD'}
       altitude={al.value}
       altitudeUnit={al.unit}

--- a/src/lib/components/RadarAlertBanner.svelte
+++ b/src/lib/components/RadarAlertBanner.svelte
@@ -12,7 +12,7 @@
   import { radarAlerts, type ContactAlert } from '$lib/controllers/radarAlerts';
   import { radarSelection } from '$lib/stores/radarTracking';
   import { contactTypeKey } from '$lib/helpers/radar3d';
-  import { convertSpeed, convertAltitude, convertDistance, formatConverted } from '$lib/utils/units';
+  import { convertSpeed, convertAltitude, convertDistance, formatConverted, speedDigits } from '$lib/utils/units';
   import type { InterfaceSettings } from '$lib/stores/settings';
 
   let { interfaceSettings }: { interfaceSettings: InterfaceSettings } = $props();
@@ -26,7 +26,7 @@
   const compass = (deg: number) => COMPASS[Math.round(deg / 45) % 8];
 
   const fmtSpeed = (ms: number | null) =>
-    ms == null ? '—' : formatConverted(convertSpeed(ms, interfaceSettings.speedUnit), 0);
+    ms == null ? '—' : formatConverted(convertSpeed(ms, interfaceSettings.speedUnit), speedDigits(interfaceSettings.speedUnit));
   const fmtDist = (m: number | null) => {
     if (m == null) return '—';
     const d = convertDistance(m, interfaceSettings.distanceUnit);

--- a/src/lib/components/RadarPanel.svelte
+++ b/src/lib/components/RadarPanel.svelte
@@ -21,7 +21,7 @@
   import { panelState } from '$lib/stores/panelState';
   import type { AppSettings, RadarSettings, InterfaceSettings } from '$lib/stores/settings';
   import type { PortInfo } from '$lib/stores/connection';
-  import { convertSpeed, convertAltitude, convertDistance, formatConverted } from '$lib/utils/units';
+  import { convertSpeed, convertAltitude, convertDistance, formatConverted, speedDigits } from '$lib/utils/units';
   import { RELATIVE_LEGEND_STOPS, LEGEND_LEVEL_PCT } from '$lib/helpers/radarMap';
 
   let { radar, interfaceSettings, referencePoint = null, mspSupported = false, onPatch = (_p: Partial<AppSettings>) => {} }: {
@@ -135,7 +135,7 @@
     return formatConverted(d, d.value < 10 ? 1 : 0);
   };
   const fmtSpeed = (ms: number | null) =>
-    ms == null ? '—' : formatConverted(convertSpeed(ms, interfaceSettings.speedUnit), 0);
+    ms == null ? '—' : formatConverted(convertSpeed(ms, interfaceSettings.speedUnit), speedDigits(interfaceSettings.speedUnit));
   const fmtAlt = (m: number | null) =>
     m == null ? '—' : formatConverted(convertAltitude(m, interfaceSettings.altitudeUnit), 0);
   const fmtBrg = (b: number | null) => (b == null ? '—' : `${Math.round(b)}°`);

--- a/src/lib/components/widgets/CompassWidget.svelte
+++ b/src/lib/components/widgets/CompassWidget.svelte
@@ -7,7 +7,7 @@
 <script lang="ts">
   import type { TelemetryData } from "$lib/stores/telemetry";
   import type { InterfaceSettings } from "$lib/stores/settings";
-  import { convertSpeed } from "$lib/utils/units";
+  import { convertSpeed, speedDigits } from "$lib/utils/units";
   import { t } from 'svelte-i18n';
 
   let {
@@ -111,7 +111,7 @@
     {#if windShown}
       <text x="100" y="128" text-anchor="middle" dominant-baseline="middle"
             fill="#7fd4ff" font-size="15" font-weight="600" font-family="sans-serif"
-            style="font-variant-numeric: tabular-nums">{windSpeedConv.value.toFixed(0)} {windSpeedConv.unit}</text>
+            style="font-variant-numeric: tabular-nums">{windSpeedConv.value.toFixed(speedDigits(interfaceSettings.speedUnit))} {windSpeedConv.unit}</text>
     {/if}
 
     <!-- Bezel ring -->

--- a/src/lib/components/widgets/RawTelemetryWidget.svelte
+++ b/src/lib/components/widgets/RawTelemetryWidget.svelte
@@ -7,7 +7,7 @@
 <script lang="ts">
   import type { TelemetryData } from "$lib/stores/telemetry";
   import type { InterfaceSettings } from "$lib/stores/settings";
-  import { convertAltitude, convertSpeed, convertVerticalSpeed, formatConverted } from "$lib/utils/units";
+  import { convertAltitude, convertSpeed, convertVerticalSpeed, formatConverted, speedDigits } from "$lib/utils/units";
   import { t } from 'svelte-i18n';
 
   let {
@@ -21,7 +21,7 @@
   } = $props();
 
   let altText = $derived(formatConverted(convertAltitude(telem.altitude, interfaceSettings.altitudeUnit), 1));
-  let speedText = $derived(formatConverted(convertSpeed(telem.groundSpeed, interfaceSettings.speedUnit), 0));
+  let speedText = $derived(formatConverted(convertSpeed(telem.groundSpeed, interfaceSettings.speedUnit), speedDigits(interfaceSettings.speedUnit)));
   let varioText = $derived(() => {
     const converted = convertVerticalSpeed(telem.vario, interfaceSettings.verticalSpeedUnit);
     return `${telem.vario >= 0 ? '+' : ''}${converted.value.toFixed(1)} ${converted.unit}`;

--- a/src/lib/components/widgets/SpeedWidget.svelte
+++ b/src/lib/components/widgets/SpeedWidget.svelte
@@ -9,7 +9,7 @@
   import type { TelemetryData } from "$lib/stores/telemetry";
   import type { InterfaceSettings } from "$lib/stores/settings";
   import { settings } from "$lib/stores/settings";
-  import { convertSpeed } from "$lib/utils/units";
+  import { convertSpeed, speedDigits } from "$lib/utils/units";
   import { t } from 'svelte-i18n';
 
   let {
@@ -32,10 +32,11 @@
 
   let label = $derived(hasAir ? $t('widgetLabels.aspd') : $t('widgetLabels.spd'));
   let primaryConv = $derived(hasAir ? asConv : gsConv);
-  let speed = $derived(telem.lastUpdate ? primaryConv.value.toFixed(0) : '—');
+  let digits = $derived(speedDigits(interfaceSettings.speedUnit));
+  let speed = $derived(telem.lastUpdate ? primaryConv.value.toFixed(digits) : '—');
   let secondary = $derived(
     hasAir
-      ? $t('widgetLabels.gs', { values: { value: `${gsConv.value.toFixed(0)} ${gsConv.unit}` } })
+      ? $t('widgetLabels.gs', { values: { value: `${gsConv.value.toFixed(digits)} ${gsConv.unit}` } })
       : null
   );
 

--- a/src/lib/utils/units.ts
+++ b/src/lib/utils/units.ts
@@ -30,6 +30,15 @@ export function convertSpeed(ms: number, unit: SpeedUnit): ConvertedValue {
   }
 }
 
+/**
+ * Decimals for a speed readout. m/s is by far the coarsest of the offered units — one step is
+ * 3.6 km/h, 1.9 kt — so a whole number hides most of the resolution the FC actually sends (cm/s on
+ * both INAV and ArduPilot). The others are fine-grained enough to read as integers.
+ */
+export function speedDigits(unit: SpeedUnit): number {
+  return unit === 'ms' ? 1 : 0;
+}
+
 export function convertAltitude(meters: number, unit: AltitudeUnit): ConvertedValue {
   if (unit === 'ft') {
     return { value: meters * 3.280839895, unit: 'ft' };


### PR DESCRIPTION
Two import bugs reported against real INAV logs, plus one small display change. Both bugs put wrong data in the **database**, not just on screen — the live MSP path was correct all along.

## Wind speed ×100

INAV's wind estimator keeps its vectors in **cm/s** (`wind_estimator.c`: *"wind velocity vectors in cm / sec in earth frame"*), and the importer wrote the raw CSV column straight into `wind_n_ms` / `wind_e_ms` / `wind_d_ms`.

Measured in a real database: imported flights hold values up to **450** and **300**, while live flights — same quantity, taken through `MSP2_INAV_WIND`, which already divides by 100 — top out at **3.93**.

## Fixed wings filed as multirotors

The old heuristic read *one motor plus servos* as fixed-wing and **anything from two motors up as multirotor**, so every plane with differential thrust or a twin was misfiled. The reporting user's aircraft log `motor[0..1]` and `motor[0..2]`.

INAV logs the navigation PID fields under mutually exclusive conditions (`blackbox.c`):

| Field group | Condition |
|---|---|
| `fwAlt*`, `fwPos*` | `STATE(FIXED_WING_LEGACY) && BLACKBOX_FEATURE_NAV_PID` |
| `mcPos*`, `mcVel*`, `mcSurface*` | `!STATE(FIXED_WING_LEGACY) && BLACKBOX_FEATURE_NAV_PID` |

Either group therefore settles it outright. The motor/servo shape remains as the fallback for logs with nav-PID logging switched off, where no better signal exists.

Verified against every archived log in a real database: the **seven** misfiled planes flip to fixed-wing, the already-correct ones stay correct, and ArduPilot `.bin` imports go through their own parser untouched.

## Existing data

Deliberately left alone — no migration before 1.0. Flights already imported keep their wrong wind values and platform type; re-import if that gets in the way.

## Also: m/s speeds get one decimal

m/s is the coarsest of the offered speed units — one step is 3.6 km/h or 1.9 kt — so whole numbers threw away most of the resolution the FC actually sends (cm/s on both INAV and ArduPilot). The finer units keep reading as integers, via a `speedDigits()` helper applied at each readout: speed widget, compass wind, FPV HUD, radar banner and panel, map popups, raw telemetry. Sites that already printed a decimal (logbook detail, end-of-flight dialog, mission waypoint speeds) are unchanged.

`npm run check` 0 errors · `npm run build` clean · `cargo check` / `cargo test --no-run` clean.


---

## Third fix: flight mode N/A on INAV 8 and older logs

Imported flights showed a grey **N/A** instead of a mode. Two causes, only one of them a live bug.

INAV 9 added `activeFlightModeFlags` (the real FLIGHT_MODE bitmask) to the slow frame, and the importer reads only that. Logs from **INAV 8 and older carry just `flightModeFlags`** — the RC box activation mask — so nothing resolved and every row stored a null mode.

The raw value of that field is a `boxId_e` **enum ordinal** mask, and those ordinals move between releases: ordinal 53 is `MIXERPROFILE` in a 9.0 log, while the *permanent id* the live path maps at 53 is `NAVCRUISE`. `blackbox_decode` has already resolved the ordinals to names against the matching table, so the importer parses **those** instead — names are stable where ordinals are not. Non-mode boxes (`ARM`, `LIGHTS`, `MIXERPROFILE`, …) map to nothing, which correctly leaves an armed craft with no mode box as `acro`.

Cross-checked on a 9.0.1 log carrying **both** fields — the name path and the numeric path agree on every primary mode:

| decoded names | `activeFlightModeFlags` | both resolve to |
|---|---|---|
| `ARM\|NAVRTH` | 16409 | `rth` |
| `ARM\|NAVCRUISE` | 4104 | `cruise` |
| `ARM\|ANGLE\|MIXERPROFILE` | 1 | `angle` |

On an INAV 8 log the two states present, `ARM` and `ARM|ANGLE`, resolve to `acro` and `angle`.

**Limitation inherent to the source:** a box mask says which mode the pilot *selected*, not which one the FC actually *entered* — a NAV box without a GPS fix never engages yet still shows. INAV 9+ logs keep using the accurate field, so this only ever applies to older logs.

**Not a code bug:** flights imported before the unified flight-mode model (`f8e5699`, 2026-06-14) predate the column entirely and stay null until re-imported.

---

## Fourth fix: `state_flags` never stored, and misread as arming

`blackbox_decode` renders `stateFlags` as **names** (`GPS_FIX_HOME|GPS_FIX|…`), so the importer's numeric read never resolved and every imported row stored a **null** — the column was write-only in practice. The names are now parsed, same approach as the flight-mode fallback.

Bit positions are `runtime_config.h` `stateFlags_t`, established two independent ways:

1. **Derived from the data** — pairing the name output against the same logs decoded under `--unit-flags raw` fixes each name's bit by position. Agreed with the firmware enum on all 16 names those logs contain.
2. **Verified end to end** — the finished table reproduces the raw numeric value on **all 574,038 rows** of both logs, zero disagreements.

### The part that made this worth doing carefully

The replay adapter fed `state_flags` straight into `armingFlags`. Those are **different bitfields**: `ARMED` is `armingFlags` bit 2, while `stateFlags` bit 2 is `CALIBRATE_MAG`.

It only ever behaved because the parse failed and the `??` fallback took over. **Repairing the parse alone would have made every imported flight replay as disarmed** — neither log checked here sets bit 2 anywhere, so the arming indicator, the map's armed styling, and everything else gated on `isArmed` would have flipped off for the whole flight.

Nothing records `armingFlags`: the live recorder has no source for it and a blackbox log never carries it. So the derivation from the recording *is* the whole story, and `armingFlags` now says so instead of pretending a stray column supplies it.

---

## Fifth fix: grey N/A on the opening frames of an ArduPilot import

ArduPilot writes `MODE` **only when the mode changes**, so rows logged before the first one carry no mode and replay as a grey N/A. On a log-on-arm file those are the opening frames of the flight — the first second or two right after arming. The vehicle was in that mode all along; only the message had yet to be written.

The first known mode is now carried back over them, right next to the existing log-on-arm backfill that does the same for the armed flag.

Measured on two imported ArduPlane logs:

| flight | rows | leading nulls | total nulls |
|---|---|---|---|
| #159 | 3830 | 6 (1.2 s) | 6 |
| #138 | 19966 | 3 | 3 |

In both cases every null in the flight is a leading null, so the backfill covers them completely. INAV imports have none — that field rides the slow frame and is present from the first row.

---

## Sixth fix: pre-2026-06 recordings replay without a flight mode

Flights recorded **before the unified flight-mode model** (`f8e5699`, 2026-06-14) stored the raw mode flags but no canonical mode, so they replay as a grey N/A. An import can simply be repeated — a **live recording cannot**, so those flights would stay blank forever. The flags are sitting right there in the row, so the mode is now derived whenever the column is empty.

`active_flight_mode_flags` holds INAV's bitmask or MAVLink's `custom_mode` depending on where the flight came from, so the dispatch reads the flight's `fc_variant` — looked up once per track, not per row. Rows carrying a stored mode do no work at all.

Covers **11 flights** in the database checked here, every one from before the model landed and none after:

| flight | source | flags → derived |
|---|---|---|
| #83, #85 (HITL, MSP live) | INAV | `18441` → mission +althold · `20489` → cruise +althold · `1` → angle · `0` → acro |
| #75 | INAV blackbox | `1` → angle |
| #66 | INAV MSP | `8` → acro +althold |
| #42 | ArduCopter dataflash | `2` → alt hold · `5` → loiter |

Nothing is written back — this is a read-time derivation, not a migration.
