### PR TITLE
fix(phone): toasts and alerts centre on the map area, in the bands between the corner buttons

### DIFF
--- a/src/lib/components/RadarAlertBanner.svelte
+++ b/src/lib/components/RadarAlertBanner.svelte
@@ -118,6 +118,12 @@
   :global(html.is-mobile) .alert-stack {
     top: calc(var(--toolbar-h, 53px) - var(--safe-top, 0px) + 8px);
   }
+  /* Phone: the parent .app-toasts is the band between the corner buttons at --safe-top — start in
+     the buttons' row and never grow past the band (the rows wrap; an alert is not ellipsized). */
+  :global(html.is-phone) .alert-stack {
+    top: 8px;
+    max-width: calc(100% - 16px);
+  }
 
   .banner {
     pointer-events: auto;

--- a/src/lib/components/StatusTextToasts.svelte
+++ b/src/lib/components/StatusTextToasts.svelte
@@ -70,6 +70,15 @@
   :global(html.is-mobile) .msg-banner {
     top: calc(var(--toolbar-h, 53px) - var(--safe-top, 0px) + 8px);
   }
+  /* Phone: the parent .app-toasts IS the band between the corner buttons and already sits at
+     --safe-top, so start in the buttons' row and let the band — not the viewport — cap the width.
+     --toast-dock-inset is a viewport x; the band's own left edge (--toast-band-left) comes off it
+     first, so a banner beside an open panel still centres in what is left of the band. */
+  :global(html.is-phone) .msg-banner {
+    top: 8px;
+    left: calc(max(var(--toast-dock-inset, 0px) - var(--toast-band-left, 0px), 0px) + 8px);
+    max-width: min(640px, calc(100% - max(var(--toast-dock-inset, 0px) - var(--toast-band-left, 0px), 0px) - 16px));
+  }
 
   .msg-lines {
     display: flex;

--- a/src/lib/components/logbook/BatteryManager.svelte
+++ b/src/lib/components/logbook/BatteryManager.svelte
@@ -1010,6 +1010,15 @@
   .modal-card { box-sizing: border-box; background: #2e2e2e; border: 1px solid rgba(55, 168, 219, 0.35); border-radius: 8px; padding: 14px; width: min(540px, 92vw); max-height: 88vh; overflow-y: auto; box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5); }
 
   .bat-status { position: fixed; bottom: 14px; left: 50%; transform: translateX(-50%); z-index: 1001; padding: 6px 12px; font-size: 11px; color: #f39c12; background: rgba(0, 0, 0, 0.8); border-radius: 6px; }
+  /* Phone: centre on the map area — a screen-centred pill runs under the widget column. */
+  :global(html.is-phone) .bat-status {
+    left: calc((100vw - var(--phone-panel-w, 0px) + var(--phone-shift, 0px)) / 2);
+    max-width: calc(100vw - var(--phone-panel-w, 0px) + var(--phone-shift, 0px) - 24px);
+    box-sizing: border-box;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   @media (max-width: 760px) {
     .form-grid { grid-template-columns: 1fr; }

--- a/src/lib/components/logbook/VehicleManager.svelte
+++ b/src/lib/components/logbook/VehicleManager.svelte
@@ -1050,6 +1050,15 @@
   .modal-card { box-sizing: border-box; background: #2e2e2e; border: 1px solid rgba(55, 168, 219, 0.35); border-radius: 8px; padding: 14px; width: min(600px, 94vw); max-height: 90vh; overflow-y: auto; box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5); }
 
   .veh-status { position: fixed; bottom: 14px; left: 50%; transform: translateX(-50%); z-index: 1001; padding: 6px 12px; font-size: 11px; color: #f39c12; background: rgba(0, 0, 0, 0.8); border-radius: 6px; }
+  /* Phone: centre on the map area — a screen-centred pill runs under the widget column. */
+  :global(html.is-phone) .veh-status {
+    left: calc((100vw - var(--phone-panel-w, 0px) + var(--phone-shift, 0px)) / 2);
+    max-width: calc(100vw - var(--phone-panel-w, 0px) + var(--phone-shift, 0px) - 24px);
+    box-sizing: border-box;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   @media (max-width: 760px) {
     .form-grid, .vmv-sensor-grid { grid-template-columns: 1fr; }

--- a/src/lib/components/mission/MissionManager.svelte
+++ b/src/lib/components/mission/MissionManager.svelte
@@ -610,4 +610,13 @@
 
 
   .mmv2-status { position: fixed; bottom: 14px; left: 50%; transform: translateX(-50%); z-index: 1001; padding: 6px 12px; font-size: 11px; color: #f39c12; background: rgba(0, 0, 0, 0.8); border-radius: 6px; }
+  /* Phone: centre on the map area — a screen-centred pill runs under the widget column. */
+  :global(html.is-phone) .mmv2-status {
+    left: calc((100vw - var(--phone-panel-w, 0px) + var(--phone-shift, 0px)) / 2);
+    max-width: calc(100vw - var(--phone-panel-w, 0px) + var(--phone-shift, 0px) - 24px);
+    box-sizing: border-box;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4389,6 +4389,54 @@
     bottom: calc(8px + var(--safe-bottom, 0px));
     z-index: 170; /* over every panel (150 / 160), under the dialogs */
   }
+  /* Toasts and alerts live in the TOP band between the burger (12 + 42 + 8) and the chain-link
+     button (panel-w + 8 + 42 + 8 from the right) — the same gap the replay player uses. The
+     container already sits at --safe-top (is-mobile rule), so its children start 8px down, in
+     the buttons' row; the right edge rides along when the widget column slides out. */
+  :global(html.is-phone) .app-toasts {
+    left: calc(62px + var(--safe-left, 0px));
+    right: calc(var(--phone-panel-w, 0px) - var(--phone-shift, 0px) + 58px);
+    transition: right 0.3s ease;
+    /* The system-message banner takes this off --toast-dock-inset (a viewport x) to centre in
+       the free band beside an open panel, as it does on the desktop. */
+    --toast-band-left: calc(62px + var(--safe-left, 0px));
+  }
+  /* BOTTOM band: between the chip row (+ Debug) and the map-control column (38 + 8 + 8 from the
+     map area's right edge). The error bar sits in the chip row itself, centred and capped to the
+     band instead of spanning the screen; a long message ellipsizes, the ✕ stays. */
+  :global(html.is-phone) .error-bar {
+    left: calc(var(--phone-bottom-w, 0px) + var(--phone-debug-w, 0px) + 8px);
+    right: calc(var(--phone-panel-w, 0px) - var(--phone-shift, 0px) + 54px);
+    bottom: calc(8px + var(--safe-bottom, 0px));
+    margin-inline: auto;
+    width: max-content;
+    max-width: calc(100% - var(--phone-bottom-w, 0px) - var(--phone-debug-w, 0px) - var(--phone-panel-w, 0px) + var(--phone-shift, 0px) - 62px);
+    box-sizing: border-box;
+    gap: 8px;
+    border-radius: 6px;
+    transition: right 0.3s ease;
+  }
+  :global(html.is-phone) .error-bar > span {
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  /* The resume banner goes one row up (the chip row may hold the error bar at the same time — a
+     failed reconnect attempt while waiting for one), centred between the nav rail and the map
+     controls and capped to that gap. */
+  :global(html.is-phone) .resume-banner {
+    --band-l: calc(62px + var(--safe-left, 0px));
+    --band-r: calc(100vw - var(--phone-panel-w, 0px) + var(--phone-shift, 0px) - 54px);
+    left: calc((var(--band-l) + var(--band-r)) / 2);
+    bottom: calc(46px + var(--safe-bottom, 0px));
+    max-width: calc(var(--band-r) - var(--band-l) - 16px);
+    box-sizing: border-box;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition: left 0.3s ease;
+  }
 
   .zone-status-bar {
     grid-area: status-bar;


### PR DESCRIPTION
**Regression: introduced by the phone chrome (PR #102), never released.**

On the phone, every in-flight message was still positioned for a desktop screen: FC system
messages and the ADS-B conflict alert (both inside `.app-toasts`, which spanned the whole
viewport) were screen-centred, so their right part sat under the widget column, and their top
offset was written for a toolbar the phone does not have. The red error bar ran `left:0 / right:0`
across the screen; the continue-on-reconnect banner and the manager status pills were
screen-centred too.

## Top band

`.app-toasts` on the phone is now the band between the burger (12 + 42 + 8) and the chain-link
button (panel-w + 8 + 42 + 8 from the right) — the gap the replay player already uses — and it
follows the column when it slides out for the player. Both banners start at 8 px, i.e. in the
corner buttons' row, and are capped to the band:

- system messages (`StatusTextToasts`) ellipsize per line as before; the issue-#10 dock inset
  (centre beside an open panel) has the band's left edge taken off it and keeps working;
- the conflict alert (`RadarAlertBanner`) wraps instead — a callsign is not something to cut.

## Bottom band

Between the chip row (+ Debug button) and the map-control column:

- the error bar centres in the chip row, capped and ellipsized, the ✕ stays;
- the resume banner ("Recording paused — connect to continue") sits one row above it so both can
  show at once — a failed reconnect attempt while waiting for one is exactly the combination that
  happens;
- the Vehicle / Battery / Mission manager status pills centre on the map area.

## Deliberately unchanged

Modal dialogs (14 backdrops) stay screen-centred: full-attention elements whose backdrop dims the
column anyway. What matters is what can appear in flight while the map and telemetry are being
watched.

CSS only, phone-gated (`html.is-phone`). `npm run check` 0 errors / 0 warnings. Not yet checked on
the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
