### PR TITLE
Polish: mini map markers, zoom-only mini map, edit-mode return, phone touch fixes

### DIFF
--- a/docs/user/guides/video.md
+++ b/docs/user/guides/video.md
@@ -148,7 +148,9 @@ back to the full-screen background.
 How interactive the swapped-in **mini-map** is depends on where it landed:
 
 - **In the widget** — deliberately limited by space: **2D only** and **heading-follow only**, but you
-  **can zoom**.
+  **can zoom**. Nothing else on that little map reacts (no waypoint placing or dragging, no context
+  menu), and its markers are drawn at half size. Switching the mission editor on brings the map back
+  to full screen automatically.
 - **In the floating window** — fully interactive: pan and zoom normally (left-drag / single-touch). To
   **move the floating frame itself** while it holds the map, drag with the **right mouse button**
   (desktop) or **two fingers** (touchscreen).

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -71,7 +71,7 @@
   import { toTelemetryData } from "$lib/adapters/telemetryAdapter";
   import { sunAltitudeDeg, cesiumLikeBrightness } from "$lib/utils/sun";
   import { ensureUserLocation, resolveUserLocation, userGeoLocation } from "$lib/helpers/userLocation";
-  import { isMobile, isPhone } from "$lib/platform";
+  import { isMobile } from "$lib/platform";
   import { radarVehicles, radarSelection, enrichList, type RadarSnapshot, type EnrichedVehicle } from "$lib/stores/radarTracking";
   import { radarAlertLevels, type AlertLevel } from "$lib/controllers/radarAlerts";
   import { gcsLocation, gcsAccuracyM, gcsWatchPaused, setGcsManual } from "$lib/stores/gcsLocation";
@@ -1968,13 +1968,30 @@
     void centerInsetRight;
     if (map && viewMode === 'heading-follow') applyHeadingUpSize(true);
   });
-  // Phone mini map (docked frame / widget tile, PHONE_VIDEO.md D6): pinch zooms, but a double-tap
-  // must not zoom — it is the swap gesture on the surfaces around it, and the mini map relays
-  // touches to the tile underneath. Dragging is already off (follow modes).
+  // Mini map (the widget tile everywhere, the docked frame on the phone — `miniControls`): ZOOM
+  // only. Wheel and pinch reach Leaflet as before; every click / double-click / context menu /
+  // single-pointer press is swallowed in the CAPTURE phase on the container, before Leaflet, the
+  // mission layers (add / drag a waypoint), the GCS context menu or the geozone handles see it
+  // (Marc, 2026-09-04: the widget map placed and moved waypoints). Dragging is already off in
+  // the follow modes; Leaflet's double-click zoom goes too — a double-tap is the swap gesture on
+  // the surfaces around the frame, and the phone relays touches to the tile underneath.
   $effect(() => {
-    if (!map || !isPhone) return;
-    if (miniControls) map.doubleClickZoom.disable();
-    else map.doubleClickZoom.enable();
+    if (!map || !mapContainer) return;
+    if (!miniControls) {
+      map.doubleClickZoom.enable();
+      return;
+    }
+    map.doubleClickZoom.disable();
+    const swallow = (e: Event) => {
+      e.stopImmediatePropagation();
+      if (e.type === 'contextmenu') e.preventDefault(); // pointer events stay uncancelled: pinch = touch events
+    };
+    const el = mapContainer;
+    const types = ['click', 'dblclick', 'contextmenu', 'mousedown', 'mouseup', 'pointerdown', 'pointerup'];
+    for (const t of types) el.addEventListener(t, swallow, true);
+    return () => {
+      for (const t of types) el.removeEventListener(t, swallow, true);
+    };
   });
 
   // Apply the side-effects for a view mode (idempotent): heading-up container sizing, panning enable/
@@ -2102,7 +2119,7 @@
 </script>
 
 <div class="map-wrapper" style="--map-inset-right: {centerInsetRight}px">
