### PR TITLE
fix(macos): declare the real system floor and the local-network purpose

### DIFF
--- a/docs/user/getting-started/installation.md
+++ b/docs/user/getting-started/installation.md
@@ -29,6 +29,10 @@ grabbing:
     ```
     After the first launch it opens normally.
 
+!!! warning "macOS 13 (Ventura) or newer"
+    The macOS build targets **macOS 13**. Older systems are not supported — on macOS 11 or 12 the app
+    installs but does not start.
+
 ### Linux quick install
 
 ```bash

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -7,6 +7,10 @@
   The camera usage string is required for the video panel's "Camera (device)" source: it uses
   getUserMedia, which macOS blocks without a usage description. This covers USB/UVC capture devices
   (e.g. an HDMI capture card fed from FPV goggles/VRX), the same webcam access Windows/Linux already have.
+  The local-network string covers everything Kite talks to on the LAN — an RTSP video source on a
+  companion computer, MAVLink over UDP/TCP from a Wi-Fi telemetry bridge. macOS 15 gates that behind a
+  consent prompt; without this key the prompt carries a generic system text instead of saying what
+  Kite actually wants the network for. (Loopback, i.e. our own MediaMTX, is exempt from the gate.)
 -->
 <plist version="1.0">
 <dict>
@@ -16,5 +20,7 @@
     <string>Kite Ground Control uses Bluetooth to connect to your flight controller / telemetry link over BLE.</string>
     <key>NSCameraUsageDescription</key>
     <string>Kite Ground Control uses the camera to display an FPV video feed from a connected capture device.</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Kite Ground Control connects to devices on your local network — a video stream from an onboard companion computer, or telemetry from a flight controller over Wi-Fi.</string>
 </dict>
 </plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
     },
     "macOS": {
       "entitlements": "Entitlements.plist",
-      "minimumSystemVersion": "10.15"
+      "minimumSystemVersion": "13.0"
     },
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
Two macOS bundle facts that were out of step with reality, both found while auditing the RC1→RC2 range. Neither is observable from a Windows or Linux machine, which is how both survived this long.

## `minimumSystemVersion` said 10.15

The app has never run below **macOS 13** — that is the build-environment floor, and it is what the macOS 26 field report from 2026-08-04 confirmed from the other side ("macOS 11/12: does not run at all; 13/14/15: works"). The declared value is what the installer enforces, so a macOS 11 or 12 user could install successfully and then hit an opaque failure instead of a clear refusal.

macOS 13 is nearly four years old. Declaring it is just writing down what we already support.

## `NSLocalNetworkUsageDescription` was missing

macOS 15 gates local-network access behind a consent prompt, and Kite crosses that line constantly: an RTSP source on a companion computer, MAVLink over UDP or TCP from a Wi-Fi telemetry bridge. Without the key the prompt carries a generic system string instead of saying what the app wants the network for.

Not a hard block the way it is on iOS — the prompt still appears — but the purpose string is the whole point of the mechanism. Loopback (our own MediaMTX) is exempt from the gate, so the WebRTC path was never affected either way.

The docs commit lands first: the download table listed a macOS build with no version requirement anywhere, while Linux has a detailed glibc note.

## Checks

`tauri.conf.json` validates as JSON, `Info.plist` as XML. No code paths touched — the deployment target change takes effect on the next macOS bundle build.