### PR TITLE
fix(mission): file drag-and-drop actually works — native event router

### DIFF
--- a/src/lib/components/mission/ArduMissionPanel.svelte
+++ b/src/lib/components/mission/ArduMissionPanel.svelte
@@ -21,7 +21,7 @@
     arduUndo, arduRedo, arduCanUndo, arduCanRedo, arduClearUndoHistory,
     arduVehicleClass, setArduVehicleClass,
     MAV_FRAME_GLOBAL, MAV_FRAME_GLOBAL_TERRAIN_ALT,
-    serializeWaypoints, parseWaypoints, parsePlanFile,
+    serializeWaypoints, parseWaypoints, parsePlanFile, loadArduMissionFromFile,
     type ArduWaypoint,
   } from '$lib/stores/missionArdupilot';
   import { onMissionDownloadProgress, onMissionUploadProgress } from '$lib/stores/mission';
@@ -52,7 +52,6 @@
   let currentEditing  = $state<boolean>(get(arduEditMode));
   let currentConn     = $state(get(connection));
   let statusMessage   = $state('');
-  let dragOver        = $state(false);
   let confirmDialog: ReturnType<typeof ConfirmDialog>;
   let missionSaveDialog: ReturnType<typeof MissionSaveDialog>;
   // Auto-clear the transient status line after 10s — persistent state is shown by the flags.
@@ -163,11 +162,7 @@
       if (!path) return;
       const content = await invoke<string>('read_text_file', { path: typeof path === 'string' ? path : path });
       const wps = parseMissionFile(String(path), content);
-      arduMission.set(wps);
-      arduSelectedWpIndex.set(-1);
-      arduLoadedMissionId.set(null); // fresh file → not yet a library mission
-      arduClearUndoHistory(); // loaded mission = fresh undo baseline
-      markArduMissionSynced('file', wps);
+      loadArduMissionFromFile(wps); // fresh selection/undo, FILE provenance, not a library mission
       statusMessage = $t('mission.loaded', { values: { count: wps.length } });
       frameMissionOnMap();
     } catch (e) {
@@ -180,29 +175,9 @@
     return /\.plan$/i.test(name) ? parsePlanFile(content) : parseWaypoints(content);
   }
 