-  <div bind:this={mapContainer} class="map" class:tile-overlap={isWebKitGtk} style="--map-rotation: 0deg"></div>
+  <div bind:this={mapContainer} class="map" class:tile-overlap={isWebKitGtk} class:mini={miniControls} style="--map-rotation: 0deg"></div>
 
   <div class="map-controls-corner">
     {#if !miniControls}
@@ -2216,6 +2233,30 @@
   :global(.map.heading-up) {
     transform: rotate(var(--map-rotation, 0deg));
     transform-origin: center center;
+  }
+
+  /* Mini map (the video-swap frame / widget tile, `miniControls`): every marker at half size, in
+     proportion to the little frame. Leaflet positions the marker root itself (its transform is
+     Leaflet's), so the CHILD — the icon's own root element — is scaled around the icon centre;
+     centre-anchored icons keep their anchor exactly, bottom-anchored ones move by a few px. */
+  .map.mini {
+    --marker-scale: 0.5;
+  }
+  .map.mini :global(.leaflet-marker-icon:not(.mission-wp-icon):not(.mission-fbh-icon) > *) {
+    transform: scale(var(--marker-scale));
+    transform-origin: 50% 50%;
+  }
+  /* Mission waypoint icons (INAV + ArduPilot layers): the SVG child is scaled — Leaflet's own
+     positioning transform on the marker root stays untouched — by the UI scale × a global 0.85
+     (a touch smaller everywhere, Marc 2026-09-04) × the map's --marker-scale. transform-origin
+     keeps the on-coordinate anchor fixed (teardrops anchor bottom-centre, circles centre). */
+  :global(.mission-wp-icon > svg),
+  :global(.mission-fbh-icon > svg) {
+    transform: scale(calc(var(--ui-scale, 1) * 0.85 * var(--marker-scale, 1)));
+    transform-origin: 50% 50%;
+  }
+  :global(.mission-wp-icon.wp-anchor-bottom > svg) {
+    transform-origin: 50% 100%;
   }
 
   /* Counter-rotate Leaflet controls so they stay readable */

--- a/src/lib/components/mission/InavMissionLayer.svelte
+++ b/src/lib/components/mission/InavMissionLayer.svelte
@@ -902,13 +902,8 @@
 <style>
   :global(.mission-wp-icon) { background: none !important; border: none !important; }
   :global(.mission-fbh-icon) { background: none !important; border: none !important; }
-  /* Scale the marker SVG with the global UI scale (--ui-scale inherits from .ui-root).
-     The transform is on the SVG child, not on the Leaflet-positioned `.leaflet-marker-icon`,
-     so Leaflet's positioning transform is untouched. transform-origin keeps the on-coordinate
-     anchor fixed (teardrops anchor bottom-centre, circles centre). */
-  :global(.mission-wp-icon > svg),
-  :global(.mission-fbh-icon > svg) { transform: scale(var(--ui-scale, 1)); transform-origin: 50% 50%; }
-  :global(.mission-wp-icon.wp-anchor-bottom > svg) { transform-origin: 50% 100%; }
+  /* The waypoint SVG scale (UI scale × global size × the map's --marker-scale) lives in Map.svelte
+     so it applies to every mission layer (INAV and ArduPilot alike). */
   /* Active target waypoint: the icon itself pulses in brightness + a green glow, at
      0.5 Hz (2 s period). Only `filter` is animated, so it never fights Leaflet's
      positioning transform on the marker element. */

--- a/src/lib/components/phone/PhoneWidgetPanel.svelte
+++ b/src/lib/components/phone/PhoneWidgetPanel.svelte
@@ -117,6 +117,8 @@
   let pressY = 0;
   /** Edit mode: a touch that moved before the hold elapsed is a page flick, tracked here. */
   let flickY: number | null = null;
+  /** The current press was relayed from the swapped-in mini map (a layer over a tile). */
+  let relayedPress = false;
   let edgeTimer: ReturnType<typeof setTimeout> | null = null;
   let edgeDir = 0;
 
@@ -256,13 +258,17 @@
       if (flickY != null) return; // page flick in progress — decided on release
       if (pressId && Math.hypot(e.clientX - pressX, e.clientY - pressY) > DRAG_SLOP_PX) {
         // Moved before the hold elapsed: not a pickup. In edit mode the cells block native
-        // scrolling (touch-action none), so the flick is ours to turn into a page change.
+        // scrolling (touch-action none), so the flick is ours to turn into a page change — and so
+        // is a swipe that started on the swapped-in mini map (a layer outside the scroller, which
+        // never sees it; the video tile scrolls natively, the map tile must match).
+        const relayed = relayedPress;
         clearPress();
-        if (editing) flickY = pressY;
+        if (editing || relayed) flickY = pressY;
       }
     };
     const onUp = (e: PointerEvent) => {
       clearPress();
+      relayedPress = false;
       if (dragId) endDrag(true);
       if (flickY != null) {
         const dy = e.clientY - flickY;
@@ -273,6 +279,7 @@
     };
     const onCancel = () => {
       clearPress();
+      relayedPress = false;
       flickY = null;
       if (dragId) endDrag(false);
     };
@@ -284,19 +291,25 @@
       const target = e.target as HTMLElement | null;
       if (!editing && e.pointerType !== 'mouse' && target?.closest('.layer-map.in-frame')) {
         const cell = cellElAt(e.clientX, e.clientY);
-        if (cell?.dataset.id) onCellPointerDown(e, cell.dataset.id);
+        if (cell?.dataset.id) {
+          relayedPress = true;
+          onCellPointerDown(e, cell.dataset.id);
+        }
         return;
       }
       if (editing && rootEl && !rootEl.contains(target as Node)) editing = false;
     };
