### PR TITLE
refactor(mobile): one platform seam per transport instead of cfg at every call site

### DIFF
--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -18,18 +18,12 @@ use crate::scheduler;
 use crate::scheduler::TelemetryConfig;
 use crate::state::{ActiveProtocol, AppState};
 use crate::transport::{ByteTransport, Transport, TransportType};
-// PortInfo is only returned by list_serial_ports, which is desktop-only.
-#[cfg(not(target_os = "ios"))]
 use crate::transport::PortInfo;
-#[cfg(not(target_os = "ios"))]
 use crate::transport::serial::SerialConnection;
 use crate::transport::tcp::TcpTransport;
 use crate::transport::udp::UdpTransport;
-// BLE backend: btleplug on desktop, CoreBluetooth (objc2) on iOS. Same public surface either way.
-#[cfg(not(target_os = "ios"))]
+// `transport::ble` resolves per platform behind one name (btleplug on desktop, CoreBluetooth on iOS).
 use crate::transport::ble::{self as ble_backend, BleDeviceInfo};
-#[cfg(target_os = "ios")]
-use crate::transport::ble_ios::{self as ble_backend, BleDeviceInfo};
 
 /// Home position pushed to the frontend (event `home-position`). Same shape/name regardless of
 /// protocol so MAVLink (HOME_POSITION) can emit it identically later.
@@ -40,12 +34,8 @@ struct HomeEvent {
     alt: f64,
 }
 
