### PR TITLE
fix(scheduler): keep asking for MSP_BOXIDS until the FC answers

### DIFF
--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -97,6 +97,8 @@ enum PendingKind {
     Radar,
     /// A link-speed probe RAW_RC (sent WITH reply during the post-engage window) — times the ACK.
     RcProbe,
+    /// A retried MSP_BOXIDS query — its reply installs the index→permanent-ID mapping.
+    BoxIds,
 }
 
 /// Max telemetry/one-shot/radar requests in flight at once (protects the FC's MSP RX buffer). RC frames
@@ -113,6 +115,12 @@ const MAX_IN_FLIGHT: usize = 8;
 /// (`SCHED_READ_TIMEOUT`) this still allows far more requests per second than any slot set asks for.
 /// RC frames are exempt — they're the control path and bypass this budget entirely.
 const MAX_WRITES_PER_TICK: usize = 1;
+/// How long to wait before asking for MSP_BOXIDS again while we still have no mapping. Without it the
+/// activeModes bitmask cannot be decoded at all (`parse_active_modes` refuses to guess), so the whole
+/// session shows no flight mode and MSP RC OVERRIDE is never detected — for the price of one 9-byte
+/// frame every few seconds we simply keep asking until the FC answers.
+const BOXIDS_RETRY_INTERVAL: Duration = Duration::from_secs(3);
+
 /// Short transport read timeout so the pipelined drain/emit loop ticks ≈100 Hz (like Configurator's
 /// executor) instead of being quantized by the coarse idle read timeout.
 const SCHED_READ_TIMEOUT: Duration = Duration::from_millis(8);
@@ -274,20 +282,28 @@ fn scheduler_loop(
     let mut rc_probe_timeout: u32 = 0;
     let mut rc_probe_lat = Duration::ZERO;
 
-    // Query MSP_BOXIDS once at startup to get the index→permanent_id mapping.
+    // Query MSP_BOXIDS at startup to get the index→permanent_id mapping.
     // INAV's activeModes bitmask uses INDEX-based packing, not permanent box IDs.
     // Without this mapping, we can't correctly decode which modes are active.
-    let box_ids: Vec<u8> = match transport.msp_request(crate::msp::MSP_BOXIDS, &[]) {
+    //
+    // This attempt is only the fast path — one 2 s request, no retry. Losing it on a lossy air link
+    // (mLRS/ELRS right at connect) used to cost the flight modes for the WHOLE session, silently:
+    // `parse_active_modes` deliberately reports nothing rather than guessing without the mapping, and
+    // `box_active` therefore never sees MSP RC OVERRIDE either. A miss here is no longer terminal —
+    // the loop keeps re-asking (see `BOXIDS_RETRY_INTERVAL`) until the FC answers.
+    let mut box_ids: Vec<u8> = match transport.msp_request(crate::msp::MSP_BOXIDS, &[]) {
         Ok(msg) => {
-            eprintln!("[MSP-BOXIDS] Received {} box IDs: {:?}", msg.payload.len(), msg.payload);
+            log::info!("MSP_BOXIDS: received {} box IDs", msg.payload.len());
+            log::debug!("MSP_BOXIDS payload: {:?}", msg.payload);
             msg.payload
         }
         Err(e) => {
-            log::warn!("Failed to query MSP_BOXIDS: {} — flight mode detection may be inaccurate", e);
-            eprintln!("[MSP-BOXIDS] Query FAILED: {} — using empty mapping", e);
+            log::warn!("MSP_BOXIDS query failed ({e}) — retrying from the scheduler loop; flight modes stay blank until it answers");
             Vec::new()
         }
     };
+    // Paced from here, so the first retry lands one interval after the failed attempt, not instantly.
+    let mut boxids_last_try = Instant::now();
 
     // Pipelined I/O: tighten the transport read timeout so the drain/emit loop cycles fast (≈100 Hz).
     // (The BOXIDS query above still ran through the blocking `msp_request` handshake path — fine, it's
@@ -317,6 +333,7 @@ fn scheduler_loop(
                 crate::msp::MSP_FC_VERSION,
                 crate::msp::MSP_BOARD_INFO,
                 crate::msp::MSPV2_INAV_MIXER,
+                crate::msp::MSP_BOXIDS,
             ],
         )
     };
@@ -526,6 +543,31 @@ fn scheduler_loop(
             }
         }
 
