### PR TITLE
feat(docs-site): versioned documentation with a release/Dev selector (mike)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,20 @@
-# Build + deploy the user documentation site (MkDocs Material) to GitHub Pages.
+# Build + deploy the VERSIONED user documentation site (MkDocs Material + mike) to GitHub Pages.
 #
-# DORMANT until the repository is public AND Pages is enabled:
-#   Repo → Settings → Pages → Build and deployment → Source = "GitHub Actions".
-# GitHub Pages on a PRIVATE repo requires GitHub Pro/Team, so until then this workflow simply has
-# nothing to publish to. The build job still validates the docs on every push (mkdocs build --strict).
+# mike (https://github.com/jimporter/mike) commits every deployed version as a subfolder of the
+# gh-pages branch and maintains a versions.json there; the Material theme renders the header
+# version dropdown from it. Pages must serve that branch:
+#   Repo → Settings → Pages → Build and deployment → Source = "Deploy from a branch: gh-pages /(root)".
 #
-# Local preview needs no CI: `mkdocs serve` (see docs/requirements.txt).
+# Versioning model — ONE docs version per MINOR release (x.y.1 patches never change features):
+#   push to master → redeploy "<major.minor>" (from package.json) with the alias "latest",
+#                    then redeploy "Dev" (the master tip). The site root redirects to "latest".
+#   release merge  → bumps package.json, so the same job creates the next minor's dropdown entry
+#                    and moves "latest" onto it; older minors stay frozen on gh-pages as-is.
+#   docs-only fix  → lands on master (see contributing.md) and redeploys the current minor,
+#                    keeping the published release docs correct between releases.
+#
+# Local preview needs no CI: `mkdocs serve` (single version, see docs/requirements.txt) or
+# `mike serve` (the full versioned site from a local gh-pages branch).
 
 name: docs
 
@@ -18,38 +27,42 @@ on:
       - overrides/**
       - docs/requirements.txt
       - .github/workflows/docs.yml
+      - package.json # a release merge must (re)deploy even when it changes no docs file
+
   workflow_dispatch:
 
+# mike pushes the built site to the gh-pages branch.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Allow only one concurrent deployment.
+# Allow only one concurrent deployment — parallel gh-pages pushes would race.
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # mike appends commits to the existing gh-pages history
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: pip install -r docs/requirements.txt
+      # Validate before any deploy — mike's own builds are not strict.
       - run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Resolve the release minor from package.json
+        id: ver
+        run: echo "minor=$(node -p "require('./package.json').version.split('.').slice(0,2).join('.')")" >> "$GITHUB_OUTPUT"
+      - name: Author the gh-pages commits as the Actions bot
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Deploy the release docs (${{ steps.ver.outputs.minor }} = latest)
+        run: mike deploy --push --update-aliases "${{ steps.ver.outputs.minor }}" latest
+      - name: Deploy the development docs (Dev = master tip)
+        run: mike deploy --push --title Dev dev
+      - name: Point the site root at the latest release
+        run: mike set-default --push latest

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@
 #   python -m venv .venv && .venv/bin/pip install -r docs/requirements.txt        (Linux/macOS)
 # Then: mkdocs serve   (http://localhost:8000)   ·   mkdocs build --strict
 mkdocs-material>=9.5
+mike>=2.1  # docs versioning (gh-pages subfolders + versions.json); used by .github/workflows/docs.yml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,9 @@
 # MkDocs config for the Kite Ground Control user documentation site.
 # Source = docs/user/ only (dev docs under docs/ are NOT published). See
 # docs/active/USER_DOCS_ARCHITECTURE.md. Local preview: `mkdocs serve` (http://localhost:8000).
+#
+# The published site is VERSIONED with mike (one entry per minor release + "Dev" for the master
+# tip) — see .github/workflows/docs.yml for the deployment model.
 
 site_name: Kite Ground Control
 site_description: User documentation for Kite Ground Control — an INAV / ArduPilot / PX4 ground control station.
@@ -51,6 +54,12 @@ plugins:
 
 extra_css:
   - assets/branding/extra.css
+
+extra:
+  # Header version dropdown (Material's native mike support): reads the versions.json that mike
+  # maintains on the gh-pages branch. Old versions get the "outdated" banner (overrides/main.html).
+  version:
+    provider: mike
 
 markdown_extensions:
   - admonition

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -5,3 +5,13 @@
   Kite Ground Control is in <strong>public beta</strong> — your
   <a href="https://github.com/b14ckyy/Kite-GC/issues">feedback &amp; bug reports</a> are very welcome.
 {% endblock %}
+
+<!-- Shown by the theme on every version whose aliases do NOT include the site default ("latest"),
+     i.e. on old releases and on "Dev". ../<base_url> climbs out of the version folder to the site
+     root, which redirects to the latest release. -->
+{% block outdated %}
+  You are not reading the documentation for the latest release.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Switch to the latest release.</strong>
+  </a>
+{% endblock %}


### PR DESCRIPTION
## What

The published docs site so far had exactly **one** state — whatever `master` holds. Once docs for a future release land on `master`, the site runs ahead of the app users actually have.

The site is now **versioned with [mike](https://github.com/jimporter/mike)**, the versioning layer Material for MkDocs supports natively:

- **Header dropdown** listing every deployed version — the same UX as the INAV docs site.
- **One docs version per minor release** (`1.0`, `1.1`, …) — patch releases never change features, so they redeploy their minor's docs in place.
- **`Dev`** tracks the `master` tip.
- The **site root redirects to the latest release**; every other version (old minors and `Dev`) shows an *outdated* banner linking back to it.

## How

- Every deployed version is a subfolder of the **`gh-pages` branch**; mike maintains the `versions.json` the theme reads. Old versions are frozen snapshots — a deploy only touches its own version's folder.
- `docs.yml` on a `master` push (docs paths **or `package.json`**): strict-validate, then `mike deploy <major.minor> latest` (minor read from `package.json`) followed by `mike deploy Dev`. A release merge bumps `package.json` and thereby creates the next minor's entry and moves `latest` automatically — no manual release step.
- Docs-only fixes keep targeting `master` directly (unchanged rule) and keep the published release docs correct between releases.

## Ops

- Pages source is switched from "GitHub Actions" to **"Deploy from a branch: `gh-pages`"** (mike pushes the branch itself; the artifact-based deploy job is gone). The `gh-pages` branch is seeded by one `workflow_dispatch` run.
- Until this PR is merged, a docs push to `master` would still run the **old** workflow, whose artifact deploy fails against the switched Pages source — merging closes that window.

## Verification

- `mkdocs build --strict` passes with the new config (0 warnings).
- Seeding run deploys `1.0` (+`latest`), `Dev`, and the root redirect; verified against the live site.
