### PR TITLE
fix(px4): import QGC .plan missions + 3D overlay for PX4 missions

### DIFF
--- a/docs/user/guides/missions.md
+++ b/docs/user/guides/missions.md
@@ -211,7 +211,11 @@ the aircraft will fly.
 ## Files & the mission library
 
 - **Save / load files** — INAV uses `.mission` (MultiWii XML); ArduPilot and PX4 use `.waypoints`
-  (the QGroundControl-compatible plain-text format). You can also drag a file onto the map.
+  (the QGroundControl-compatible plain-text format). Kite also **imports QGroundControl `.plan`
+  files** (the only format modern QGC saves, so the usual hand-off in PX4 workflows) — mission
+  waypoints only: QGC pattern items (Survey, Corridor Scan, …) can't be expanded outside QGC and are
+  refused with a clear message, and a plan's embedded geofence/rally sections are ignored. Saving
+  from Kite produces `.waypoints`, which QGC can open. You can also drag a file onto the map.
 - **Provenance badges** tell you where the loaded plan came from — **FC** (downloaded), **FILE** (opened
   from disk) or **DB** (from the library) — plus a **Modified** badge once you've edited it. Shown for
   all three stacks.

--- a/docs/user/reference/file-formats.md
+++ b/docs/user/reference/file-formats.md
@@ -9,6 +9,7 @@ Kite can save/export it.
 |---|---|---|---|
 | **INAV mission** | `.mission` | R / W | MultiWii XML, compatible with the INAV Configurator and MWPTools. |
 | **ArduPilot / PX4 mission** | `.waypoints` | R / W | QGroundControl-compatible plain text. |
+| **QGroundControl plan** | `.plan` | R | QGC's JSON plan — the format QGC saves (PX4 workflows). Mission waypoints only: QGC pattern items (Survey, Corridor Scan, …) are refused with a clear message, and the plan's geofence/rally sections are ignored — manage those in Kite's own Airspace tools. |
 
 You can also drag a mission file straight onto the map. See **[Missions](../guides/missions.md)**.
 

--- a/src/lib/components/Map3D.svelte
+++ b/src/lib/components/Map3D.svelte
@@ -3799,11 +3799,14 @@
     // Build the protocol-neutral model (only async part: terrain sampling). Replay → follow the MISSION
     // toggle; planning/live → always shown.
     const visible = !curReplayActive || curShowMission;
+    // 'inav' is the discriminator, NOT 'ardupilot': PX4 is its own system value and uses the
+    // ArduPilot mission stack — testing for 'ardupilot' silently routed PX4 into the (empty)
+    // INAV model and the 3D overlay rendered nothing for PX4 missions.
     const model = !visible
       ? null
-      : curAutopilotSystem === 'ardupilot'
-        ? await buildArduModel(token)
-        : await buildInavModel(token);
+      : curAutopilotSystem === 'inav'
+        ? await buildInavModel(token)
+        : await buildArduModel(token);
     if (token !== missionRenderToken || !viewer) return; // superseded while building
 
     // The mission sits at `altMsl + geoidOffset`, so the offset must be ready before we draw.

--- a/src/lib/components/mission/ArduMissionPanel.svelte
+++ b/src/lib/components/mission/ArduMissionPanel.svelte
@@ -21,7 +21,7 @@
     arduUndo, arduRedo, arduCanUndo, arduCanRedo, arduClearUndoHistory,
     arduVehicleClass, setArduVehicleClass,
     MAV_FRAME_GLOBAL, MAV_FRAME_GLOBAL_TERRAIN_ALT,
-    serializeWaypoints, parseWaypoints,
+    serializeWaypoints, parseWaypoints, parsePlanFile,
     type ArduWaypoint,
   } from '$lib/stores/missionArdupilot';
   import { onMissionDownloadProgress, onMissionUploadProgress } from '$lib/stores/mission';