+        // 3b. Re-ask for MSP_BOXIDS while we still have no mapping. Cheap (one 9-byte frame per
+        //     interval), stops the moment a usable reply lands, and shares the same in-flight window
+        //     and write budget as everything else, so it can never crowd out telemetry.
+        if box_ids.is_empty()
+            && boxids_last_try.elapsed() >= BOXIDS_RETRY_INTERVAL
+            && tele_in_flight < MAX_IN_FLIGHT
+            && writes_this_tick < MAX_WRITES_PER_TICK
+            && !in_flight
+                .get(&crate::msp::MSP_BOXIDS)
+                .map_or(false, |q| !q.is_empty())
+        {
+            boxids_last_try = now;
+            let code = crate::msp::MSP_BOXIDS;
+            debug_tracker.on_request(code, 9);
+            link_stats.on_tx(9);
+            if transport.msp_send(code, &[]).is_ok() {
+                writes_this_tick += 1;
+                in_flight.entry(code).or_default().push_back(Pending {
+                    sent_at: now,
+                    deadline: reply_deadline(now, rtt_ewma),
+                    kind: PendingKind::BoxIds,
+                });
+            }
+        }
+
         // 4. Adjust the adaptive scale (AIMD) once per window from the saturation observed since the last
         //    adjust: multiplicative back-off when the link was saturated, gentle additive recovery when it
         //    had headroom. `scale` then stretches every due slot's interval toward its floor (section 5).
@@ -681,6 +723,20 @@ fn scheduler_loop(
                                         rc_probe_slow += 1;
                                     }
                                 }
+                                PendingKind::BoxIds => {
+                                    // An empty payload is no mapping — keep asking rather than
+                                    // locking in a state that decodes every mode as absent.
+                                    if msg.payload.is_empty() {
+                                        log::warn!("MSP_BOXIDS answered with an empty payload — still retrying");
+                                    } else {
+                                        log::warn!(
+                                            "MSP_BOXIDS recovered on retry: {} box IDs — flight modes are live",
+                                            msg.payload.len()
+                                        );
+                                        log::debug!("MSP_BOXIDS payload: {:?}", msg.payload);
+                                        box_ids = msg.payload;
+                                    }
+                                }
                             }
                         }
                         None => {
@@ -727,6 +783,8 @@ fn scheduler_loop(
                         rc_probe_timeout += 1;
                         rc_probe_lat += Duration::from_millis(RC_PROBE_TIMEOUT_MS);
                     }
+                    // Lapsed retry — the next interval simply asks again.
+                    PendingKind::BoxIds => debug_tracker.on_timeout(code),
                 }
             }
         }


### PR DESCRIPTION
Found while auditing every PR merged since RC1 for side effects.

`MSP_BOXIDS` carries the index → permanent-box-ID mapping, without which INAV's `activeModes` bitmask cannot be decoded at all. It is fetched **exactly once**, as a single blocking request with a 2 s timeout and **no retry**, and a miss was written off with one log line.

That was survivable while a missing mapping still produced *something*: the decoder used to fall back to treating the raw bit index as a permanent ID. Removing that fallback was right — it produced confidently wrong modes, whatever box the pilot had configured at that position — but it changed what a lost BOXIDS frame costs:

- `parse_active_modes` reports **no modes at all** for the rest of the session, so the flight mode stays blank the whole flight;
- `box_active` never sees `BOX_MSP_RC_OVERRIDE`, so **RC streaming can never engage**;
- the only record is a single `log::warn!`, and the only way out is a reconnect.

One dropped frame at connect on a lossy air link — mLRS / ELRS is exactly where that happens — is enough to trigger it.

## What changes

The startup query stays as the fast path, so in the normal case the mapping is in place before the first status frame. Failing it is simply no longer terminal:

- while `box_ids` is empty, the scheduler re-sends `MSP_BOXIDS` every **3 s** through the ordinary pipelined path;
- it shares the in-flight window (`MAX_IN_FLIGHT`) and the per-tick write budget (`MAX_WRITES_PER_TICK`) with everything else, so it can never crowd out telemetry — worst case it delays one poll by a single ~8 ms tick, once per interval;
- it stops the moment a **non-empty** reply lands. An empty payload does not count as an answer; locking that in would decode every mode as absent forever;
- the recovery is logged at `warn` so it reaches a tester's diagnostics file, and `MSP_BOXIDS` is registered with the debug tracker as a handshake code so the Debug Monitor shows the retries rather than hiding them.

The two `eprintln!` calls in the old block are gone — they were never captured in a release log, which is precisely why this failure mode was invisible.

## Checks

`cargo test`: 101 passed, 1 ignored, 0 failed. `cargo clippy`: no new warning class (the one added `map_or(false, …)` matches four existing siblings in the same file).