### PR TITLE
fix(scheduler): stop starving every code after the first in a multi-code slot

### DIFF
--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -131,6 +131,10 @@ struct TelemetrySlot {
     last_poll: Option<Instant>,
     /// For groups with rotating secondary codes, track current index
     rotation_index: usize,
+    /// Next code to send in a multi-code slot. The write budget can cut a slot off mid-list, and
+    /// without a cursor the next turn would restart at codes[0] — permanently starving everything
+    /// behind it (see the poll loop).
+    code_cursor: usize,
     /// Scheduling priority (higher = more important, polled first when overloaded)
     priority: u8,
     /// Minimum poll rate (Hz) this slot is never scaled below under link congestion (adaptive floor).
@@ -145,6 +149,7 @@ impl TelemetrySlot {
             interval: Duration::from_secs_f64(1.0 / rate_hz),
             last_poll: None,
             rotation_index: 0,
+            code_cursor: 0,
             priority,
             floor_hz,
         }
@@ -575,20 +580,28 @@ fn scheduler_loop(
                 if budget == 0 {
                     break;
                 }
-                // Rotating secondaries poll one code per turn; every other slot polls all its codes.
-                let codes: Vec<u16> = match slots[i].group {
-                    TelemetryGroup::PositionSecondary => {
-                        let code = slots[i].codes[slots[i].rotation_index % slots[i].codes.len()];
-                        slots[i].rotation_index = slots[i].rotation_index.wrapping_add(1);
-                        vec![code]
-                    }
-                    _ => slots[i].codes.clone(),
+                // Rotating secondaries poll one code per turn; every other slot works through all of
+                // its codes — but across ticks, resuming at `code_cursor`. MAX_WRITES_PER_TICK is 1, so
+                // a slot that restarted its list every turn could only ever emit codes[0]: everything
+                // behind it was starved for the whole session. That is what silently killed
+                // MSP_SENSOR_STATUS and MSP_NAV_STATUS behind MSPV2_INAV_STATUS in the Status slot,
+                // and with NAV_STATUS the active-waypoint highlight. The slot counts as polled (and
+                // its interval restarts) only once the cursor has been all the way round.
+                let rotating = matches!(slots[i].group, TelemetryGroup::PositionSecondary);
+                let codes: Vec<u16> = if rotating {
+                    let code = slots[i].codes[slots[i].rotation_index % slots[i].codes.len()];
+                    slots[i].rotation_index = slots[i].rotation_index.wrapping_add(1);
+                    vec![code]
+                } else {
+                    slots[i].codes[slots[i].code_cursor..].to_vec()
                 };
                 let mut emitted = false;
+                let mut advanced = 0usize;
                 for code in codes {
                     if budget == 0 {
                         break;
                     }
+                    advanced += 1;
                     if in_flight.get(&code).map_or(false, |q| !q.is_empty()) {
                         continue; // dedup: this code is already outstanding
                     }
@@ -610,8 +623,16 @@ fn scheduler_loop(
                         emitted = true;
                     }
                 }
-                if emitted {
-                    slots[i].last_poll = Some(now);
+                if rotating {
+                    if emitted {
+                        slots[i].last_poll = Some(now);
+                    }
+                } else {
+                    slots[i].code_cursor += advanced;
+                    if slots[i].code_cursor >= slots[i].codes.len() {
+                        slots[i].code_cursor = 0;
+                        slots[i].last_poll = Some(now);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Symptom

The active-waypoint pulsing glow never appeared, in 2D or 3D, even with the mission downloaded from the FC on connect, armed, and the mission started.

## Root cause — from a raw MSP capture

A 52-second `.rawmsp` recording of a live session, decoded frame by frame:

| code | requests sent |
|---|---|
| `MSPV2_INAV_STATUS` (0x2000) | **51** (1 Hz, as configured) |
| `MSP_SENSOR_STATUS` (151) | **0** |
| `MSP_NAV_STATUS` (121) | **0** |

All three sit in the same Status slot. The FC was never asked for the active waypoint, so `activeWpNumber` could never leave 0 — no gate, no store and no renderer was ever involved.

`MAX_WRITES_PER_TICK` is **1**, and the per-slot loop breaks on `budget == 0` after the first code. The slot was then marked polled and its interval restarted, so the next turn began again at `codes[0]`:

```rust
_ => slots[i].codes.clone(),   // fresh list every turn
...
for code in codes {
    if budget == 0 { break; }  // budget is 1 → only codes[0] ever goes out
```

Anything behind the first entry of a non-rotating slot could therefore **never** be sent — not throttled, never. `PositionSecondary` escaped only because it rotates one code per turn by design.

## Fix

Give non-rotating slots a cursor. They resume where the budget cut them off, and count as polled — restarting their interval — only once the cursor has been all the way round. At the ~125 Hz tick rate the Status slot's three codes now go out within a few milliseconds of each other, so each keeps its intended 1 Hz.

Single-code slots (every other slot) behave exactly as before: cursor 0 → 1, wraps, poll recorded.

A code stuck in flight still advances the cursor, so a silent FC can't stall the rotation.

## Restores

- The FC's **active target waypoint** → the pulsing glow in 2D and 3D. Note this stays gated as designed on NAV_WP flight mode **and** a trusted mission, so it appears once the FC is actually navigating.
- **Live sensor health status** (`MSP_SENSOR_STATUS`), starved by the same mechanism.

## Verification

`cargo check` / `cargo test --no-run` clean, no new warnings · `npm run check` 0 errors.

Field check for the next session: take another `.rawmsp` and confirm 121 and 151 now appear at ~1 Hz alongside 0x2000 — the same decode that found this.
