### PR TITLE
ci: check the crate for the iOS target on the macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,22 @@ jobs:
         working-directory: src-tauri
         run: cargo check --verbose
 
+      # --- iOS target check (macOS runner only) ---
+      # The iOS build swaps whole dependency sets (CoreBluetooth via objc2 instead of btleplug; no
+      # serialport, no starship-battery — see the target cfg blocks in Cargo.toml), so a green desktop
+      # check proves nothing about it, and nobody maintaining this repo owns a Mac. This is the only
+      # signal that a desktop change did not break the mobile crate. `--lib` because mobile consumes
+      # the staticlib through the generated Xcode project; that project (gen/apple) is not tracked, so
+      # a full `tauri ios build` is not possible here — the Rust crate is the part CI can hold green.
+      - name: Add the iOS Rust target
+        if: matrix.os == 'macos-latest'
+        run: rustup target add aarch64-apple-ios
+
+      - name: Run cargo check for iOS
+        if: matrix.os == 'macos-latest'
+        working-directory: src-tauri
+        run: cargo check --target aarch64-apple-ios --lib
+
       - name: Run clippy (warnings allowed — informational only)
         working-directory: src-tauri
         run: cargo clippy


### PR DESCRIPTION
First step of the mobile-platform refactor plan: give CI a mobile signal **before** touching any code, so the refactor that follows has a red/green light on the very target it is being done for.

Until now no job compiled the mobile crate. The iOS build swaps whole dependency sets behind target cfg blocks (CoreBluetooth via objc2 instead of btleplug; no serialport, no starship-battery), so a green desktop check proves nothing about it — and nobody maintaining this repo owns a Mac. A desktop change could break the iOS build silently, and the report would come from @SebastianKumor's next local build, weeks later.

This adds `cargo check --target aarch64-apple-ios --lib` to the existing macOS runner:

- `--lib` because mobile consumes the staticlib through the generated Xcode project, and `gen/apple` is not tracked — the Rust crate is the part CI can hold green. The iOS SDK is already on GitHub's macOS runners; no device, no signing, no extra job.
- The ffmpeg sidecar fetch is untouched: it hangs off `tauri.macos.conf.json`, which is not merged for the iOS target.
- **No Android check yet, deliberately** — the crate does not compile for Android today (`starship-battery` is excluded for iOS only). It comes with the separation refactor, which is the next step.

This PR is also the first live run of the check: if the iOS lane comes up red, that is a finding about the current `development` state, not about this workflow.