@@ -156,11 +156,13 @@
       const path = await open({
         title: $t('mission.openMissionTitle'),
         multiple: false,
-        filters: [{ name: 'Waypoints', extensions: anyCase(['waypoints', 'txt']) }],
+        // .plan = QGroundControl's JSON plan (the only format QGC saves — the PX4 ecosystem's
+        // mission files); .waypoints/.txt = the QGC WPL 110 text format (Mission Planner et al).
+        filters: [{ name: 'Missions', extensions: anyCase(['waypoints', 'txt', 'plan']) }],
       });
       if (!path) return;
       const content = await invoke<string>('read_text_file', { path: typeof path === 'string' ? path : path });
-      const wps = parseWaypoints(content);
+      const wps = parseMissionFile(String(path), content);
       arduMission.set(wps);
       arduSelectedWpIndex.set(-1);
       arduLoadedMissionId.set(null); // fresh file → not yet a library mission
@@ -173,6 +175,11 @@
     }
   }
 
+  /** Route by extension: .plan → the QGC JSON plan parser, everything else → QGC WPL text. */
+  function parseMissionFile(name: string, content: string): ArduWaypoint[] {
+    return /\.plan$/i.test(name) ? parsePlanFile(content) : parseWaypoints(content);
+  }
+
   function onDragOver(e: DragEvent) { e.preventDefault(); dragOver = true; }
   function onDragLeave() { dragOver = false; }
   async function onDrop(e: DragEvent) {
@@ -180,11 +187,11 @@
     const files = e.dataTransfer?.files;
     if (!files || files.length === 0) return;
     const file = files[0];
-    if (!file.name.endsWith('.waypoints') && !file.name.endsWith('.txt')) {
+    if (!/\.(waypoints|txt|plan)$/i.test(file.name)) {
       statusMessage = $t('arduMission.onlyWaypointsFiles'); return;
     }
     try {
-      const wps = parseWaypoints(await file.text());
+      const wps = parseMissionFile(file.name, await file.text());
       arduMission.set(wps);
       arduSelectedWpIndex.set(-1);
       arduLoadedMissionId.set(null); // fresh file → not yet a library mission

--- a/src/lib/components/mission/MissionManager.svelte
+++ b/src/lib/components/mission/MissionManager.svelte
@@ -27,7 +27,7 @@
   } from '$lib/stores/mission';
   import {
     arduMission, arduSelectedWpIndex, arduLoadedMissionId, markArduMissionSynced, arduClearUndoHistory,
-    parseWaypoints, type ArduWaypoint,
+    parseWaypoints, parsePlanFile, type ArduWaypoint,
   } from '$lib/stores/missionArdupilot';
   import { frameMissionOnMap } from '$lib/stores/mapCamera';
   import {
@@ -363,11 +363,15 @@
 
   async function handleImportButton() {
     try {
-      const path = await open({ title: $t('missionMgr.openTitle'), multiple: false, filters: [{ name: 'Mission', extensions: anyCase(['mission', 'waypoints', 'txt']) }] });
+      const path = await open({ title: $t('missionMgr.openTitle'), multiple: false, filters: [{ name: 'Mission', extensions: anyCase(['mission', 'waypoints', 'txt', 'plan']) }] });
       if (!path || typeof path !== 'string') return;
       const stem = path.replace(/^.*[\\/]/, '').replace(/\.[^.]+$/, '');
       const lower = path.toLowerCase();
-      if (lower.endsWith('.waypoints') || lower.endsWith('.txt')) {
+      if (lower.endsWith('.plan')) {
+        // QGroundControl JSON plan (the PX4 ecosystem's mission file) → the ArduPilot/PX4 stack.
+        const text = await invoke<string>('read_text_file', { path });
+        await importArduMission(parsePlanFile(text), stem || autoName());
+      } else if (lower.endsWith('.waypoints') || lower.endsWith('.txt')) {
         const text = await invoke<string>('read_text_file', { path });
         await importArduMission(parseWaypoints(text), stem || autoName());
       } else {
@@ -393,13 +397,15 @@
     dragOver = false;
     const file = e.dataTransfer?.files?.[0];
     const name = file?.name.toLowerCase() ?? '';
-    if (!file || !(name.endsWith('.mission') || name.endsWith('.waypoints') || name.endsWith('.txt'))) {
+    if (!file || !(name.endsWith('.mission') || name.endsWith('.waypoints') || name.endsWith('.txt') || name.endsWith('.plan'))) {
       statusMessage = $t('missionMgr.onlyMission'); return;
     }
     try {
       const text = await file.text();
       const stem = file.name.replace(/\.[^.]+$/, '');
-      if (name.endsWith('.waypoints') || name.endsWith('.txt')) {
+      if (name.endsWith('.plan')) {
+        await importArduMission(parsePlanFile(text), stem || autoName());
+      } else if (name.endsWith('.waypoints') || name.endsWith('.txt')) {
         await importArduMission(parseWaypoints(text), stem || autoName());
       } else {
         const m = await missionImportXml(text);

--- a/src/lib/components/widgets/FlightModeWidget.svelte
+++ b/src/lib/components/widgets/FlightModeWidget.svelte
@@ -26,11 +26,12 @@
   // X (total): in replay use the flown mission's count (linked library mission or Blackbox
   // header); live uses the loaded planner mission's length.
   // X (total): replay → flown mission count; live → the loaded planner mission length, from the
-  // ArduPilot store when ArduPilot is active, otherwise the INAV store.
+  // INAV store on INAV, otherwise the ArduPilot store (which PX4 shares — 'px4' is its own
+  // system value, so discriminate on 'inav', never on 'ardupilot').
   let wpTotal = $derived(
     $replayActive ? ($replayWpTotal ?? 0)
-    : $autopilotSystem === 'ardupilot' ? $arduMission.length
-    : $mission.waypoints.length,
+    : $autopilotSystem === 'inav' ? $mission.waypoints.length
+    : $arduMission.length,
   );
   let wpText = $derived.by(() => {
     if (!inMission) return null;

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -1654,8 +1654,8 @@
     "delay": "Закъснение",
     "downloading": "Изтегля се мисия от FC…",
     "uploading": "Качване на мисия във FC…",
-    "dropHint": "Пуснете файла .waypoints тук",
-    "onlyWaypointsFiles": "Поддържат се само .waypoints файлове"
+    "dropHint": "Пуснете файл .waypoints или .plan тук",
+    "onlyWaypointsFiles": "Поддържат се само .waypoints и .plan файлове"
   },
   "wpAction": {
     "waypoint": "Маршрутна точка",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -1657,8 +1657,8 @@
     "delay": "Verzögerung",
     "downloading": "Mission vom FC wird heruntergeladen…",
     "uploading": "Mission wird zum FC hochgeladen…",
-    "dropHint": ".waypoints-Datei hier ablegen",
-    "onlyWaypointsFiles": "Nur .waypoints-Dateien unterstützt"
+    "dropHint": ".waypoints- oder .plan-Datei hier ablegen",
+    "onlyWaypointsFiles": "Nur .waypoints- und .plan-Dateien unterstützt"
   },
   "wpAction": {
     "waypoint": "Wegpunkt",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1657,8 +1657,8 @@
     "delay": "Delay",
     "downloading": "Downloading mission from FC…",
     "uploading": "Uploading mission to FC…",
-    "dropHint": "Drop .waypoints file here",
-    "onlyWaypointsFiles": "Only .waypoints files supported"
+    "dropHint": "Drop a .waypoints or .plan file here",
+    "onlyWaypointsFiles": "Only .waypoints and .plan files supported"
   },
   "wpAction": {
     "waypoint": "Waypoint",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -1567,8 +1567,8 @@
     "delay": "Délai",
     "downloading": "Téléchargement de la mission depuis le FC…",
     "uploading": "Téléversement de la mission vers le FC…",
-    "dropHint": "Déposez un fichier .waypoints ici",
-    "onlyWaypointsFiles": "Seuls les fichiers .waypoints sont pris en charge"
+    "dropHint": "Déposez un fichier .waypoints ou .plan ici",
+    "onlyWaypointsFiles": "Seuls les fichiers .waypoints et .plan sont pris en charge"
   },
   "wpAction": {
     "waypoint": "Waypoint",

--- a/src/lib/i18n/locales/zh.json
+++ b/src/lib/i18n/locales/zh.json
@@ -1654,8 +1654,8 @@
     "delay": "延迟",
     "downloading": "正在从飞控下载任务…",
     "uploading": "正在上传任务到飞控…",
-    "dropHint": "将 .waypoints 文件拖放到此处",
-    "onlyWaypointsFiles": "仅支持 .waypoints 文件"
+    "dropHint": "将 .waypoints 或 .plan 文件拖放到此处",
+    "onlyWaypointsFiles": "仅支持 .waypoints 和 .plan 文件"
   },
   "wpAction": {
     "waypoint": "航点",

--- a/src/lib/stores/missionArdupilot.ts
+++ b/src/lib/stores/missionArdupilot.ts
@@ -476,3 +476,69 @@ export function parseWaypoints(text: string): ArduWaypoint[] {
   }
   return wps;
 }
+
+// ── QGroundControl .plan file format (PX4 ecosystem) ──────────────────
+// A QGC "Plan" is a JSON container: `mission.items[]` of SimpleItems (command / frame /
+// params[7] / autoContinue — exactly the ArduWaypoint fields, with lat/lon/alt riding in
+// params[4..6]), plus a plannedHomePosition and geoFence/rallyPoints sections. QGC saves
+// ONLY this format since v3.2 (it still *imports* .waypoints), so missions coming out of
+// the PX4 ecosystem arrive as .plan files. Import scope for 1.0:
+//  * ComplexItems (Survey, Corridor Scan, …) are QGC-computed patterns that only QGC can
+//    expand into waypoints → refuse the whole file with a readable error rather than
+//    silently dropping flight path.
+//  * geoFence / rallyPoints sections are ignored — Kite handles fence and rally as
+//    separate subsystems; a .plan EXPORT that bundles them is a planned 1.1 feature.
+//  * plannedHomePosition is ignored — like the MAVLink path, the working mission holds
+//    only real waypoints (ArduPilot's home slot 0 is synthesized on upload, PX4 has no
+//    home slot at all; see `reserve_home` in mavlink_proto/mission.rs).
+//  * null params (QGC's "no preference", typically yaw) become 0 — the same value
+//    Kite-authored missions carry in those fields. NaN cannot cross the Tauri IPC
+//    boundary (JSON has no NaN; the Rust side deserializes plain f32).
+
+export function parsePlanFile(text: string): ArduWaypoint[] {
+  let root: unknown;
+  try {
+    root = JSON.parse(text);
+  } catch {
+    throw new Error('Not a valid .plan file (broken JSON)');
+  }
+  const plan = root as { fileType?: string; mission?: { items?: unknown[] } };
+  if (plan?.fileType !== 'Plan' || !Array.isArray(plan.mission?.items)) {
+    throw new Error('Not a QGroundControl .plan file');
+  }
+  const wps: ArduWaypoint[] = [];
+  for (const raw of plan.mission.items) {
+    const item = raw as {
+      type?: string;
+      command?: number;
+      frame?: number;
+      autoContinue?: boolean;
+      params?: (number | null)[];
+    };
+    if (item?.type !== 'SimpleItem') {
+      throw new Error(
+        `unsupported "${item?.type ?? 'unknown'}" item — pattern items (Survey, Corridor Scan, …) exist only inside QGroundControl`,
+      );
+    }
+    if (typeof item.command !== 'number' || !Array.isArray(item.params) || item.params.length < 7) {
+      throw new Error('malformed mission item in .plan file');
+    }
+    const p = (i: number): number => {
+      const v = item.params?.[i];
+      return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+    };
+    wps.push({
+      command: item.command,
+      frame: (item.frame ?? MAV_FRAME_GLOBAL_RELATIVE_ALT) as MavFrame,
+      param1: p(0),
+      param2: p(1),
+      param3: p(2),
+      param4: p(3),
+      lat: Math.round(p(4) * 1e7),
+      lon: Math.round(p(5) * 1e7),
+      alt: p(6),
+      autocontinue: item.autoContinue !== false,
+    });
+  }
+  return wps;
+}


### PR DESCRIPTION
Two PX4 mission fixes for the 1.0 line, both user-reported / found while testing. Both carry `Affects: v1.0.0-rc2 and earlier` — neither is a regression.

## 1. Import QGroundControl `.plan` files

PX4 users could not get their missions into Kite: **QGC saves only its JSON `.plan` format** since v3.2 (it still *imports* `.waypoints`, but never produces them), while Kite's ArduPilot/PX4 stack accepted `.waypoints`/`.txt` only.

`parsePlanFile()` maps `mission.items[]` SimpleItems 1:1 onto `ArduWaypoint` (command / frame / params[7] / autoContinue — lat/lon/alt ride in params 5–7). Scope decisions (documented at the parser):

- **ComplexItems** (Survey, Corridor Scan, …) are QGC-computed patterns only QGC can expand → the file is refused with a readable error instead of silently dropping flight path.
- **geoFence / rallyPoints** sections are ignored — Kite handles fence and rally as separate subsystems. A `.plan` **export** that bundles them is deliberately deferred to 1.1 (no reworking of the fence/rally handling during the RC phase).
- **plannedHomePosition** is ignored — the working mission holds only real waypoints; the firmware home-slot convention already lives in the MAVLink layer (`reserve_home`: ArduPilot synthesizes slot 0 on upload, PX4 has no home slot).
- **null params** (QGC's "no preference", typically yaw) become 0 — NaN can't cross the Tauri IPC boundary (JSON has no NaN, Rust reads plain `f32`), and 0 matches what Kite-authored missions carry.

Wired into **both** import paths: the ArduPilot/PX4 mission panel (file dialog + drop zone) and the Mission Manager (import button + drop zone). i18n in all five locales; user docs updated (file-formats table + missions guide).

Verified: parser run against a real QGC/PX4 plan (22 items — takeoff, waypoints, speed changes, RTL; null yaw; coordinate scaling), plus in-app import on Windows (mission on the 2D + 3D map, correct list rendering).

## 2. PX4 missions were invisible on the 3D map

The autopilot system is `'inav' | 'ardupilot' | 'px4'` — PX4 is its own value but shares the ArduPilot mission stack. Two places branched on `=== 'ardupilot'` and silently routed PX4 into the (empty) INAV stores:

- **Map3D `renderMission3D`** built the INAV model for PX4 → the 3D map showed **no mission overlay at all** for any PX4 mission (file-loaded or FC-downloaded). The 2D map and the 3D camera framing discriminate on `'inav'` and were always correct — which is why 2D worked and this went unnoticed.
- **FlightModeWidget** counted the "WP n/X" total from the INAV store under PX4.

Both now branch on `=== 'inav'` with the ArduPilot stack as the shared else. Every remaining `=== 'ardupilot'` site was audited: all others are deliberate ArduPilot-only special cases (QuadPlane QLAND, guided-mode switch before takeoff, vehicle-class picker).

## Verification

- `npm run check` 0 errors / 0 warnings, `npm run build` passes.
- Tested by @b14ckyy on Windows: `.plan` import via panel + Mission Manager, 2D + 3D rendering of the imported PX4 mission.

Note: while testing we confirmed the mission **drag-and-drop zones have never worked** (Tauri's `dragDropEnabled` swallows DOM drop events; only the logbook's native `tauri://drag-drop` path works) — that is a separate fix, not part of this PR.

After merge this should be merged down into `development` per the branching rules.
