### PR TITLE
Fix: 3D map lost its input and the video hole; refused toggle showed the wrong state

### DIFF
--- a/docs/user/for-developers/building.md
+++ b/docs/user/for-developers/building.md
@@ -245,9 +245,10 @@ KiteGC_<OS>_<arch>_<version>_<type>.<ext>
 - The naming logic lives in `scripts/collect-release.*` and is shared by local builds and the GitHub
   release workflow (`.github/workflows/release.yml`), so filenames match everywhere.
 - `just build-android` drops its APK into the same folder as `KiteGC_Android_<abi>_<version>_installer.apk`
-  (one file per ABI folder Gradle produced, e.g. `arm64` or `universal`) **without** clearing the desktop
-  outputs already there; a desktop build also picks up any Android release APK that is still lying in the
-  Gradle outputs.
+  (one file per ABI folder Gradle produced, e.g. `arm64` or `universal`). It collects **only** the APK and
+  leaves the desktop outputs already in `release/` alone — an earlier desktop build's binaries still sit in
+  `target/release/`, and collecting those here would republish a stale one under the current version number.
+  A desktop build, in turn, also picks up any Android release APK still lying in the Gradle outputs.
 
 The folder is refreshed on each desktop build and is git-ignored (local to your machine). The raw
 desktop outputs also remain in `src-tauri/target/release/` (and its `bundle/` subfolders) as usual; the

--- a/justfile
+++ b/justfile
@@ -52,19 +52,22 @@ build-macos:
 notarize-macos:
     @bash scripts/notarize-macos.sh
 
-# Android APK, arm64 (EXPERIMENTAL — needs ANDROID_HOME + NDK_HOME; see the Build Guide).
-# Prefer the "Android" GitHub Actions workflow, which needs nothing installed locally.
-# The APK is collected into release/ under the unified name (KiteGC_Android_arm64_<version>_installer.apk)
-# WITHOUT wiping desktop outputs already there (`-Keep` / `--keep`).
+# Needs ANDROID_HOME + NDK_HOME (see the Build Guide); prefer the "Android" GitHub Actions
+# workflow, which needs nothing installed locally. The APK lands in release/ under the unified name
+# (KiteGC_Android_<abi>_<version>_installer.apk). `-AndroidOnly` / `--android-only` keeps whatever
+# desktop outputs are already in release/ and collects NOTHING but the APK: an earlier desktop
+# build's binaries still sit in target/release, and collecting them here would republish a stale
+# one under the current version number.
+# Android APK, arm64 (EXPERIMENTAL)
 [windows]
 build-android:
     npm run tauri android build -- --apk --target aarch64
-    @powershell -ExecutionPolicy Bypass -File scripts/collect-release.ps1 -Keep
+    @powershell -ExecutionPolicy Bypass -File scripts/collect-release.ps1 -AndroidOnly
 
 [unix]
 build-android:
     npm run tauri android build -- --apk --target aarch64
-    @bash scripts/collect-release.sh --keep
+    @bash scripts/collect-release.sh --android-only
 
 # Android dev build on a connected device / emulator, with hot reload
 dev-android:

--- a/scripts/collect-release.ps1
+++ b/scripts/collect-release.ps1
@@ -11,10 +11,15 @@
 #
 # One naming source shared by local builds (`just build` / `just build-windows` / `just build-android`)
 # AND the GitHub release workflow, so the filenames are identical everywhere. The release/ folder is
-# git-ignored and refreshed on every run — `-Keep` adds to it instead (the Android build runs
-# separately from the desktop one and must not wipe its outputs).
+# git-ignored and refreshed on every run — `-Keep` adds to it instead.
+#
+# `-AndroidOnly` collects the APKs alone (implies -Keep). `just build-android` uses it: an Android
+# build leaves the DESKTOP outputs of an earlier build untouched in target/release, and collecting
+# them would republish a stale binary under the current version number — a 1.0.0-rc2 kite-gc.exe
+# came out as KiteGC_Windows_x64_1.1.0-dev_portable.zip (found 2026-09-04).
 # ============================================================
-param([switch]$Keep)
+param([switch]$Keep, [switch]$AndroidOnly)
+if ($AndroidOnly) { $Keep = $true }
 $ErrorActionPreference = 'Stop'
 
 $root = (Resolve-Path "$PSScriptRoot\..").Path
