### PR TITLE
fix(map): keep the 2D flight track when switching through 3D

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2512,7 +2512,9 @@
     style={mapInFrame ? inFrameStyle : mapLayerStyle}
     onclick={minimizeLogbook}
   >
-    {#if mapViewMode === '2d'}
+    <!-- 2D stays mounted (hidden) exactly like 3D below: the live track lives in Leaflet layers
+         inside the component, so unmounting it on every switch to 3D threw the trail away. -->
+    <div class="map2d-layer" class:active={mapViewMode === '2d'}>
       <Map
         playbackTrack={mapTrack}
         playbackPoint={playbackPoint}
@@ -2531,7 +2533,7 @@
         {radarReference}
         {radarRefAltM}
       />
-    {/if}
+    </div>
     <!-- 3D stays mounted (hidden) once opened, so toggling back is instant. -->
     {#if map3dEverOpened}
       <div class="map3d-layer" class:active={mapViewMode === '3d'}>
@@ -3065,12 +3067,14 @@
     z-index: 0;
     overflow: hidden;
   }
-  /* 3D map overlay — kept mounted but hidden (visibility, not display, so Cesium
-     keeps a sized canvas) while 2D is shown. */
+  /* Both map overlays stay mounted and hide with visibility, not display: that keeps their box
+     size, so Leaflet and Cesium come back without a resize dance. */
+  .map2d-layer,
   .map3d-layer {
     position: absolute;
     inset: 0;
   }
+  .map2d-layer:not(.active),
   .map3d-layer:not(.active) {
     visibility: hidden;
     pointer-events: none;


### PR DESCRIPTION
## Problem

Switching 2D → 3D → 2D restarts the 2D flight track from scratch. The 3D track survives the same round trip.

## Cause

The two map layers were mounted differently:

```svelte
{#if mapViewMode === '2d'}          <!-- destroyed on every switch to 3D -->
  <Map ... />
{/if}
<!-- 3D stays mounted (hidden) once opened, so toggling back is instant. -->
{#if map3dEverOpened}
  <div class="map3d-layer" class:active={mapViewMode === '3d'}>
```

The live trail lives in Leaflet layers **inside** `Map.svelte` — `trailSegments`, `trailCurrentPositions`, `preArmPositions` and their polylines. Destroying the component throws all of it away, so a remount can only start over.

That also explains why only the *live* trail was affected: the replayed track arrives as the `playbackTrack` prop and is simply re-rendered on mount.

## Fix

Mount 2D the way 3D already is — kept in the DOM, hidden with `visibility` rather than `display` so the box keeps its size and Leaflet needs no `invalidateSize` dance on the way back. The two layers now share one CSS rule.

Nothing inside `Map.svelte` had to change: it reads `mapViewMode` only for the toggle button's label, with no behavioural coupling.

## Trade-off worth watching during the test session

The hidden 2D map keeps following the vehicle, so it also keeps **loading tiles** while 3D is up. That is the same bargain 3D already makes in reverse, and it is what makes the switch back instant — but on a Pi or another low-power host it is new load that was not there before.

The follow animation is not a concern: `followLoop` eases to the target and then stops itself (`followRaf = null`), restarting only when a new target arrives. So the added cost is tile fetches, not a permanent rAF loop. Worth a glance at CPU on the Pi while sitting in 3D; if it bites, the next step is an `active` prop that lets `Map.svelte` skip recentering while hidden.

`npm run check` 0 errors · `npm run build` clean.
