### PR TITLE
fix(docs-site): forward pre-versioning deep links to latest/ via a root 404 page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ on:
     branches: [master, main]
     paths:
       - docs/user/**
+      - docs/404.html
       - mkdocs.yml
       - overrides/**
       - docs/requirements.txt
@@ -66,3 +67,16 @@ jobs:
         run: mike deploy --push --title Dev dev
       - name: Point the site root at the latest release
         run: mike set-default --push latest
+      # GitHub Pages serves exactly ONE 404 page for the whole site: /404.html at the gh-pages
+      # root. mike only manages version folders, so publish it in a throwaway worktree. It
+      # forwards pre-versioning deep links (old bookmarks) to the same path under latest/.
+      - name: Publish the root 404 redirect
+        run: |
+          git worktree add "$RUNNER_TEMP/ghp" gh-pages
+          cp docs/404.html "$RUNNER_TEMP/ghp/404.html"
+          cd "$RUNNER_TEMP/ghp"
+          git add 404.html
+          if ! git diff --cached --quiet; then
+            git commit -m "Publish the root 404 redirect"
+            git push origin gh-pages
+          fi

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<!--
+  Root-level GitHub Pages 404 handler for the VERSIONED docs site. Source of truth lives here
+  (docs/404.html, NOT part of the MkDocs build - docs_dir is docs/user); the docs workflow
+  copies it to the root of the gh-pages branch, which is the one 404 page GitHub Pages serves
+  for the whole project site.
+
+  Why: before the site was versioned (PR #86), pages lived at /Kite-GC/<page>/; they now live
+  at /Kite-GC/<version>/<page>/. Old bookmarks and search-engine hits therefore 404 at the old
+  root paths - this page forwards them to the same path under latest/. A path that already
+  carries a version prefix (latest / dev / x.y) is a genuinely missing page and gets a plain
+  404 message instead (no redirect loop).
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Kite Ground Control &mdash; page not found</title>
+  <script>
+    (function () {
+      var base = '/Kite-GC/';
+      var path = window.location.pathname;
+      if (path.indexOf(base) === 0) {
+        var rest = path.slice(base.length);
+        var seg = rest.split('/')[0];
+        var versioned = seg === 'latest' || seg === 'dev' || /^\d+\.\d+$/.test(seg);
+        if (rest && !versioned) {
+          // Pre-versioning deep link: same page, current release.
+          window.location.replace(base + 'latest/' + rest + window.location.search + window.location.hash);
+          return;
+        }
+      }
+      // Genuinely missing page: reveal the 404 UI (kept hidden so it never flashes mid-redirect).
+      document.documentElement.setAttribute('data-notfound', '');
+    })();
+  </script>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #1e2129;
+      color: #eceff4;
+      font-family: 'Segoe UI', Tahoma, sans-serif;
+      text-align: center;
+    }
+    main { display: none; padding: 2rem; }
+    html[data-notfound] main { display: block; }
+    h1 { font-size: 1.6rem; font-weight: 600; }
+    p { color: #a8adb8; }
+    a { color: #37a8db; }
+    noscript { display: block; padding: 2rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>404 &mdash; page not found</h1>
+    <p>This page does not exist in this version of the documentation.</p>
+    <p><a href="/Kite-GC/">Go to the latest documentation</a></p>
+  </main>
+  <noscript>
+    <p>This page has moved with the versioned documentation.</p>
+    <p><a href="/Kite-GC/">Go to the latest documentation</a></p>
+  </noscript>
+</body>
+</html>


### PR DESCRIPTION
## What

Versioning the docs site (#86) moved every page from `/Kite-GC/<page>/` to `/Kite-GC/<version>/<page>/` — existing **bookmarks and search-engine hits now 404**. With hundreds of users that is not acceptable, so this adds the missing forwarder.

GitHub Pages serves exactly **one** 404 page for a project site: `/404.html` at the `gh-pages` root. This PR publishes one that:

- redirects any path **without** a version prefix (`latest` / `dev` / `x.y`) to the same path under `latest/`, preserving query string and hash — old deep links land on the right page of the current release;
- shows a plain dark-themed "page not found" (with a link home) for paths that **already** carry a version prefix — a genuinely missing page, never a redirect loop;
- is `noindex` and has a `noscript` fallback link.

## How

Source of truth is `docs/404.html` (outside the MkDocs build — `docs_dir` is `docs/user`). mike only manages version folders, so the docs workflow copies the file onto the `gh-pages` root in a throwaway git worktree after the mike deploys, committing only when it changed. `docs/404.html` is in the workflow's path triggers.

**Merging this PR deploys it automatically** (the workflow triggers on its own file).

Regression: introduced by fab3e03 (PR #86, versioned docs site) — live on the published site only, never part of an app release.
