### PR TITLE
docs(user): close three gaps the RC1 → RC2 range opened

### DIFF
--- a/docs/dev/ROADMAP.md
+++ b/docs/dev/ROADMAP.md
@@ -55,8 +55,8 @@ Kite is already a full-featured GCS. Broadly, what works today:
 
 **Platform**
 
-- Windows, macOS and Linux (x86 / ARM), a multi-language UI (English, German, French, Chinese), global
-  UI scaling, and persistent layout/settings.
+- Windows, macOS and Linux (x86 / ARM), a multi-language UI (English, German, French, Chinese,
+  Bulgarian), global UI scaling, and persistent layout/settings.
 
 ## Toward 1.0
 

--- a/docs/user/for-developers/architecture.md
+++ b/docs/user/for-developers/architecture.md
@@ -14,7 +14,7 @@ decision record (ADRs) is kept internally.
 | 3D globe | [CesiumJS](https://cesium.com/platform/cesiumjs/) |
 | Database | SQLite via `rusqlite` (bundled) |
 | Serial | `serialport` (Rust) |
-| i18n | `svelte-i18n` (ICU Message Format) — English, German, French |
+| i18n | `svelte-i18n` (ICU Message Format) — English, German, French, Chinese, Bulgarian |
 
 The frontend (WebView) and the Rust backend communicate through **Tauri commands** (frontend → backend
 calls returning `Result<T, String>`) and **events** (backend → frontend streams). A deliberate rule:

--- a/docs/user/for-developers/building.md
+++ b/docs/user/for-developers/building.md
@@ -71,8 +71,10 @@ notarize-macos` signs + notarizes it for distribution without a Gatekeeper promp
 Developer account, credentials read from your environment / keychain — never committed).
 
 ### Android
-Android support (Tauri Mobile) was experimented with but is **on hold** — it needs a separate UI and
-build pipeline. Don't run `tauri android init`; it isn't supported right now.
+Mobile (Tauri Mobile) is **not part of the 1.0 line**. An iOS / iPadOS port lives on `development`
+and an Android port is in review; both need their own UI tier and build pipeline, and both target a
+release after 1.0. Nothing mobile builds from `master` — don't run `tauri android init` or
+`tauri ios init` against a 1.0 checkout.
 
 ## Workflow
 
@@ -141,9 +143,12 @@ are not run in CI.
 
 These are things to know when **running** the packaged Linux app (not build errors):
 
-- **`blackbox_decode` is an external runtime dependency** (not bundled). Blackbox *import* shells out to
-  INAV's `blackbox_decode`; the app looks for it next to the executable, then on `PATH`. Without it, only
-  Blackbox import is affected — live recording and replay still work.
+- **Three helpers are fetched at runtime, not bundled**: `blackbox_decode` (Blackbox import shells out
+  to INAV's decoder), `ffmpeg` (the video image path) and `mediamtx` (the RTSP → WebRTC engine). Kite
+  looks for each next to the executable, then in its own app-data `bin/` directory, then on `PATH`, and
+  offers to download it on first use. Each failure is local to its feature — without `blackbox_decode`
+  only Blackbox import is affected, live recording and replay still work. On macOS `ffmpeg` is bundled
+  as a universal sidecar instead; the other two are fetched the same way as everywhere else.
 - **Serial permissions:** add yourself to the `dialout` group (`sudo usermod -aG dialout "$USER"`, then
   log out/in). Some distros use `uucp`.
 - **Blank 3D globe / WebView (WebKitGTK):** the 3D map runs in WebKitGTK, which is more fragile than

--- a/docs/user/for-developers/contributing.md
+++ b/docs/user/for-developers/contributing.md
@@ -80,12 +80,13 @@ CI runs the same checks (plus clippy) on Linux, Windows and macOS for every push
 
 ## Internationalisation
 
-Kite ships in English, German and French. For contributions:
+Kite ships in English, German, French, Chinese and Bulgarian. For contributions:
 
 - **`en.json` is the source of truth and is required** — every new or changed UI string must have its
   English key.
-- **Other locales (`de.json`, `fr.json`) are optional but very welcome.** Keeping them in sync is
-  appreciated; an AI assistant makes this quick and is the recommended way to fill in translations.
+- **Other locales (`de.json`, `fr.json`, `zh.json`, `bg.json`) are optional but very welcome.** Keeping
+  them in sync is appreciated; an AI assistant makes this quick and is the recommended way to fill in
+  translations. Chinese and Bulgarian came in exactly that way, as community contributions.
 - Use **named placeholders** (`{name}`) for parameters, passed as an object.
 
 Missing non-English keys fall back gracefully, so an English-only PR is fine — a maintainer (or you, with

--- a/docs/user/guides/vehicle-control.md
+++ b/docs/user/guides/vehicle-control.md
@@ -84,6 +84,18 @@ Toggle **Guided** on, then **click the map** to send the vehicle to that point a
 and speed. The toggle turns itself off automatically if the FC leaves the guided mode (for example you
 pick another mode here or on the transmitter), so the map interaction always matches the FC.
 
+You don't have to press the toggle first if the vehicle is **already** in its guided mode — after a
+mid-flight connect, or when another ground station put it there. Clicking the map works straight away
+in that case, so Kite never has to re-send a mode change just to let you command a point. (While a
+mission editor or the survey generator is open, those own the map click instead.)
+
+**What you see on the 2D map:** the target is marked where the flight controller says it is, not merely
+where you clicked — Kite reads it back from the FC once per second, so a target set or moved by another
+ground station shows up too. For a **fixed-wing** vehicle a dashed green circle around it draws the
+loiter track the aircraft will actually fly: the radius you set for this Fly Here, or the firmware's
+configured default (`WP_LOITER_RAD` / `NAV_LOITER_RAD`) when you didn't set one. A copter simply holds
+the point, so it gets no circle. Both disappear when the FC leaves guided or the link drops.
+
 !!! note "Why there's no 'set heading' for planes"
     Set Heading is offered for **ArduCopter in Guided only** (it simply yaws the nose). It is
     **intentionally not exposed for fixed-wing / Cruise**: ArduPlane's guided heading change sets a

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -68,7 +68,8 @@ Everything you'd expect from a ground station:
 - **Mission planning** — create, upload, download and edit missions; undo/redo; survey-pattern
   generator; terrain-following / AGL waypoints.
 - **[Vehicle control](guides/vehicle-control.md)** — arm/disarm, flight-mode changes, takeoff/RTL/loiter and more (ArduPilot/PX4).
-- **Comfort** — a multi-language interface (English, German and French at launch; more to follow) and
+- **Comfort** — a multi-language interface (English, German, French, Chinese and Bulgarian; more
+  community translations welcome) and
   persistent window, layout and settings between sessions.
 
 ## What makes Kite special


### PR DESCRIPTION
Found by checking every user-facing change merged since RC1 against the published docs.

## Languages

Chinese and Bulgarian arrived as community contributions (#34, #54, #61), but three places still told readers the app speaks English, German and French: the feature list on the landing page, the tech-stack table in the architecture page, and the internationalisation section for contributors. That last one also named only `de.json` and `fr.json` as the locales worth topping up.

## Guided flight

PR #36 added two visible elements that no page mentioned:

- the **target marker** shows where the *flight controller* says the target is, read back once per second — so a point set or moved by **another ground station** appears too;
- a **fixed-wing** gets a dashed ring drawing the loiter track it will actually fly, at the radius set for this Fly Here or the firmware default (`WP_LOITER_RAD` / `NAV_LOITER_RAD`). A copter holds the point and gets none.

The same PR also made the map click work while the FC is **already** in its guided mode without pressing the toggle first — which is exactly what a mid-flight connect needs, since toggling would re-send the mode change.

Verified against `Map.svelte` / `Map3D.svelte`: both elements are **2D only**, so the text says so rather than "on the map".

## Building from source

The Linux runtime notes named `blackbox_decode` as *the* external dependency — written before `ffmpeg` and `mediamtx` joined it. All three are fetched on first use; the exception is macOS, where `ffmpeg` ships as a universal sidecar.

The Android paragraph still read "experimented with… on hold", while an iOS/iPadOS port sits on `development`, an Android port is in review, and the README already names both for a release after 1.0.

## Checks

`mkdocs build --strict` passes. No code touched.