### PR TITLE
fix(video): engine start wedged until app restart on an odd RTP port allocation

### DIFF
--- a/src-tauri/src/video/mediamtx.rs
+++ b/src-tauri/src/video/mediamtx.rs
@@ -691,7 +691,14 @@ fn free_loopback_udp_pair() -> Result<(u16, u16), String> {
             .local_addr()
             .map_err(|e| format!("Cannot read allocated UDP port: {e}"))?
             .port();
-        if port == u16::MAX {
+        // MediaMTX validates the RTP port as EVEN (RTP/RTCP convention: RTP even, RTCP =
+        // RTP+1) and EXITS otherwise — the API never comes up and the start fails as
+        // "did not become ready". Windows hands ephemeral ports out roughly sequentially
+        // (see free_webrtc_port), so one odd allocation used to wedge EVERY subsequent
+        // engine start on the next odd port: video dead until an app restart moved the
+        // cursor (field report 2026-09-01). Hold the odd socket so the cursor advances.
+        // `u16::MAX` is odd, so the +1 overflow case is covered by the same check.
+        if port % 2 != 0 {
             held.push(first);
             continue;
         }


### PR DESCRIPTION
**Affects: v1.0.0-rc2 and earlier** — release-notes relevant.

`free_loopback_udp_pair()` handed MediaMTX any adjacent UDP pair, but MediaMTX validates its `rtpAddress` port as **even** (RTP/RTCP convention) and exits during config validation otherwise — the API never comes up and every engine start fails as "MediaMTX did not become ready on its API port".

Because Windows allocates ephemeral ports roughly sequentially, one odd allocation parked **all** subsequent engine starts on the next odd port: classic-mode video stayed dead until an app restart moved the allocator's cursor. Field reproduction: one failed source attempt, and afterwards even known-good H.264 sources would not connect any more (log shows `ERR RTP port (49545) must be even`, then 49547, 62307 — odd every retry).

Fix: odd allocations are held (so the OS cursor advances) until an even/odd pair is found. `u16::MAX` is odd, which also covers the former `+1` overflow special case.

Verified with the full local suite; cherry-picked from the tested `feat/rtsp-native` field session (86f468e).