### PR TITLE
fix(hud): flight-path marker winds up and pins at the dial edge (angle ease never normalized)

### DIFF
--- a/src/lib/utils/smoothing.ts
+++ b/src/lib/utils/smoothing.ts
@@ -9,8 +9,12 @@ export function easeToward(cur: number, target: number, factor: number): number 
   return cur + (target - cur) * factor;
 }
 
-/** Ease an angle (degrees) toward `target` along the shortest path (handles 359°→1° wrap). */
+/** Ease an angle (degrees) toward `target` along the shortest path (handles 359°→1° wrap).
+ *  The result is normalized to -180..180: the consumers (AHI / FPV-HUD flight-path marker) use it
+ *  as a LINEAR offset, and without the normalization every ±180° crossing of the target (routine
+ *  on a multirotor, where course vs. yaw is unconstrained) winds the eased value up by full turns
+ *  until the marker sits pinned at the dial edge for the rest of the session. */
 export function easeAngleToward(curDeg: number, targetDeg: number, factor: number): number {
   const delta = (((targetDeg - curDeg) % 360) + 540) % 360 - 180; // -180..180
-  return curDeg + delta * factor;
+  return (((curDeg + delta * factor) % 360) + 540) % 360 - 180;
 }


### PR DESCRIPTION
## What

The AHI / FPV-HUD **flight-path marker** could end up **pinned at the dial edge** for the rest of the session — on every flight replayed afterwards.

**Affects: v1.0.0-rc2 and earlier** (latent since 2267c2e, the original frozen-FPM fix; same symptom, different mechanism).

## Root cause

`easeAngleToward()` steps along the shortest path but **never normalized its result**, while the marker consumes the eased crab angle as a **linear** pixel offset (× `PITCH_SCALE`, clamped to ±72 px). Every ±180° crossing of the target — routine on a multirotor, where course-over-ground vs. yaw is unconstrained — winds the eased value up by a full turn. Replaying a real ArduCopter log through the exact widget math shows the eased crab drifting to **−1150°** → clamped hard left for **100 %** of the flight. The widget stays mounted across flight switches, so the wound-up state then pins the marker on perfectly healthy fixed-wing logs too ("all logs"), until restart.

## Fix

Normalize the eased result back into −180..180 (one line + rationale comment). Verified against the same log: the eased value stays bounded, the marker moves again and only touches the clamp while the *real* crab exceeds the dial range (a multirotor flying sideways) — and recovers immediately.

## Verification

- Simulation over the real DB rows: before −1150° / pinned 100 % → after bounded ±180°, pinned only during genuine large-crab segments.
- `npm run check` 0 errors / 0 warnings.

After merge: backport master → development via PR as usual.