-    window.addEventListener('pointermove', onMove);
-    window.addEventListener('pointerup', onUp);
-    window.addEventListener('pointercancel', onCancel);
+    // All in the CAPTURE phase: the mini map swallows pointer events on its container (zoom-only
+    // map), which would otherwise hide a release from us — the relayed press then ran into its
+    // long-press timer and a short tap on a waypoint popup opened edit mode.
+    window.addEventListener('pointermove', onMove, true);
+    window.addEventListener('pointerup', onUp, true);
+    window.addEventListener('pointercancel', onCancel, true);
     window.addEventListener('pointerdown', onDown, true);
     return () => {
-      window.removeEventListener('pointermove', onMove);
-      window.removeEventListener('pointerup', onUp);
-      window.removeEventListener('pointercancel', onCancel);
+      window.removeEventListener('pointermove', onMove, true);
+      window.removeEventListener('pointerup', onUp, true);
+      window.removeEventListener('pointercancel', onCancel, true);
       window.removeEventListener('pointerdown', onDown, true);
       clearPress();
       clearEdge();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -143,7 +143,14 @@
   $effect(() => { if (mapViewMode === '3d') map3dEverOpened = true; });
   // Waypoints can only be edited on the 2D map → entering edit mode forces 2D (untracked read/write so
   // toggling the view later doesn't re-trigger this; it reacts to the edit-mode transition only).
-  $effect(() => { if ($editMode) untrack(() => { if (mapViewMode === '3d') mapViewMode = '2d'; }); });
+  // Mission edit mode needs the full map: leave 3D, and bring the map back from a mini frame (the
+  // widget tile / the phone's docked frame take no waypoint interaction — Marc, 2026-09-04).
+  $effect(() => {
+    if ($editMode) untrack(() => {
+      if (mapViewMode === '3d') mapViewMode = '2d';
+      if (mapInFrame) setMapLocation('main');
+    });
+  });
   // Map3D instance handle — used to read the 3D camera focus on a 3D→2D switch so
   // the 2D map can re-centre on the same spot (keeping its own zoom).
   let map3dRef: {
@@ -394,12 +401,14 @@
   // hidden via `miniControls`). The FLOATING map stays fully operational on the desktop; on the phone
   // the docked frame is a mini map too and takes the same lock (PHONE_VIDEO.md D6). Restore the view
   // on release.
-  const miniMapLocked = $derived(mapInWidget || (phoneUi && mapFloating));
+  // Only while the map is actually in a frame (mapInFrame includes `status === 'live'`): a stale
+  // mapLocation with the video off must not put the FULL map into mini mode (half-size markers).
+  const miniMapLocked = $derived(mapInFrame && (mapInWidget || phoneUi));
   let miniLockActive = false;
   let savedMapViewMode: '2d' | '3d' = '2d';
   let savedMode2d: 'free' | 'follow' | 'heading-follow' = 'free';
   $effect(() => {
-    const lock = miniMapLocked && $videoState.status === 'live';
+    const lock = miniMapLocked;
     untrack(() => {
       if (lock && !miniLockActive) {
         miniLockActive = true;
@@ -4039,6 +4048,11 @@
       calc(100vw - var(--phone-panel-w, 0px) + var(--phone-shift, 0px) + var(--phone-pad, 4px))
     );
     z-index: 2;
+  }
+  /* Editing the grid: the mini map drops UNDER the column (dimmed through the glass) so the tile's
+     own edit chrome — the resize button — is on top and reachable. */
+  :global(html.phone-editing) .map-clip.clip-column {
+    z-index: 0;
   }
   :global(html.is-mobile) .app-toasts {
     top: var(--safe-top, 0px);


### PR DESCRIPTION
Stacked on #105 (phone video) — follow-ups from the fourth and fifth Sony test rounds. Retargets to `development` once #105 merges.

## Changes
- **Half-size markers in the mini map** (video-swap frame / widget tile): the map carries `--marker-scale`; non-waypoint icons scale their icon child by it, the waypoint SVGs multiply it into their existing anchor-aware transform — which moved from the INAV layer into `Map.svelte` (ArduPilot missions had none) and gained a **global ×0.85**: waypoints are a touch smaller on every map, desktop included (Marc's call).
- **Mini map = zoom only** — the widget everywhere, the docked frame on the phone: `Map.svelte` swallows click / double-click / context menu / mouse+pointer down/up in the capture phase on the container while `miniControls`. No waypoint placing or dragging, no GCS context menu, no geozone handles; wheel and pinch untouched (wheel / touch events), double-click zoom off. The desktop floating window's map stays fully interactive.
- **Mission editor on → map comes home** from any frame (next to the existing "leave 3D").
- Phone: in grid edit mode the mini map drops under the column so the tile's **resize button** is reachable; `miniMapLocked` requires the map to be in a frame with the video live (a stale swap state had put the full map into mini mode).
- Phone: the widget panel's pointer listeners are **capture-phase** — the zoom-only map swallowed the release, so a short tap on a waypoint popup ran into the long-press and opened edit mode; a **swipe on the mini map flicks the page** (the layer sits outside the scroller).

## Verification
Sony XQ-CT54: waypoints 41×56 px main / ×0.425 mini; clicks, context menu and pointer presses on the mini map reach nothing; mission edit returns the map; resize button hit-testable in edit mode; short tap leaves edit mode alone; swipe on the mini map flips the page (408 → 0). `npm run check` 0 errors, `npm run build` clean.

Regression: introduced by #105 (unreleased), never released — except the global waypoint size, a deliberate change on every platform.
