### PR TITLE
fix(widgets): drag and drop with a finger, not just a mouse

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -12,6 +12,12 @@
       /* The app is a full-screen cockpit, not a scrollable page: never let trackpad/touch gestures
          scroll-chain or bounce the whole frame (the per-panel scrollers handle their own overflow). */
       html, body { overscroll-behavior: none; }
+
+      /* Touch: the long-press text selection and the tap flash are mouse-era idioms that only get
+         in the way of dragging a widget or a waypoint. Panning/zooming is deliberately NOT blocked
+         here — the panels scroll themselves and the map handles its own gestures. No effect on a
+         desktop WebView. */
+      body { -webkit-tap-highlight-color: transparent; -webkit-touch-callout: none; }
     </style>
     <title>Tauri + SvelteKit + Typescript App</title>
     %sveltekit.head%

--- a/src/lib/components/WidgetPanel.svelte
+++ b/src/lib/components/WidgetPanel.svelte
@@ -93,20 +93,27 @@
     };
   });
 
-  // Mouse-based fallback DnD (independent from HTML5 drag events).
+  // Pointer-based DnD (independent from HTML5 drag events). Pointer events, not mouse events, on
+  // purpose: a finger never fires mousemove/mouseup, so the mouse-only version could start a drag
+  // on touch (mousedown is synthesised from a tap) and then never move or drop it — the widgets
+  // simply refused to move on a tablet. Pointer events cover mouse, pen and touch with one path.
   $effect(() => {
-    const onWindowMouseMove = (e: MouseEvent) => {
+    // This panel's own drag visuals (index highlight, insert marker, ghost) — never the global
+    // payload, which belongs to whichever panel consumes the drop.
+    const resetLocalDrag = () => {
+      dragIdx = -1;
+      insertIdx = -1;
+      externalDragOver = false;
+      activeDragPayload = null;
+      clearGhost();
+    };
+
+    const onWindowPointerMove = (e: PointerEvent) => {
       if (!editing) return;
       const payload = getGlobalDragPayload();
       if (!payload) {
         // Another panel may have consumed the drop; clear stale local drag visuals.
-        if (dragIdx !== -1 || insertIdx !== -1 || externalDragOver) {
-          dragIdx = -1;
-          insertIdx = -1;
-          externalDragOver = false;
-          activeDragPayload = null;
-          clearGhost();
-        }
+        if (dragIdx !== -1 || insertIdx !== -1 || externalDragOver) resetLocalDrag();
         return;
       }
 
@@ -119,49 +126,61 @@
       const inside = isPointInsidePanel(e.clientX, e.clientY);
       externalDragOver = inside;
       insertIdx = inside ? computeInsertIdxFromPoint(e.clientX, e.clientY) : -1;
-      if (DND_DEBUG) console.log('[WIDGET-DND] mousemove', { panelId, inside, insertIdx, payload });
+      if (DND_DEBUG) console.log('[WIDGET-DND] pointermove', { panelId, inside, insertIdx, payload });
     };
 
-    const onWindowMouseUp = (e: MouseEvent) => {
+    const onWindowPointerUp = (e: PointerEvent) => {
       if (!editing) return;
       const payload = getGlobalDragPayload();
-      if (!payload) return;
+      if (!payload) {
+        // The other panel's listener ran first and consumed the drop. With a mouse the next move
+        // would have cleared our leftovers; a lifted finger sends no further event, so do it here.
+        resetLocalDrag();
+        return;
+      }
       const inside = isPointInsidePanel(e.clientX, e.clientY);
       if (inside) {
         const dropAt = computeInsertIdxFromPoint(e.clientX, e.clientY);
-        if (DND_DEBUG) console.log('[WIDGET-DND] mouseup drop', { panelId, dropAt, payload });
+        if (DND_DEBUG) console.log('[WIDGET-DND] pointerup drop', { panelId, dropAt, payload });
         executeDrop(payload, dropAt);
         setGlobalDragPayload(null);
-        dragIdx = -1;
-        insertIdx = -1;
-        externalDragOver = false;
-        activeDragPayload = null;
-        clearGhost();
+        resetLocalDrag();
         return;
       }
 
-      // Important for cross-panel moves: if source panel sees mouseup first while cursor is
-      // over another widget panel, do NOT clear global payload yet.
+      // Released outside this panel. Our visuals end with the pointer either way — the ghost must
+      // not outlive the finger (on touch nothing else would ever clear it). Only the global payload
+      // is kept alive, and only while another widget panel sits under the pointer and will consume
+      // it in its own listener (cross-panel move); over anything else the drag is cancelled.
       if (payload.panelId === panelId) {
+        resetLocalDrag();
         const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
         const overWidgetPanel = !!el?.closest('.widget-panel');
         if (!overWidgetPanel) {
-          if (DND_DEBUG) console.log('[WIDGET-DND] mouseup cancel outside panels', { panelId, payload });
+          if (DND_DEBUG) console.log('[WIDGET-DND] pointerup cancel outside panels', { panelId, payload });
           setGlobalDragPayload(null);
-          dragIdx = -1;
-          insertIdx = -1;
-          externalDragOver = false;
-          activeDragPayload = null;
-          clearGhost();
         }
       }
     };
 
-    window.addEventListener('mousemove', onWindowMouseMove, true);
-    window.addEventListener('mouseup', onWindowMouseUp, true);
+    // pointercancel matters on touch specifically: Android fires it when the system takes the
+    // gesture over (a back swipe, a notification pull, the WebView deciding it is a scroll after
+    // all). Without it the payload and the ghost would be left behind and the panel would look
+    // permanently mid-drag.
+    const onWindowPointerCancel = () => {
+      if (!getGlobalDragPayload()) return;
+      if (DND_DEBUG) console.log('[WIDGET-DND] pointercancel', { panelId });
+      setGlobalDragPayload(null);
+      resetLocalDrag();
+    };
+
+    window.addEventListener('pointermove', onWindowPointerMove, true);
+    window.addEventListener('pointerup', onWindowPointerUp, true);
+    window.addEventListener('pointercancel', onWindowPointerCancel, true);
     return () => {
-      window.removeEventListener('mousemove', onWindowMouseMove, true);
-      window.removeEventListener('mouseup', onWindowMouseUp, true);
+      window.removeEventListener('pointermove', onWindowPointerMove, true);
+      window.removeEventListener('pointerup', onWindowPointerUp, true);
+      window.removeEventListener('pointercancel', onWindowPointerCancel, true);
     };
   });
 
@@ -315,7 +334,8 @@
     }
   }
 