@@ -31,6 +36,8 @@ if (-not $Keep -and (Test-Path $out)) { Remove-Item $out -Recurse -Force }
 if (-not (Test-Path $out)) { New-Item -ItemType Directory -Path $out | Out-Null }
 
 $collected = @()
+
+if (-not $AndroidOnly) {
 
 # NSIS installer. Pick the NEWEST match, not the first: Tauri never prunes its bundle dir, so
 # stale installers from earlier builds pile up beside the fresh one and a first-match (which is
@@ -64,6 +71,8 @@ if ($collected.Count -gt 0) {
     Remove-Item (Join-Path $bundle 'nsis') -Recurse -Force -ErrorAction SilentlyContinue
 }
 
+} # -not $AndroidOnly
+
 # Android: `tauri android build --apk` leaves one release APK per ABI folder under the Gradle
 # outputs (universal / arm64 / armv7 / x86_64 / x86). Same rules as above: newest file per folder,
 # then the raw output is deleted so a stale APK can't be re-collected under a newer version.
@@ -84,7 +93,8 @@ Get-ChildItem $apkRoot -Directory -ErrorAction SilentlyContinue | ForEach-Object
 
 Write-Host ''
 if ($collected.Count -eq 0) {
-    Write-Host "[collect-release] No build outputs found under $rel - did the build succeed?" -ForegroundColor Yellow
+    $where = if ($AndroidOnly) { $apkRoot } else { $rel }
+    Write-Host "[collect-release] No build outputs found under $where - did the build succeed?" -ForegroundColor Yellow
 } else {
     Write-Host "[collect-release] Collected into $out :" -ForegroundColor Green
     $collected | ForEach-Object { Write-Host "  - $_" }

--- a/scripts/collect-release.sh
+++ b/scripts/collect-release.sh
@@ -13,13 +13,23 @@
 #
 # One naming source shared by local builds (`just build*`) AND the GitHub release workflow, so the
 # filenames are identical everywhere. The release/ folder is git-ignored and refreshed on every
-# run — `--keep` adds to it instead (the Android build runs separately from the desktop one and
-# must not wipe its outputs).
+# run — `--keep` adds to it instead.
+#
+# `--android-only` collects the APKs alone (implies --keep). `just build-android` uses it: an
+# Android build leaves the DESKTOP outputs of an earlier build untouched in target/release, and
+# collecting them would republish a stale binary under the current version number (found on the
+# Windows side 2026-09-04: a 1.0.0-rc2 kite-gc.exe came out as a 1.1.0-dev portable zip).
 # ============================================================
 set -e
 
 KEEP=0
-[ "${1:-}" = "--keep" ] && KEEP=1
+ANDROID_ONLY=0
+for arg in "$@"; do
+    case "$arg" in
+        --keep)         KEEP=1 ;;
+        --android-only) ANDROID_ONLY=1; KEEP=1 ;;
+    esac
+done
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VERSION="$(grep '"version"' "$ROOT/package.json" | head -1 | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
@@ -78,7 +88,9 @@ zip_portable() { # <binary-path> <name-in-zip>
     collected+=("$dest")
 }
 
-if [ "$OS" = "macOS" ]; then
+if [ "$ANDROID_ONLY" = 1 ]; then
+    : # desktop outputs are skipped — see --android-only in the header
+elif [ "$OS" = "macOS" ]; then
     BUNDLE="$TARGET/universal-apple-darwin/release/bundle"
     grab_file "$BUNDLE/dmg/*.dmg" installer dmg
     # .app is a bundle (directory) → zip with ditto so the bundle structure/symlinks stay intact.
@@ -103,7 +115,7 @@ fi
 # lets stale, wrongly-versioned artifacts accumulate and get mis-collected next time. Removing
 # them (both the packages and Tauri's staging dirs beside them) keeps the source clean. The bare
 # CLI binary at $REL/kite-gc is a cargo output, not a bundle artifact — it stays.