-  function onDragOver(e: DragEvent) { e.preventDefault(); dragOver = true; }
-  function onDragLeave() { dragOver = false; }
-  async function onDrop(e: DragEvent) {
-    e.preventDefault(); dragOver = false;
-    const files = e.dataTransfer?.files;
-    if (!files || files.length === 0) return;
-    const file = files[0];
-    if (!/\.(waypoints|txt|plan)$/i.test(file.name)) {
-      statusMessage = $t('arduMission.onlyWaypointsFiles'); return;
-    }
-    try {
-      const wps = parseMissionFile(file.name, await file.text());
-      arduMission.set(wps);
-      arduSelectedWpIndex.set(-1);
-      arduLoadedMissionId.set(null); // fresh file → not yet a library mission
-      arduClearUndoHistory(); // loaded mission = fresh undo baseline
-      markArduMissionSynced('file', wps);
-      statusMessage = $t('mission.loadedFromFile', { values: { count: wps.length, file: file.name } });
-      frameMissionOnMap();
-    } catch (e) {
-      statusMessage = $t('mission.importFailed', { values: { error: String(e) } });
-    }
-  }
+  // No DOM drop zone here: with Tauri's dragDropEnabled the WebView never receives DOM drop
+  // events — file drops arrive as the native `tauri://drag-drop` event, routed in +page.svelte
+  // (mission files import from anywhere over the app).
 
   /** Auto-name for fresh missions: "New Mission - YYYY-MM-DD HH:MM". */
   function autoMissionName(): string {
@@ -435,7 +410,7 @@
 
 {#snippet body()}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="miss-dropzone" class:drag-over={dragOver} ondragover={onDragOver} ondragleave={onDragLeave} ondrop={onDrop}>
+  <div class="miss-dropzone">
     {#if showPatternPanel}
       {#await import('./SurveyPatternPanel.svelte')}
         <div class="wp-empty">{$t('survey.loading')}</div>
@@ -488,7 +463,6 @@
         </tbody>
       </table>
     {/if}
-    {#if dragOver}<div class="drop-overlay">{$t('arduMission.dropHint')}</div>{/if}
   </div>
 {/snippet}
 
@@ -573,7 +547,6 @@
   .ap-vehicle-select:disabled { opacity: 0.55; cursor: not-allowed; color: #f39c12; }
 
   .miss-dropzone { position: relative; min-height: 100%; }
-  .miss-dropzone.drag-over { outline: 2px dashed #37a8db; outline-offset: -2px; border-radius: 4px; }
 
   .wp-empty { padding: 16px; text-align: center; color: #888; font-size: 13px; }
   .wp-table { width: 100%; border-collapse: collapse; font-size: 12px; }
@@ -614,5 +587,4 @@
   .prov-file { background: #6c7a89; }
   .prov-db { background: #59aa29; }
   .wp-warn { color: #f39c12; margin-left: 3px; cursor: help; }
-  .drop-overlay { position: absolute; inset: 0; background: rgba(55,168,219,0.15); border: 2px dashed #37a8db; border-radius: 8px; display: flex; align-items: center; justify-content: center; color: #37a8db; font-size: 13px; font-weight: bold; z-index: 10; pointer-events: none; }
 </style>

--- a/src/lib/components/mission/InavMissionPanel.svelte
+++ b/src/lib/components/mission/InavMissionPanel.svelte
@@ -15,7 +15,6 @@
     mission, selectedWpIndex, selectedWpIndices, editMode,
     selectWpSingle, toggleWpSelection, selectWpRange, clearWpSelection, removeSelectedWps,
     missionDownload, missionUpload,
-    missionImportXml,
     missionSaveFile, missionLoadFile,
     activeMissionIndex, missionCount,
     switchMission, addMission, removeMission, getTotalWpCount,
@@ -117,7 +116,6 @@
     const id = setTimeout(() => { statusMessage = ''; }, 10000);
     return () => clearTimeout(id);
   });
-  let dragOver = $state(false);
   let currentTelem = $state<TelemetryData>(get(telemetry));
   const unsubTelem = telemetry.subscribe(t => { currentTelem = t; });
 
@@ -287,24 +285,9 @@
     }
   }
 
-  function onDragOver(e: DragEvent) { if (get(missionManagerOpen)) return; e.preventDefault(); dragOver = true; }
-  function onDragLeave() { dragOver = false; }
-  async function onDrop(e: DragEvent) {
-    if (get(missionManagerOpen)) return;
-    e.preventDefault(); dragOver = false;
-    const files = e.dataTransfer?.files;
-    if (!files || files.length === 0) return;
-    const file = files[0];
-    if (!file.name.endsWith('.mission')) { statusMessage = $t('mission.onlyMissionFiles'); return; }
-    try {
-      const xml = await file.text();
-      if (!xml.includes('<mission')) { statusMessage = $t('mission.invalidMissionFile'); return; }
-      const m = await missionImportXml(xml);
-      statusMessage = $t('mission.loadedFromFile', { values: { count: m.waypoints.length, file: file.name } });
-    } catch (e) {
-      statusMessage = $t('mission.importFailed', { values: { error: String(e) } });
-    }
-  }
+  // No DOM drop zone here: with Tauri's dragDropEnabled the WebView never receives DOM drop
+  // events — file drops arrive as the native `tauri://drag-drop` event, routed in +page.svelte
+  // (mission files import from anywhere over the app).
 
   async function handleClear() {
     if (currentMission.waypoints.length > 0) {
@@ -475,7 +458,7 @@
 
 {#snippet body()}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="miss-dropzone" class:drag-over={dragOver} ondragover={onDragOver} ondragleave={onDragLeave} ondrop={onDrop}>
+  <div class="miss-dropzone">
     {#if $geozoneMissionResult.active}
       {#if $geozoneMissionResult.nfzLaunchInside}
         <div class="gz-warn gz-warn-red">{$t('geozone.warnNfzLaunch')}</div>
@@ -552,7 +535,6 @@
       </table>
     {/if}
 
-    {#if dragOver}<div class="drop-overlay">{$t('mission.dropHint')}</div>{/if}
   </div>
 {/snippet}
 
@@ -636,7 +618,6 @@
   .tb-spacer { flex: 1; }
 
   .miss-dropzone { position: relative; min-height: 100%; }
-  .miss-dropzone.drag-over { outline: 2px dashed #37a8db; outline-offset: -2px; border-radius: 4px; }
 
   /* Geozone safety-check warnings (above the mission tabs/WP list). */
   .gz-warn { padding: 4px 8px; font-size: 11.5px; font-weight: 600; border-radius: 4px; margin-bottom: 4px; }
@@ -693,5 +674,4 @@
   .prov-fc { background: #37a8db; }
   .prov-file { background: #6c7a89; }
   .prov-db { background: #59aa29; }
-  .drop-overlay { position: absolute; inset: 0; background: rgba(55,168,219,0.15); border: 2px dashed #37a8db; border-radius: 8px; display: flex; align-items: center; justify-content: center; color: #37a8db; font-size: 13px; font-weight: bold; z-index: 10; pointer-events: none; }
 </style>

--- a/src/lib/components/mission/MissionManager.svelte
+++ b/src/lib/components/mission/MissionManager.svelte
@@ -61,7 +61,6 @@
   });
   let nameDraft = $state('');
   let notesDraft = $state('');
-  let dragOver = $state(false);
 
   const UNKNOWN = ''; // sorts first; rendered as the localized "unknown" label
 
@@ -389,32 +388,9 @@
     return `New Mission - ${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`;
   }
 
-  function onDragOver(e: DragEvent) { e.preventDefault(); e.stopPropagation(); dragOver = true; }
-  function onDragLeave() { dragOver = false; }
-  async function onDrop(e: DragEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    dragOver = false;
-    const file = e.dataTransfer?.files?.[0];
-    const name = file?.name.toLowerCase() ?? '';
-    if (!file || !(name.endsWith('.mission') || name.endsWith('.waypoints') || name.endsWith('.txt') || name.endsWith('.plan'))) {
-      statusMessage = $t('missionMgr.onlyMission'); return;
-    }
-    try {
-      const text = await file.text();
-      const stem = file.name.replace(/\.[^.]+$/, '');
-      if (name.endsWith('.plan')) {
-        await importArduMission(parsePlanFile(text), stem || autoName());
-      } else if (name.endsWith('.waypoints') || name.endsWith('.txt')) {
-        await importArduMission(parseWaypoints(text), stem || autoName());
-      } else {
-        const m = await missionImportXml(text);
-        await importMission(m.waypoints, stem || autoName());
-      }
-    } catch (err) {
-      statusMessage = $t('missionMgr.importFailed', { values: { error: String(err) } });
-    }
-  }
+  // No DOM drop zone here: with Tauri's dragDropEnabled the WebView never receives DOM drop
+  // events — file drops arrive as the native `tauri://drag-drop` event, routed in +page.svelte
+  // (a dropped mission file loads to the MAP; importing into the library stays on the button).
 
   // ── Formatters ─────────────────────────────────────────────────────
   function fmtDist(m: number | null): string {
@@ -478,7 +454,7 @@
 
 {#snippet body()}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="mmv2-dropzone" class:drag-over={dragOver} ondragover={onDragOver} ondragleave={onDragLeave} ondrop={onDrop}>
+  <div class="mmv2-dropzone">
     {#if missions.length === 0}
       <div class="panel-empty">
         <span class="panel-empty-icon">🗂</span>
@@ -509,7 +485,6 @@
         </div>
       {/each}
     {/if}
-    {#if dragOver}<div class="drop-overlay">{$t('missionMgr.dropHint')}</div>{/if}
   </div>
 {/snippet}
 
@@ -593,7 +568,6 @@
   .section-heading { margin: 8px 0 6px 0; font-size: 11px; font-weight: 600; color: #37a8db; text-transform: uppercase; letter-spacing: 0.5px; }
 
   .mmv2-dropzone { position: relative; min-height: 100%; }
-  .mmv2-dropzone.drag-over { outline: 2px dashed #37a8db; outline-offset: -2px; border-radius: 4px; }
 
   .panel-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; padding: 40px 0; color: #555; font-size: 12px; }
   .panel-empty-icon { font-size: 28px; opacity: 0.4; }
@@ -634,7 +608,6 @@
   .flight-meta { color: #888; flex-shrink: 0; }
   .flight-none { color: #777; font-size: 12px; padding: 4px 0; }
 
-  .drop-overlay { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(55, 168, 219, 0.18); border: 2px dashed #37a8db; border-radius: 6px; color: #fff; font-weight: 600; pointer-events: none; z-index: 10; }
 
   .mmv2-status { position: fixed; bottom: 14px; left: 50%; transform: translateX(-50%); z-index: 1001; padding: 6px 12px; font-size: 11px; color: #f39c12; background: rgba(0, 0, 0, 0.8); border-radius: 6px; }
 </style>

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -1195,7 +1195,6 @@
     "statClimbDescent": "Общо изкачване/спускане по отсечките",
     "statTime": "Време на полет (от крейсерските скорости на точката)",
     "infiniteRepeatTip": "Мисията се повтаря завинаги (безкраен JUMP цикъл) — показаното разстояние/време са за едно пълно преминаване",
-    "dropHint": "Пуснете .mission файл тук",
     "notConnected": "Не е свързан",
     "downloaded": "Изтеглени {count} WPs",
     "downloading": "Изтегляне на маршрутни точки…",
@@ -1216,8 +1215,6 @@
     "openMissionTitle": "Отворена мисия",
     "loaded": "Заредени {count} WPs",
     "openFailed": "Неуспешно отваряне: {error}",
-    "onlyMissionFiles": "Поддържат се само .mission файлове",
-    "invalidMissionFile": "Невалиден файл на мисията",
     "loadedFromFile": "Заредени {count} WP от {file}",
     "importFailed": "Неуспешно импортиране: {error}",
     "missionCleared": "Мисията е разрешена",
@@ -1257,8 +1254,6 @@
     "created": "Създаден",
     "linkedFlights": "Полети с тази мисия",
     "noFlights": "Няма свързани полети",
-    "dropHint": "Пуснете файл .mission или .waypoints за импортиране",
-    "onlyMission": "Могат да се импортират само .mission и .waypoints файлове",
     "systemLocked": "Свързан с различен автопилот — прекъснете връзката, за да заредите тази мисия",
     "filterByFormat": "Филтрирай по формат на мисията",
     "filterAll": "Всички",
@@ -1653,9 +1648,7 @@
     "throttle": "Газ (−1=запазване)",
     "delay": "Закъснение",
     "downloading": "Изтегля се мисия от FC…",
-    "uploading": "Качване на мисия във FC…",
-    "dropHint": "Пуснете файл .waypoints или .plan тук",
-    "onlyWaypointsFiles": "Поддържат се само .waypoints и .plan файлове"
+    "uploading": "Качване на мисия във FC…"
   },
   "wpAction": {
     "waypoint": "Маршрутна точка",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -1198,7 +1198,6 @@
     "statClimbDescent": "Gesamter Anstieg / Abstieg über die Strecken",
     "statTime": "Flugzeit (aus den Wegpunkt-Geschwindigkeiten)",
     "infiniteRepeatTip": "Mission wiederholt sich endlos (unendliche JUMP-Schleife) — Distanz/Zeit gelten für einen kompletten Durchlauf",
-    "dropHint": ".mission Datei hier ablegen",
     "notConnected": "Nicht verbunden",
     "downloaded": "{count} WPs heruntergeladen",
     "downloading": "Wegpunkte werden heruntergeladen…",
@@ -1219,8 +1218,6 @@
     "openMissionTitle": "Mission öffnen",
     "loaded": "{count} WPs geladen",
     "openFailed": "Öffnen fehlgeschlagen: {error}",
-    "onlyMissionFiles": "Nur .mission Dateien unterstützt",
-    "invalidMissionFile": "Ungültige Missionsdatei",
     "loadedFromFile": "{count} WPs aus {file} geladen",
     "importFailed": "Import fehlgeschlagen: {error}",
     "missionCleared": "Mission gelöscht",
@@ -1260,8 +1257,6 @@
     "created": "Erstellt",
     "linkedFlights": "Flüge mit dieser Mission",
     "noFlights": "Keine Flüge verlinkt",
-    "dropHint": "Eine .mission- oder .waypoints-Datei zum Importieren ablegen",
-    "onlyMission": "Nur .mission- und .waypoints-Dateien können importiert werden",
     "systemLocked": "Mit einem anderen Autopiloten verbunden — zum Laden dieser Mission trennen",
     "filterByFormat": "Nach Missionsformat filtern",
     "filterAll": "Alle",
@@ -1656,9 +1651,7 @@
     "throttle": "Drossel (−1=beibehalten)",
     "delay": "Verzögerung",
     "downloading": "Mission vom FC wird heruntergeladen…",
-    "uploading": "Mission wird zum FC hochgeladen…",
-    "dropHint": ".waypoints- oder .plan-Datei hier ablegen",
-    "onlyWaypointsFiles": "Nur .waypoints- und .plan-Dateien unterstützt"
+    "uploading": "Mission wird zum FC hochgeladen…"
   },
   "wpAction": {
     "waypoint": "Wegpunkt",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1198,7 +1198,6 @@
     "statClimbDescent": "Total climb / descent across the legs",
     "statTime": "Flight time (from the waypoint cruise speeds)",
     "infiniteRepeatTip": "Mission repeats forever (infinite JUMP loop) — distance/time shown are for one full pass",
-    "dropHint": "Drop .mission file here",
     "notConnected": "Not connected",
     "downloaded": "Downloaded {count} WPs",
     "downloading": "Downloading waypoints…",
@@ -1219,8 +1218,6 @@
     "openMissionTitle": "Open Mission",
     "loaded": "Loaded {count} WPs",
     "openFailed": "Open failed: {error}",
-    "onlyMissionFiles": "Only .mission files supported",
-    "invalidMissionFile": "Invalid mission file",
     "loadedFromFile": "Loaded {count} WPs from {file}",
     "importFailed": "Import failed: {error}",
     "missionCleared": "Mission cleared",
@@ -1260,8 +1257,6 @@
     "created": "Created",
     "linkedFlights": "Flights with this mission",
     "noFlights": "No flights linked",
-    "dropHint": "Drop a .mission or .waypoints file to import",
-    "onlyMission": "Only .mission and .waypoints files can be imported",
     "systemLocked": "Connected to a different autopilot — disconnect to load this mission",
     "filterByFormat": "Filter by mission format",
     "filterAll": "All",
@@ -1656,9 +1651,7 @@
     "throttle": "Throttle (−1=keep)",
     "delay": "Delay",
     "downloading": "Downloading mission from FC…",
-    "uploading": "Uploading mission to FC…",
-    "dropHint": "Drop a .waypoints or .plan file here",
-    "onlyWaypointsFiles": "Only .waypoints and .plan files supported"
+    "uploading": "Uploading mission to FC…"
   },
   "wpAction": {
     "waypoint": "Waypoint",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -1140,7 +1140,6 @@
     "statClimbDescent": "Montée / descente totale sur les segments",
     "statTime": "Temps de vol (d'après les vitesses des waypoints)",
     "infiniteRepeatTip": "La mission se répète indéfiniment (boucle JUMP infinie) — distance/temps affichés pour un passage complet",
-    "dropHint": "Déposez un fichier .mission ici",
     "notConnected": "Non connecté",
     "downloaded": "{count} WP téléchargés",
     "downloadFailed": "Échec du téléchargement : {error}",
@@ -1159,8 +1158,6 @@
     "openMissionTitle": "Ouvrir une mission",
     "loaded": "{count} WP chargés",
     "openFailed": "Échec de l'ouverture : {error}",
-    "onlyMissionFiles": "Seuls les fichiers .mission sont pris en charge",
-    "invalidMissionFile": "Fichier de mission invalide",
     "loadedFromFile": "{count} WP chargés depuis {file}",
     "importFailed": "Échec de l'importation : {error}",
     "missionCleared": "Mission effacée",
@@ -1200,8 +1197,6 @@
     "created": "Créée",
     "linkedFlights": "Vols avec cette mission",
     "noFlights": "Aucun vol lié",
-    "dropHint": "Déposez un fichier .mission pour l'importer",
-    "onlyMission": "Seuls les fichiers .mission peuvent être importés",
     "importTitle": "Importer une mission",
     "importMsg": "Importer cette mission dans la bibliothèque (et la charger sur la carte), ou seulement la charger sur la carte ?",
     "importMapOnly": "Charger sur la carte seulement",
@@ -1566,9 +1561,7 @@
     "throttle": "Gaz (−1=garder)",
     "delay": "Délai",
     "downloading": "Téléchargement de la mission depuis le FC…",
-    "uploading": "Téléversement de la mission vers le FC…",
-    "dropHint": "Déposez un fichier .waypoints ou .plan ici",
-    "onlyWaypointsFiles": "Seuls les fichiers .waypoints et .plan sont pris en charge"
+    "uploading": "Téléversement de la mission vers le FC…"
   },
   "wpAction": {
     "waypoint": "Waypoint",

--- a/src/lib/i18n/locales/zh.json
+++ b/src/lib/i18n/locales/zh.json
@@ -1195,7 +1195,6 @@
     "statClimbDescent": "各航段总爬升/下降",
     "statTime": "飞行时间（根据航点巡航速度）",
     "infiniteRepeatTip": "任务无限循环（无限JUMP循环）— 显示的距离/时间为单次完整通过",
-    "dropHint": "将 .mission 文件拖放到此处",
     "notConnected": "未连接",
     "downloaded": "已下载 {count} 个航点",
     "downloading": "正在下载航点…",
@@ -1216,8 +1215,6 @@
     "openMissionTitle": "打开任务",
     "loaded": "已加载 {count} 个航点",
     "openFailed": "打开失败：{error}",
-    "onlyMissionFiles": "仅支持 .mission 文件",
-    "invalidMissionFile": "无效的任务文件",
     "loadedFromFile": "从 {file} 加载了 {count} 个航点",
     "importFailed": "导入失败：{error}",
     "missionCleared": "任务已清除",
@@ -1257,8 +1254,6 @@
     "created": "创建时间",
     "linkedFlights": "使用此任务的飞行",
     "noFlights": "无关联飞行",
-    "dropHint": "拖放 .mission 或 .waypoints 文件导入",
-    "onlyMission": "仅可导入 .mission 和 .waypoints 文件",
     "systemLocked": "已连接到不同的自驾仪 — 断开连接以加载此任务",
     "filterByFormat": "按任务格式筛选",
     "filterAll": "全部",
@@ -1653,9 +1648,7 @@
     "throttle": "油门（−1=保持）",
     "delay": "延迟",
     "downloading": "正在从飞控下载任务…",
-    "uploading": "正在上传任务到飞控…",
-    "dropHint": "将 .waypoints 或 .plan 文件拖放到此处",
-    "onlyWaypointsFiles": "仅支持 .waypoints 和 .plan 文件"
+    "uploading": "正在上传任务到飞控…"
   },
   "wpAction": {
     "waypoint": "航点",

--- a/src/lib/stores/missionArdupilot.ts
+++ b/src/lib/stores/missionArdupilot.ts
@@ -495,6 +495,29 @@ export function parseWaypoints(text: string): ArduWaypoint[] {
 //    Kite-authored missions carry in those fields. NaN cannot cross the Tauri IPC
 //    boundary (JSON has no NaN; the Rust side deserializes plain f32).
 
+/** Which system a .plan targets: `mission.firmwareType` 12 (MAV_AUTOPILOT_PX4) → px4, everything
+ *  else (3 = ArduPilotMega, absent, unparseable) → ardupilot. Both share the mission stack — this
+ *  only steers which family tab the global drag-drop router activates. */
+export function planFirmwareTarget(text: string): 'ardupilot' | 'px4' {
+  try {
+    const fw = (JSON.parse(text) as { mission?: { firmwareType?: number } })?.mission?.firmwareType;
+    return fw === 12 ? 'px4' : 'ardupilot';
+  } catch {
+    return 'ardupilot';
+  }
+}
+
+/** Replace the working mission with waypoints loaded from a file — the shared post-parse sequence
+ *  of every file-import path (panel dialog, global drag-drop): fresh selection, not a library
+ *  mission, fresh undo baseline, FILE provenance. */
+export function loadArduMissionFromFile(wps: ArduWaypoint[]): void {
+  arduMission.set(wps);
+  arduSelectedWpIndex.set(-1);
+  arduLoadedMissionId.set(null);
+  arduClearUndoHistory();
+  markArduMissionSynced('file', wps);
+}
+
 export function parsePlanFile(text: string): ArduWaypoint[] {
   let root: unknown;
   try {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -91,9 +91,10 @@
   import { initPulseBlink } from "$lib/stores/pulseBlink";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import TerrainAnalysisPanel from "$lib/components/terrain/TerrainAnalysisPanel.svelte";
-  import { editMode, replayActive, mission, missionFlags, missionDownload, missionUpload, missionFcInfo, markMissionSynced, loadedMissionId, missionSetWaypoints, launchPoint, hasLocation, toDeg, type Waypoint } from "$lib/stores/mission";
-  import { pendingSystemSwitch, autopilotSystem, setAutopilotSystem, confirmSystemSwitch } from "$lib/stores/autopilotContext";
-  import { arduMission, arduSelectedWpIndex, arduLoadedMissionId, type ArduWaypoint } from "$lib/stores/missionArdupilot";
+  import { editMode, replayActive, mission, missionFlags, missionDownload, missionUpload, missionFcInfo, markMissionSynced, loadedMissionId, missionSetWaypoints, missionImportXml, launchPoint, hasLocation, toDeg, type Waypoint } from "$lib/stores/mission";
+  import { pendingSystemSwitch, autopilotSystem, autopilotLocked, setAutopilotSystem, confirmSystemSwitch } from "$lib/stores/autopilotContext";
+  import { arduMission, arduSelectedWpIndex, arduLoadedMissionId, parseWaypoints, parsePlanFile, planFirmwareTarget, loadArduMissionFromFile, type ArduWaypoint } from "$lib/stores/missionArdupilot";
+  import { frameMissionOnMap } from "$lib/stores/mapCamera";
   import { terrainAnalysis, patchTerrainAnalysis } from "$lib/stores/terrainAnalysis";
   import { DEFAULT_RADAR, DEFAULT_AIRSPACE, BUILTIN_ADSB_PROVIDERS } from "$lib/stores/settings";
   import type { AppSettings, InterfaceSettings, PanelConfig, RadarSettings, GcsMode, AirspaceSettings, SystemMessagesLevel, LogLevel } from "$lib/stores/settings";
@@ -1385,6 +1386,43 @@
     await importFiles(supported);
   }
 
+  /** Import a mission file dropped anywhere over the app (the docs' "drag a mission file onto the
+   *  map") — the ONLY working drop path is Tauri's native drag-drop event: with `dragDropEnabled`
+   *  the WebView never sees DOM drop events, so element-scoped drop zones cannot exist. Routed by
+   *  extension: .mission → INAV, .plan/.waypoints → the ArduPilot/PX4 stack. `.txt` stays with the
+   *  logbook (SD blackbox logs use it too). If the file belongs to the other mission family, the
+   *  editor switches — with 'keep': INAV and Ardu keep separate stores, so nothing is lost — unless
+   *  a connected FC locks the system, which reports instead of silently importing into a hidden
+   *  store. */
+  async function importDroppedMission(path: string): Promise<void> {
+    console.log('[IMPORT] mission file dropped:', path);
+    try {
+      const content = await invoke<string>('read_text_file', { path });
+      if (/\.mission$/i.test(path)) {
+        if (get(autopilotSystem) !== 'inav') {
+          if (get(autopilotLocked)) { errorMsg = $t('missionMgr.systemLocked'); return; }
+          setAutopilotSystem('inav');
+          if (get(pendingSystemSwitch)) confirmSystemSwitch('keep');
+          if (get(autopilotSystem) !== 'inav') return;
+        }
+        await missionImportXml(content);
+      } else {
+        const isPlan = /\.plan$/i.test(path);
+        const wps = isPlan ? parsePlanFile(content) : parseWaypoints(content);
+        if (get(autopilotSystem) === 'inav') {
+          if (get(autopilotLocked)) { errorMsg = $t('missionMgr.systemLocked'); return; }
+          setAutopilotSystem(isPlan ? planFirmwareTarget(content) : 'ardupilot');
+          if (get(pendingSystemSwitch)) confirmSystemSwitch('keep');
+          if (get(autopilotSystem) === 'inav') return;
+        }
+        loadArduMissionFromFile(wps);
+      }
+      frameMissionOnMap();
+    } catch (e) {
+      errorMsg = $t('mission.importFailed', { values: { error: String(e) } });
+    }
+  }
+
   async function exportFlightsToKflight(flightIds: number[]) {
     if (flightIds.length === 0) return;
     try {
@@ -2458,9 +2496,16 @@
       blackboxImportProgress = event.payload;
     });
     void listen<{ paths: string[] }>('tauri://drag-drop', (event) => {
-      if (activeTab === 'logbook' && event.payload.paths?.length) {
-        importDroppedFiles(event.payload.paths);
+      const paths = event.payload.paths ?? [];
+      if (!paths.length) return;
+      // Mission files import from anywhere (see importDroppedMission); everything else keeps the
+      // logbook-tab gate. `.txt` deliberately stays on the logbook side (SD blackbox collision).
+      const missionFile = paths.find((p) => /\.(mission|plan|waypoints)$/i.test(p));
+      if (missionFile) {
+        void importDroppedMission(missionFile);
+        return;
       }
+      if (activeTab === 'logbook') importDroppedFiles(paths);
     });
     // Home from the FC (MSP_WP 0), pushed once at connect — recovers Home on a mid-flight connect /
     // app restart. The live arm-transition path (Map.svelte) overwrites it on the next arm.


### PR DESCRIPTION
## Bug

The mission file drop zones (INAV panel, ArduPilot/PX4 panel, Mission Manager) **have never worked on any platform** — the user docs even promise "drag a mission file straight onto the map". Found while testing the `.plan` import (#93).

`Affects: v1.0.0-rc2 and earlier`

## Root cause

With Tauri's `dragDropEnabled`, the WebView **never receives DOM drag/drop events**: Tauri intercepts OS file drags and emits its own `tauri://drag-drop` event carrying real file paths. The mission drop zones were built on DOM events — dead code since day one. Only the logbook import used the native event, which is why log drops worked and mission drops silently did nothing.

Disabling the flag is not an option: the logbook's Rust importer needs real filesystem paths, which DOM `File` objects never carry.

## Fix

The native drag-drop router in `+page.svelte` now handles mission files too, **from anywhere over the app**:

- `.mission` → INAV; `.plan` / `.waypoints` → the ArduPilot/PX4 stack (`.plan` picks px4 vs ardupilot from its `firmwareType`).
- `.txt` stays gated to the logbook tab — SD blackbox logs use the same extension.
- Cross-family file → the editor switches with `keep` (INAV and Ardu keep separate stores, nothing is lost). A connected FC locks the system — reported with a message instead of importing into a hidden store.
- After a successful import the map frames the mission.

Cleanup: the dead DOM drop zones removed from all three components (handlers, overlays, CSS) plus their seven orphaned i18n keys in all five locales; the shared post-parse sequence moved into `loadArduMissionFromFile()`, used by the panel file dialog and the router alike.

Deliberate behavior detail: a drop while the Mission Manager is open loads to the **map** — importing into the library stays on its import button.

No docs change needed — the existing "drag a mission file straight onto the map" is simply true now.

## Verification

- `npm run check` 0 errors / 0 warnings, `npm run build` passes.
- Tested by @b14ckyy on Windows with a real QGC `.plan`: drop over the map/panel imports and frames the mission; logbook drop unaffected.

After merge this should be merged down into `development` per the branching rules.