-  function handlePointerDown(e: MouseEvent, idx: number) {
+  function handlePointerDown(e: PointerEvent, idx: number) {
+    // button is 0 for a touch contact and the primary mouse button alike.
     if (!editing || e.button !== 0) return;
     e.preventDefault();
     dragIdx = idx;
@@ -328,7 +348,7 @@
     const rect = el.getBoundingClientRect();
     ghostW = Math.max(100, Math.round(rect.width));
     ghostH = Math.max(100, Math.round(rect.height));
-    if (DND_DEBUG) console.log('[WIDGET-DND] mousedown start', activeDragPayload);
+    if (DND_DEBUG) console.log('[WIDGET-DND] pointerdown start', activeDragPayload);
   }
 
   function parseDropPayload(e: DragEvent): DragPayload | null {
@@ -452,7 +472,7 @@
       class:insert-before={showInsert && insertIdx === idx}
       class:insert-after={showInsert && insertIdx === widgetIds.length && idx === widgetIds.length - 1}
       draggable={false}
-      onmousedown={(e) => handlePointerDown(e, idx)}
+      onpointerdown={(e) => handlePointerDown(e, idx)}
     >
       {#if editing}
         <div class="drag-handle">⠿</div>
@@ -582,6 +602,10 @@
 
   .widget-panel.editing .widget-slot {
     cursor: grab;
+    /* Touch: claim the gesture so the browser does not read the drag as a pan/scroll and cancel
+       the pointer stream. Scoped to edit mode, so ordinary use keeps native scrolling and the
+       widgets stay interactive. */
+    touch-action: none;
   }
 
   .widget-panel.editing .widget-slot:active {


### PR DESCRIPTION
Widgets could not be rearranged by touch in edit mode: the drag-and-drop code listened to mouse events only, and a touch drag delivers just a synthesized `mousedown` — the drag never tracked the finger. On top of that, after a successful touch drop the drag ghost stayed on screen until the next tap, because the cleanup ran on a `mousemove` that never comes on touch.

**Affects: v1.0.0-rc2 and earlier — every touch input path, on every platform** (Windows touchscreens confirmed, Linux touch presumably identical; found during the Android work).

## Fix

- Switched the widget DnD to **pointer events** (one path for mouse, pen and touch), with `touch-action: none` scoped to edit-mode widget slots so the browser doesn't claim the gesture for scrolling.
- Release cleanup no longer depends on a trailing mouse event: the source panel resets its drag visuals on every `pointerup`/`pointercancel`, keeping the global payload only while the pointer is over another widget panel (cross-panel drops keep working).
- `pointercancel` handles the system taking over a gesture mid-drag as a silent safety net.

Cherry-pick of 10bfc0f (merged into `development` with PR #79); mouse behaviour on desktop is unchanged.

## Testing

- User-verified on a Windows touchscreen: grab/drag/drop by finger, cross-panel drop, drop outside, ghost cleanup — and unchanged mouse handling.
- `npm run check` 0/0 on the master base.