-if [ ${#collected[@]} -gt 0 ]; then
+if [ ${#collected[@]} -gt 0 ] && [ "$ANDROID_ONLY" != 1 ]; then
     if [ "$OS" = "macOS" ]; then
         rm -rf "$BUNDLE/dmg" "$BUNDLE/macos"
     else
@@ -129,7 +141,11 @@ done
 
 echo ""
 if [ ${#collected[@]} -eq 0 ]; then
-    echo "[collect-release] No build outputs found under $TARGET — did the build succeed?"
+    if [ "$ANDROID_ONLY" = 1 ]; then
+        echo "[collect-release] No APK found under $APK_ROOT — did the build succeed?"
+    else
+        echo "[collect-release] No build outputs found under $TARGET — did the build succeed?"
+    fi
 else
     echo "[collect-release] Collected into $OUT :"
     for c in "${collected[@]}"; do echo "  - $c"; done

--- a/src/lib/components/panel/Toggle.svelte
+++ b/src/lib/components/panel/Toggle.svelte
@@ -21,10 +21,21 @@
     onchange?: (checked: boolean) => void;
   } = $props();
 
+  // The switch shows the APP's state, not the click. A parent may REFUSE the change (the phone
+  // widget grid has no room, PHONE_UI.md D8) — it then leaves `checked` where it was, while the
+  // browser has already flipped the checkbox: the switch would lie, and the next click would send
+  // the same (refused) request again instead of the opposite one (Marc, 2026-09-04).
   function handle(e: Event) {
-    const c = (e.currentTarget as HTMLInputElement).checked;
-    checked = c;
-    onchange?.(c);
+    const el = e.currentTarget as HTMLInputElement;
+    const want = el.checked;
+    el.checked = checked; // back to the rendered state; an accepting parent re-renders it forward
+    checked = want; // bindable: propagates to a `bind:checked` parent
+    onchange?.(want);
+    // Nothing re-rendered us → the change was refused; follow the DOM so the local copy and the
+    // switch agree again.
+    queueMicrotask(() => {
+      if (el.isConnected && el.checked !== checked) checked = el.checked;
+    });
   }
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3283,7 +3283,6 @@
         {radarRefAltM}
       />
     </div>
-  </div>
     <!-- 3D stays mounted (hidden) once opened, so toggling back is instant. -->
     {#if map3dEverOpened}
       <div class="map3d-layer" class:active={mapViewMode === '3d'}>
@@ -3311,6 +3310,7 @@
     {/if}
 
   </div>
+  </div><!-- .map-clip -->
 
   <!-- Toasts & alerts pinned to the MAIN APP FRAME (not the map): the map can shrink into the
        floating window or a widget tile, and map-bound banners would then cover that tiny tile. This


### PR DESCRIPTION
Three fixes on top of #105 / #106, all found by Marc on the Sony.

## 1. 3D map took no input, and no video behind it — **every platform**
The clip wrapper added in #106 closed `.layer-map` one line early, so `.map3d-layer` became a direct child of `.map-clip` instead of a sibling of the 2D layer inside `.layer-map`. `.map-clip` is **not** phone-gated, so both consequences hit the desktop too:

- `.map-clip` carries `pointer-events: none` and only `.layer-map` opts back in → **the 3D view took no input at all**: no orbit, no zoom, no tilt.
- The native-video hole is cut by clipping `.layer-map` (`data-nv-clip`); with the 3D layer outside it, the opaque Cesium canvas covered the hardware surface → the docked window and the video widget showed **a transparent frame with no picture** while 3D was active.

Nesting restored to the pre-#106 shape: `.map-clip` > `.layer-map` > 2D + 3D.

## 2. A refused toggle kept showing "on"
`Toggle` set its own state from the click, so a parent that **refuses** the change (the phone widget grid has no room) left the switch lying: it showed a state the app was not in, and the next click repeated the same request instead of the opposite one — hence the second "no space" popup. The switch now shows the app's state: the DOM snaps back immediately, an accepting or `bind:checked` parent re-renders it forward, and a refused change also restores the internal copy. Applies to all 61 `<Toggle>` instances.

## 3. `just build-android` collected desktop artifacts
It ran the full collect script, which found an earlier desktop build's `kite-gc.exe` in `target/release` and republished it under the current version — a 1.0.0-rc2 binary came out as `KiteGC_Windows_x64_1.1.0-dev_portable.zip`. New `-AndroidOnly` / `--android-only` (implies keep) collects the APK alone; the `just` recipe uses it, and the "nothing found" message points at the APK path.

## Verification
`npm run check` 0 errors, `npm run build` clean. Both collect scripts parse (PowerShell + `bash -n`); the AndroidOnly path collects nothing but the APK and leaves `release/` untouched; `just --list` shows a clean summary line.

The 3D fix is verified **structurally** (the nesting and the exact CSS rules that broke) — the on-device re-test is still open, the Sony was unplugged when the release build went on it.

Regression: introduced by #106, never released. The toggle bug predates it (#102) but only became reachable with the phone grid's refusal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