-/// List available serial ports.
-///
-/// Serial and BLE links are unavailable on iOS (no raw serial access, no btleplug backend), so the
-/// serial/BLE connection commands are compiled out there; the iOS build connects over Wi-Fi
-/// (TCP/UDP MAVLink) only. Every desktop target keeps them unchanged.
-#[cfg(not(target_os = "ios"))]
+/// List available serial ports. On iOS this is always empty — `transport::serial` resolves to the
+/// stand-in there (no serial access exists), and the UI hides serial on mobile anyway.
 #[tauri::command]
 pub fn list_serial_ports() -> Vec<PortInfo> {
     crate::transport::serial::list_ports()
@@ -184,11 +174,10 @@ pub async fn connect(
         proto, transport_type, port, baud_rate, host, tcp_port, ble_device_id,
     );
 
-    // Open byte-level transport based on type. Serial is desktop-only (no raw serial access on iOS);
-    // on iOS the Serial variant falls through to the catch-all and is rejected. BLE works on both
-    // (btleplug on desktop, CoreBluetooth on iOS). TCP/UDP are platform-independent.
+    // Open byte-level transport based on type. Every variant is handled on every platform — the
+    // platform differences live behind `transport::serial` / `transport::ble` (on iOS a serial open
+    // fails with a clear runtime error; BLE is CoreBluetooth there). TCP/UDP are platform-independent.
     let byte_transport: Box<dyn ByteTransport> = match transport_type {
-        #[cfg(not(target_os = "ios"))]
         TransportType::Serial => {
             let port_name = port.ok_or("Serial port name required")?;
             let baud = baud_rate.unwrap_or(115200);
@@ -214,8 +203,6 @@ pub async fn connect(
                 Box::new(ble_backend::connect_ble(&dev_id).await?)
             }
         }
-        #[cfg(target_os = "ios")]
-        _ => return Err("Serial is not available on iOS; use Wi-Fi (TCP/UDP) or BLE".into()),
     };
 
     log::info!("Transport opened, protocol={}", proto);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,8 +24,6 @@ mod transport;
 mod video;
 
 use commands::connection::{connect, disconnect, inav_set_craft_name, inav_read_stats, scan_ble_devices, ble_scan_start, ble_scan_stop};
-// Serial listing is desktop-only (no raw serial access on iOS). BLE works on both (CoreBluetooth on iOS).
-#[cfg(not(target_os = "ios"))]
 use commands::connection::list_serial_ports;
 use commands::flightlog::{
     flightlog_list, flightlog_get, flightlog_get_track, flightlog_get_battery_records, flightlog_delete,
@@ -376,9 +374,6 @@ pub fn run() {
     let log_level = if debug_flag { log::LevelFilter::Debug } else { log::LevelFilter::Warn };
     logging::init(log_level, is_portable());
 
-    // `mut` is only used by the desktop window-state block below; iOS has no desktop window to
-    // persist, so that block is compiled out there and the binding is never reassigned.
-    #[cfg_attr(target_os = "ios", allow(unused_mut))]
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init());
@@ -395,8 +390,8 @@ pub fn run() {
     // The plugin saves to the OS app-config dir, which portable mode cannot redirect on
     // Windows (Known-Folder API, not env-driven) — so only enable it in installed mode.
     // Portable builds trade window-geometry persistence for a clean, system-path-free runtime.
-    // Desktop only: there is no free-floating window to persist on iOS.
-    #[cfg(not(target_os = "ios"))]
+    // Desktop only: there is no free-floating window to persist on mobile.
+    #[cfg(desktop)]
     if !is_portable() {
         use tauri_plugin_window_state::StateFlags;
         // Persist everything EXCEPT the decorations flag: we run with a custom titlebar
@@ -539,7 +534,6 @@ pub fn run() {
         .manage(std::sync::Arc::new(MediaMtx::new()))
         .manage(MjpegServer::new())
         .invoke_handler(tauri::generate_handler![
-            #[cfg(not(target_os = "ios"))]
             list_serial_ports,
             scan_ble_devices,
             ble_scan_start,

--- a/src-tauri/src/msp/codec.rs
+++ b/src-tauri/src/msp/codec.rs
@@ -7,9 +7,6 @@ use super::types::*;
 
 pub struct MspCodec;
 
-// The response-encoders and decoders are used by the FormationFlight radar source and the MSP serial
-// path, both compiled out on iOS - so the codec is dead there. Suppress the lint on iOS only.
-#[cfg_attr(target_os = "ios", allow(dead_code))]
 impl MspCodec {
     /// Encode an MSP v1 **response** frame (direction `>`) — for emulating an FC (e.g. FormationFlight).
     pub fn encode_v1_response(code: u16, payload: &[u8]) -> Vec<u8> {

--- a/src-tauri/src/msp/types.rs
+++ b/src-tauri/src/msp/types.rs
@@ -24,10 +24,7 @@ pub enum MspVersion {
 /// A decoded MSP message
 #[derive(Debug, Clone)]
 pub struct MspMessage {
-    // version + direction are only inspected by the FormationFlight source (iOS-excluded).
-    #[cfg_attr(target_os = "ios", allow(dead_code))]
     pub version: MspVersion,
-    #[cfg_attr(target_os = "ios", allow(dead_code))]
     pub direction: MspDirection,
     pub code: u16,
     pub payload: Vec<u8>,
@@ -44,8 +41,6 @@ pub const MSP_RC: u16 = 105;
 pub const MSP_RAW_GPS: u16 = 106;
 pub const MSP_ATTITUDE: u16 = 108;
 pub const MSP_ALTITUDE: u16 = 109;
-// Only referenced by the FormationFlight source (iOS-excluded).
-#[cfg_attr(target_os = "ios", allow(dead_code))]
 pub const MSP_ANALOG: u16 = 110;
 pub const MSP_SENSOR_STATUS: u16 = 151;
 pub const MSP_SET_REBOOT: u16 = 68;

--- a/src-tauri/src/radar/mod.rs
+++ b/src-tauri/src/radar/mod.rs
@@ -139,12 +139,9 @@ pub struct AdsbLocalSource {
     pub name: String,
     #[serde(default)]
     pub transport: String,
-    // port + baud are consumed only by the serial ADS-B source, which is compiled out on iOS.
     #[serde(default)]
-    #[cfg_attr(target_os = "ios", allow(dead_code))]
     pub port: String,
     #[serde(default)]
-    #[cfg_attr(target_os = "ios", allow(dead_code))]
     pub baud: u32,
     #[serde(default)]
     pub enabled: bool,
@@ -393,8 +390,6 @@ fn build_sources(
         for ls in config.adsb.local.iter().filter(|l| l.enabled) {
             let transport = if ls.transport.is_empty() { "serial" } else { ls.transport.as_str() };
             match transport {
-                // Serial ADS-B receivers are desktop-only (no serial backend on iOS).
-                #[cfg(not(target_os = "ios"))]
                 "serial" if !ls.port.is_empty() => {
                     let baud = if ls.baud > 0 { ls.baud } else { 57600 };
                     let src = Box::new(sources::adsb_mavlink::AdsbMavlinkSource::new(
@@ -427,27 +422,18 @@ fn make_ff(
     if !ff.enabled || ff.port.is_empty() {
         return None;
     }
-    // FormationFlight talks to the ESP32 module over a serial port, which iOS has no access to.
-    #[cfg(target_os = "ios")]
-    {
-        let _ = (tx, app, node_pos, node_name);
-        None
-    }
-    #[cfg(not(target_os = "ios"))]
-    {
-        let baud = ff_baud(config);
-        let src = Box::new(sources::formation_flight::FormationFlightSource::new(
-            "FormationFlight".to_string(),
-            ff.port.clone(),
-            baud,
-            node_name.clone(),
-            node_pos.clone(),
-            app.clone(),
-        ));
-        let handle = src.start(tx.clone());
-        eprintln!("[radar][ff] started on {} @ {}", ff.port, baud);
-        Some(FfRunning { handle, port: ff.port.clone(), baud })
-    }
+    let baud = ff_baud(config);
+    let src = Box::new(sources::formation_flight::FormationFlightSource::new(
+        "FormationFlight".to_string(),
+        ff.port.clone(),
+        baud,
+        node_name.clone(),
+        node_pos.clone(),
+        app.clone(),
+    ));
+    let handle = src.start(tx.clone());
+    eprintln!("[radar][ff] started on {} @ {}", ff.port, baud);
+    Some(FfRunning { handle, port: ff.port.clone(), baud })
 }
 
 /// Reconcile the FormationFlight source against a new config WITHOUT reopening its serial port unless the

--- a/src-tauri/src/radar/sources/mod.rs
+++ b/src-tauri/src/radar/sources/mod.rs
@@ -4,12 +4,11 @@
 // Radar — data sources. One module per source family (added incrementally, see the phasing in
 // docs/active/RADAR_TRACKING_CORE.md §9). Phase 0 ships only the dev-only `sim` source.
 
-// adsb_mavlink and formation_flight read from a serial device (serialport), unavailable on iOS.
-// The MSP/online/sim sources are transport-independent and build everywhere.
-#[cfg(not(target_os = "ios"))]
+// adsb_mavlink and formation_flight read from a serial device through `transport::serial`, which
+// exists on every target (on iOS as the stand-in whose opens fail cleanly) — so every source
+// compiles everywhere and platform capability is a runtime property, not a compile-time one.
 pub mod adsb_mavlink;
 pub mod adsb_msp;
 pub mod adsb_online;
-#[cfg(not(target_os = "ios"))]
 pub mod formation_flight;
 pub mod sim;

--- a/src-tauri/src/telemetry_forward/output/mod.rs
+++ b/src-tauri/src/telemetry_forward/output/mod.rs
@@ -5,11 +5,10 @@
 //! telemetry out a *second* link. Phase 1 = serial (covers HC-05 / BT-SPP virtual COM, e.g. U360GTS);
 //! BLE / TCP-server / UDP follow in Phase 2.
 
-// Serial (serialport) and BLE (btleplug) relay outputs are desktop-only; iOS relays over Wi-Fi
-// (TCP/UDP) only. Compiled normally on every desktop target.
-#[cfg(not(target_os = "ios"))]
+// Every sink compiles on every target: serial and ble sit on the transport/ platform seam
+// (`transport::serial` / `transport::ble`), which resolves to the platform's implementation — on
+// iOS a serial open fails with a clear error, while BLE is real (CoreBluetooth).
 pub mod ble;
-#[cfg(not(target_os = "ios"))]
 pub mod serial;
 pub mod tcp;
 pub mod udp;

--- a/src-tauri/src/telemetry_forward/output/serial.rs
+++ b/src-tauri/src/telemetry_forward/output/serial.rs
@@ -4,41 +4,39 @@
 //! Serial output sink — opens a second COM port (write-only) for relayed telemetry. Covers HC-05 /
 //! BT-SPP virtual COM ports (e.g. the U360GTS antenna tracker).
 
-use std::io::Write;
 use std::time::Duration;
 
 use super::OutputSink;
+use crate::transport::serial::SerialConnection;
+use crate::transport::ByteTransport;
 
 pub struct SerialSink {
-    name: String,
-    port: Box<dyn serialport::SerialPort>,
+    conn: SerialConnection,
 }
 
-// serialport's Box<dyn SerialPort> is Send in practice (mirrors transport::serial::SerialConnection).
-unsafe impl Send for SerialSink {}
-
 impl SerialSink {
+    /// Opens through `transport::serial` rather than the serialport crate directly. The write path is
+    /// identical (write_all + flush per frame), the port timeout is set to the same 100 ms this sink
+    /// always used, and the relay port gains the open-retry + DTR/RTS raising the inbound serial
+    /// connection already had — which is exactly what the BT-SPP modules this sink exists for (HC-05
+    /// trackers) want on first open. It also keeps this file on the platform seam, so it compiles on
+    /// mobile, where an open simply returns the platform's "no serial" error.
     pub fn open(port_name: &str, baud_rate: u32) -> Result<Self, String> {
-        let port = serialport::new(port_name, baud_rate)
-            .timeout(Duration::from_millis(100))
-            .open()
+        let mut conn = SerialConnection::open(port_name, baud_rate)
             .map_err(|e| format!("Failed to open relay port {}: {}", port_name, e))?;
-        Ok(Self { name: port_name.to_string(), port })
+        conn.set_read_timeout(Duration::from_millis(100));
+        Ok(Self { conn })
     }
 }
 
 impl OutputSink for SerialSink {
     fn write(&mut self, data: &[u8]) -> Result<(), String> {
-        self.port
-            .write_all(data)
-            .map_err(|e| format!("Relay serial write failed: {}", e))?;
-        self.port
-            .flush()
-            .map_err(|e| format!("Relay serial flush failed: {}", e))?;
-        Ok(())
+        self.conn
+            .write_bytes(data)
+            .map_err(|e| format!("Relay serial write failed: {}", e))
     }
 
     fn description(&self) -> String {
-        format!("Serial({})", self.name)
+        self.conn.description()
     }
 }

--- a/src-tauri/src/telemetry_forward/relay.rs
+++ b/src-tauri/src/telemetry_forward/relay.rs
@@ -12,10 +12,7 @@ use super::encoders::ltm::LtmEncoder;
 use super::encoders::mavlink::MavlinkEncoder;
 use super::encoders::smartport::SmartportEncoder;
 use super::encoders::Encoder;
-// Serial + BLE relay outputs are desktop-only (no serial/btleplug backend on iOS).
-#[cfg(not(target_os = "ios"))]
 use super::output::ble::BleSink;
-#[cfg(not(target_os = "ios"))]
 use super::output::serial::SerialSink;
 use super::output::tcp::TcpSink;
 use super::output::udp::UdpSink;
@@ -91,13 +88,11 @@ impl Relay {
             other => return Err(format!("Unsupported relay protocol: {}", other)),
         };
         let sink: Box<dyn OutputSink> = match cfg.output.kind.as_str() {
-            #[cfg(not(target_os = "ios"))]
             "serial" => {
                 let port = cfg.output.port.as_deref().filter(|p| !p.is_empty()).ok_or("serial relay needs a port")?;
                 let baud = cfg.output.baud.unwrap_or(115200);
                 Box::new(SerialSink::open(port, baud)?)
             }
-            #[cfg(not(target_os = "ios"))]
             "ble" => {
                 let id = cfg.output.ble_device_id.as_deref().filter(|s| !s.is_empty()).ok_or("ble relay needs a device")?;
                 Box::new(BleSink::open(id).await?)

--- a/src-tauri/src/transport/mod.rs
+++ b/src-tauri/src/transport/mod.rs
@@ -8,17 +8,25 @@
 // 1. ByteTransport — protocol-agnostic byte-level I/O (read/write/close)
 // 2. Protocol layers (MspTransport, MavlinkHandler) — built on top of ByteTransport
 
-// Serial (serialport crate) and BLE (btleplug) have no iOS support; the iOS build uses Wi-Fi
-// (TCP/UDP) transports only. Both compile normally on every desktop target.
+// Platform seam. Each transport module exists on EVERY target under one name, and this block is the
+// only place that picks an implementation — callers use `transport::serial` / `transport::ble` and
+// never carry a target cfg of their own (the same way video/ keeps its per-OS backends internal).
+//   serial: serialport-backed on desktop. iOS has no serial access of any kind, so it gets a
+//           stand-in with the same surface — opens fail cleanly, the port list is empty. Android
+//           (future) has a real serial route (USB host API) and slots in here.
+//   ble:    btleplug on desktop, CoreBluetooth (objc2) on iOS — same public surface either way.
 #[cfg(not(target_os = "ios"))]
+pub mod serial;
+#[cfg(target_os = "ios")]
+#[path = "serial_ios.rs"]
 pub mod serial;
 pub mod tcp;
 pub mod udp;
 #[cfg(not(target_os = "ios"))]
 pub mod ble;
-// iOS BLE via CoreBluetooth (objc2) rather than btleplug, which has no iOS backend.
 #[cfg(target_os = "ios")]
-pub mod ble_ios;
+#[path = "ble_ios.rs"]
+pub mod ble;
 
 use std::fmt;
 
@@ -157,9 +165,7 @@ pub trait Transport: Send {
     }
 }
 
-/// Information about an available port/device. Constructed only by the serial port lister, which is
-/// compiled out on iOS.
-#[cfg_attr(target_os = "ios", allow(dead_code))]
+/// Information about an available port/device (returned by the serial port lister).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PortInfo {
     pub path: String,

--- a/src-tauri/src/transport/serial_ios.rs
+++ b/src-tauri/src/transport/serial_ios.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+//! Serial transport — **iOS stand-in** for `transport/serial.rs`.
+//!
+//! iOS grants an app no serial-port access of any kind (no /dev nodes, no USB host API), so there is
+//! nothing to implement — but the module still exists, with the same public surface as the desktop
+//! one, so no caller has to know. `transport/mod.rs` picks the implementation once; everything above
+//! it (the connect command, the relay's serial sink, the radar's serial sources) compiles unchanged
+//! and gets an honest runtime error / an empty port list instead of being compiled out. The UI never
+//! offers serial on mobile (form-factor tiers), so these paths are a safety net, not UX.
+//!
+//! Android is different: it DOES have a serial route (the USB host API) and gets a real
+//! implementation of this same surface when the Android port lands — not this stand-in.
+
+use super::{ByteTransport, PortInfo, TransportError};
+
+const UNAVAILABLE: &str = "Serial ports are not available on iOS — connect over Wi-Fi (TCP/UDP) or BLE";
+
+/// No serial subsystem to enumerate — always empty. The connection dialog renders this as
+/// "no ports found" (and hides serial on mobile anyway).
+pub fn list_ports() -> Vec<PortInfo> {
+    Vec::new()
+}
+
+/// Same name and surface as the desktop `SerialConnection`. `open` is the only constructor and it
+/// always fails, so the methods below are formally required dead ends, never reached.
+pub struct SerialConnection {}
+
+impl SerialConnection {
+    pub fn open(port_name: &str, _baud_rate: u32) -> Result<Self, String> {
+        log::warn!("Serial open requested on iOS ({port_name}) — rejected, no serial access exists");
+        Err(UNAVAILABLE.into())
+    }
+
+    /// DTR/RTS have no meaning without a port; unreachable (no instance can exist).
+    pub fn set_control_signals(&mut self, _dtr: bool, _rts: bool) -> Result<(), String> {
+        Err(UNAVAILABLE.into())
+    }
+}
+
+impl ByteTransport for SerialConnection {
+    fn read_bytes(&mut self, _buf: &mut [u8]) -> Result<usize, TransportError> {
+        Err(TransportError::Disconnected)
+    }
+
+    fn write_bytes(&mut self, _data: &[u8]) -> Result<(), TransportError> {
+        Err(TransportError::Disconnected)
+    }
+
+    fn description(&self) -> String {
+        "Serial(unavailable on iOS)".to_string()
+    }
+}


### PR DESCRIPTION
Step 2 of the mobile-platform plan (step 1 was the iOS CI lane, #77). Pure refactor, **no behavior change on any desktop platform** — this is the separation groundwork the Android port will build on, and it wants a test pass on real iOS hardware before anything sits on top of it. @SebastianKumor, this one is for your devices.

### The problem

The iOS port separated platforms by subtraction: every capability iOS lacks was cut out at each call site with its own `#[cfg(not(target_os = "ios"))]`, and the hole propagated outward as `allow(dead_code)` lint plaster on MSP types, the codec, and radar config fields — layers that have no business knowing an OS name. Adding Android that way would have meant a third set of cfg arms in every one of those places, which is exactly how PR #45 and the iOS work came to collide. (Not a criticism of the iOS work — there was no seam to hook into; `ble_ios.rs` with its surface-identical API is precisely the pattern this PR makes the rule.)

### The change

`transport/mod.rs` picks the implementation **once**, the way `video/` always has. `serial` and `ble` exist on every target under one name:

| | desktop | iOS |
|---|---|---|
| `transport::serial` | `serial.rs` (serialport) | **new** `serial_ios.rs` — same surface, opens fail with a clear error, port list empty |
| `transport::ble` | `ble.rs` (btleplug) | `ble_ios.rs` (CoreBluetooth, **unchanged**) mounted as `ble` |

Everything above the seam — the connect command, the relay and its sinks, both serial radar sources, the command registration — compiles unchanged on every platform. All 15 call-site cfgs and all 7 `dead_code` attributes are gone; capability is a runtime property again, not a compile-time shape.

### Consequences worth naming

- **The BLE relay sink now works on iOS** — it always only needed `transport::ble`, which is CoreBluetooth there; it was compiled away for no structural reason.
- **The serial relay sink** opens through `transport::serial` instead of driving the serialport crate itself: same write path (write_all + flush per frame), same 100 ms port timeout, but relay ports now get the open-retry + DTR/RTS raising the inbound connection had — which is what the HC-05/BT-SPP trackers it exists for want on first open.
- `list_serial_ports` is registered on every platform; on iOS it returns an empty list (the UI hides serial on mobile anyway).
- The window-state plugin gate is `#[cfg(desktop)]` — the Tauri cfg the geolocation block already uses — no longer an iOS-specific spelling of "desktop only".
- FormationFlight / serial ADS-B sources compile on iOS and fail at open with the platform error if ever enabled there; the UI never offers them on mobile.

### Acceptance criterion (grep-checkable)

`target_os = "ios"` survives only where the difference is owned: the seam in `transport/mod.rs`, the `system_on_battery` pair, and the three path resolvers (db / logging / terrain). **37 sites before, 9 after, none in shared logic.**

### What to test on iOS hardware

Nothing should look different. Specifically: BLE scan + connect (CoreBluetooth path now reached through the `transport::ble` name), a normal Wi-Fi TCP/UDP session, and — if convenient — a BLE relay output, which is newly possible there. Desktop: `cargo check` clean, 103/103 unit tests, svelte-check 0/0 (frontend untouched).
