### PR TITLE
fix(relay): bound the TCP sink's writes, and cut 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kite-gc",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kite-gc",
-      "version": "1.0.0-rc2",
+      "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kite-gc",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0",
   "description": "Kite Ground Control — Universal Ground Control Station",
   "type": "module",
   "scripts": {

--- a/src-tauri/src/telemetry_forward/output/tcp.rs
+++ b/src-tauri/src/telemetry_forward/output/tcp.rs
@@ -4,8 +4,11 @@
 //! TCP server output sink — Kite hosts a TCP server; other GCS / monitoring apps connect *to* it and
 //! receive the encoded telemetry stream. Frames are broadcast to all connected clients; dead clients are
 //! dropped on the next write.
+//!
+//! Writes are **bounded** (see `WRITE_TIMEOUT`): every relay is written from the one dispatch thread, so
+//! an unbounded write to a client that stopped reading would stall every other relay behind it.
 
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -13,6 +16,14 @@ use std::thread;
 use std::time::Duration;
 
 use super::OutputSink;
+
+/// Per-client write budget. A frame set is a few hundred bytes emitted at the pace of the attitude
+/// update, so a healthy client drains it immediately — only one that has stopped reading (window
+/// closed, process suspended) lets the socket buffer fill. Without a bound, `write_all` then blocks
+/// forever and takes all relays with it, because `RelayHub::dispatch` writes them sequentially on a
+/// single thread while holding the relay lock. Over budget the client is dropped: the timeout can
+/// leave a half-written frame behind and a stream consumer cannot resynchronize from that anyway.
+const WRITE_TIMEOUT: Duration = Duration::from_millis(200);
 
 pub struct TcpSink {
     addr: String,
@@ -40,6 +51,14 @@ impl TcpSink {
                 match listener.accept() {
                     Ok((stream, peer)) => {
                         let _ = stream.set_nodelay(true);
+                        // Windows hands the accepted socket the listener's non-blocking mode (Unix
+                        // does not), which would make every full send buffer an instant WouldBlock —
+                        // a client that pauses for a moment would be dropped with no grace at all.
+                        // Blocking + the write budget below is the same behaviour on every platform.
+                        let _ = stream.set_nonblocking(false);
+                        if let Err(e) = stream.set_write_timeout(Some(WRITE_TIMEOUT)) {
+                            log::warn!("[RELAY tcp] {peer}: write timeout could not be set ({e}) — writes stay unbounded");
+                        }
                         log::info!("[RELAY tcp] client connected: {peer}");
                         c.lock().unwrap().push(stream);
                     }
@@ -60,8 +79,22 @@ impl TcpSink {
 
 impl OutputSink for TcpSink {
     fn write(&mut self, data: &[u8]) -> Result<(), String> {
-        // Broadcast to every client; retain only those that accepted the write.
-        self.clients.lock().unwrap().retain_mut(|s| s.write_all(data).is_ok());
+        // Broadcast to every client; retain only those that took the whole frame set within budget.
+        self.clients.lock().unwrap().retain_mut(|s| {
+            let result = s.write_all(data);
+            if let Err(e) = result {
+                let peer = s.peer_addr().map(|p| p.to_string()).unwrap_or_else(|_| "unknown".to_string());
+                match e.kind() {
+                    ErrorKind::WouldBlock | ErrorKind::TimedOut => log::warn!(
+                        "[RELAY tcp] client {peer} did not read within {} ms — dropped",
+                        WRITE_TIMEOUT.as_millis()
+                    ),
+                    _ => log::warn!("[RELAY tcp] client {peer} dropped: {e}"),
+                }
+                return false;
+            }
+            true
+        });
         Ok(())
     }
 
@@ -78,5 +111,56 @@ impl OutputSink for TcpSink {
 impl Drop for TcpSink {
     fn drop(&mut self) {
         self.running.store(false, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpStream;
+    use std::time::Instant;
+
+    /// Ask the OS for a free port, then release it — the sink binds it a moment later.
+    fn free_port() -> u16 {
+        let probe = TcpListener::bind("127.0.0.1:0").expect("probe bind");
+        probe.local_addr().expect("probe addr").port()
+    }
+
+    /// A client that connects and never reads is the case that used to park the dispatch thread
+    /// forever: once its receive buffer is full, an unbounded `write_all` blocks and every other
+    /// relay waits behind it. With the write budget the sink drops that client and returns.
+    #[test]
+    fn a_client_that_never_reads_is_dropped_instead_of_blocking_the_sink() {
+        let port = free_port();
+        let mut sink = TcpSink::open(port).expect("sink bind");
+
+        // Connect and then never read a byte.
+        let client = TcpStream::connect(("127.0.0.1", port)).expect("client connect");
+
+        // The accept loop runs on its own thread — wait for it to register the client.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while sink.pending() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(!sink.pending(), "the sink never accepted the test client");
+
+        // Push until the socket buffers are full and the budget trips. A healthy client would take
+        // all of this without ever reaching the timeout.
+        let payload = vec![0u8; 64 * 1024];
+        let start = Instant::now();
+        for _ in 0..256 {
+            sink.write(&payload).expect("write never reports an error upward");
+            if sink.pending() {
+                break; // the client was dropped — what this test is about
+            }
+        }
+        let elapsed = start.elapsed();
+
+        assert!(sink.pending(), "the non-reading client was not dropped");
+        assert!(
+            elapsed < Duration::from_secs(20),
+            "writing to a stalled client took {elapsed:?} — the budget did not bound it"
+        );
+        drop(client);
     }
 }


### PR DESCRIPTION
Two commits: the last open item marked "1.0 FIX" in the notes, and the version bump that
turns RC2 into the first stable release.

**Affects: v1.0.0-rc2 and earlier.**

## The bug

`TcpSink::write` was a blocking `write_all` with no timeout. A client that connects to the
relay's TCP server and then stops reading — window closed, process suspended, laptop asleep —
fills the socket buffer, and that write never returns. `RelayHub::dispatch` writes every relay
sequentially on **one** thread while holding the relay lock, so a single such client froze
every other relay and every `relay_*` command behind it.

Each accepted client now gets `set_write_timeout(200 ms)`. That is enormous for a frame set of
a few hundred bytes, so only a genuinely stuck consumer ever reaches it; over budget the client
is dropped with a warn naming the peer. Dropping is the correct answer rather than retrying: a
timed-out write can leave half a frame in the stream, and a stream consumer cannot resynchronize
from that. The serial sink (100 ms open timeout) and UDP (fire-and-forget) were already bounded —
TCP was the last unbounded one.

## The platform half of it

Found while writing the test: **Windows hands the accepted socket the listener's non-blocking
mode, Unix does not.** So on Windows a full send buffer was an instant `WouldBlock` and the
client was dropped with no grace at all, while Linux and macOS blocked forever — same code,
opposite failure. `set_nonblocking(false)` on accept puts both platforms on the same 200 ms
contract.

## Test

`a_client_that_never_reads_is_dropped_instead_of_blocking_the_sink` drives exactly that case:
the client takes ~448 KB into the buffers, the next write trips the budget at ~210 ms, and the
sink reports itself pending again. Before the fix that call never returned.

## Release

`package.json` (+ lock) 1.0.0-rc2 → **1.0.0**. It is the single version source — `tauri.conf.json`
reads it, `Cargo.toml` is crate metadata only — so the app, the bundles, the collected artifact
names and the docs-site deploy all follow from this one bump.

Checks: `cargo check` clean, `cargo test` 105 passed, `npm run check` 0 errors / 0 warnings.

Merging this is the point of no return for the tag: `v1.0.0` → release workflow → GitHub release
→ backport to `development` (keep `1.1.0-dev` there when `package.json` conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
