### PR TITLE
fix(video): Linux native RTSP on the Pi 5 — HEVC abort, paced-mode slideshow, ffmpeg left running, URL loop

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -386,6 +386,19 @@ pub fn run() {
     let log_level = if debug_flag { log::LevelFilter::Debug } else { log::LevelFilter::Warn };
     logging::init(log_level, is_portable());
 
+    // Linux: the GStreamer decode sink renders through gtkglsink, whose GL context is GDK's — and
+    // GTK3 creates a DESKTOP GL context by default (measured on a Pi 5: OpenGL 3.1, legacy). Such a
+    // context has no direct DMABuf import (`GL_OES_EGL_image_external`), so a hardware decoder's
+    // tiled output — the Pi 5 HEVC block's `NV12_128C8` — goes down gst-gl's per-plane path and
+    // ABORTS the process in `gst_gl_format_from_video_info` ("code should not be reached", twice in
+    // the field on 2026-09-04). A GLES context imports it directly (measured there: zero-copy at
+    // 60 fps). Nothing else in the process uses GDK's GL — WebKitGTK renders through its own EGL,
+    // wry/tao draw nothing — so ask GTK for GLES before it initializes; a user-set value wins.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("GDK_GL").is_none() {
+        std::env::set_var("GDK_GL", "gles");
+    }
+
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init());

--- a/src-tauri/src/video/linux_sink.rs
+++ b/src-tauri/src/video/linux_sink.rs
@@ -10,9 +10,11 @@
 //!
 //! and the gtkglsink's GtkGLArea widget is what `linux_host` places below the WebView.
 //! decodebin3 picks the decoder the machine has — VA-API (`vah264dec`/`vah265dec`, Intel/
-//! AMD), V4L2 stateful (Pi 4 H264, Pi 5 HEVC) or software (`avdec_*`) — and the GL leg
-//! imports DMABuf output without a copy where the decoder offers it. When the GL sink
-//! can't come up (no usable GL context) the cairo path `videoconvert → videoflip →
+//! AMD), V4L2 (Pi 4 H264 stateful, Pi 5 HEVC stateless `v4l2slh265dec`) or software
+//! (`avdec_*`) — and the GL leg imports DMABuf output without a copy where the decoder
+//! offers it. That import needs a GLES context (`lib.rs` asks GDK for one: a desktop-GL
+//! context cannot take the Pi 5's tiled `NV12_128C8` and gst-gl aborts on it). When the GL
+//! sink can't come up (no usable GL context) the cairo path `videoconvert → videoflip →
 //! gtksink` takes over for the rest of the process.
 //!
 //! Presentation: smoothing buffer 0 (the latency-first default) = `sync=false`, every
@@ -20,6 +22,11 @@
 //! PTS scheduled `depth × frame-interval` behind their arrival timeline (same pacing model
 //! as the Android sink: one anchor maps media time onto the pipeline clock, a timeline jump
 //! or drift beyond the cushion re-anchors), so each step adds ONE frame time of cushion.
+//! The cushion is measured at the SINK — after decode and GL upload — so those get a fixed
+//! allowance on top (`PROCESSING_ALLOWANCE_NS`), a frame may reach the sink a little late
+//! and still show (`LATE_TOLERANCE_NS`), and the sink never sends QoS upstream: a decoder
+//! that skips frames on QoS breaks the reference chain, and artefacts are worse than a
+//! repeated picture.
 //!
 //! Threads: `push` runs on the RTSP thread (appsrc is thread-safe), decode and render on
 //! GStreamer's own streaming threads, GL drawing on the GTK main thread through the
@@ -41,6 +48,18 @@ const ATTACH_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Sticky: once the GL sink failed to start, every later sink in this process goes cairo.
 static GL_UNAVAILABLE: AtomicBool = AtomicBool::new(false);
+
+/// Paced mode: what decode + GL upload may take on top of the user's `depth × frame-interval`
+/// cushion, since the cushion is judged at the sink. Measured on a Pi 5: software H.264 720p
+/// decodes in ~10 ms plus the upload. Without it a one-frame cushion at 60 fps (16 ms) was
+/// spent before the frame reached the sink — every frame late and dropped, and the sink's QoS
+/// events made the decoder skip on top: a 1 fps slideshow at 30–40 % CPU in the field.
+const PROCESSING_ALLOWANCE_NS: u64 = 20_000_000;
+
+/// Paced mode: how late a frame may reach the sink and still be shown. gtkglsink's default is
+/// 5 ms — tighter than one display refresh. A frame 15 ms late is still the newest picture
+/// there is; dropping it only lengthens the previous one.
+const LATE_TOLERANCE_NS: i64 = 20_000_000;
 
 /// The GL displays of every sink this process ran, kept alive on purpose. gtkglsink's
 /// widget wraps GDK's EGLDisplay in a GstGLDisplayEGL it considers its OWN
@@ -135,6 +154,18 @@ impl LinuxVideoSink {
         appsrc.set_property_from_str("leaky-type", "downstream");
         let parse = make(parser)?;
         let decode = make("decodebin3")?;
+        // Name the decoder decodebin3 settles on — the one line that tells a Pi log whether the
+        // hardware block (`v4l2slh265dec`) or software (`avdec_*`) does the work.
+        if let Some(bin) = decode.downcast_ref::<gst::Bin>() {
+            bin.connect_deep_element_added(|_, _, el| {
+                if let Some(f) = el.factory() {
+                    let klass = f.metadata(gst::ELEMENT_METADATA_KLASS).unwrap_or("");
+                    if klass.contains("Decoder") && klass.contains("Video") {
+                        log::info!("[video] linux sink: decoder {}", f.name());
+                    }
+                }
+            });
+        }
 
         // The post-decode leg: GL (zero-copy import where the decoder offers DMABuf) or cairo.
         let (chain, flip, sink) = if gl {
@@ -151,6 +182,9 @@ impl LinuxVideoSink {
         };
         // Latency first: render on decode. `set_buffer` flips this for the paced depths.
         sink.set_property("sync", false);
+        // Paced mode only (no effect while unsynced): see the two constants above.
+        sink.set_property("max-lateness", LATE_TOLERANCE_NS);
+        sink.set_property("qos", false);
 
         pipeline
             .add_many([appsrc.upcast_ref::<gst::Element>(), &parse, &decode])
@@ -273,7 +307,7 @@ impl LinuxVideoSink {
         p.last_media = Some(media_ns);
 
         let now = self.running_time();
-        let lead = depth as u64 * p.interval;
+        let lead = if depth > 0 { depth as u64 * p.interval + PROCESSING_ALLOWANCE_NS } else { 0 };
         let target = match p.anchor {
             Some((a_run, a_media, a_depth)) if a_depth == depth => {
                 (a_run as i64 + (media_ns as i64 - a_media as i64)).max(0) as u64

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -666,6 +666,7 @@
     "reconnectStop": "Спри",
     "rtspMobilePlaceholder": "RTSP все още не е наличен на това устройство — стрийминг машината не може да работи на мобилни устройства, а специфичен за устройството RTSP път предстои.",
     "engineMissing": "Механизмът за поточно предаване MediaMTX е необходим за RTSP и все още не е инсталиран.",
+    "invalidRtspUrl": "Това не е RTSP адрес — трябва да започва с rtsp:// (или rtsps://).",
     "engineDownload": "Изтегли MediaMTX",
     "engineReady": "MediaMTX готов",
     "ffmpegFallbackMissing": "По избор: ffmpeg позволява резервен четец за източници, които MediaMTX не може да чете директно (напр. някои OBS RTSP сървъри).",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -669,6 +669,7 @@
     "reconnectStop": "Stopp",
     "rtspMobilePlaceholder": "RTSP ist auf diesem Gerät noch nicht verfügbar — die Streaming-Engine kann auf Mobilgeräten nicht laufen, ein gerätespezifischer RTSP-Weg kommt noch.",
     "engineMissing": "Die Streaming-Engine MediaMTX wird für RTSP benötigt und ist noch nicht installiert.",
+    "invalidRtspUrl": "Das ist keine RTSP-Adresse – sie muss mit rtsp:// (oder rtsps://) beginnen.",
     "engineDownload": "MediaMTX herunterladen",
     "engineReady": "MediaMTX bereit",
     "ffmpegFallbackMissing": "Optional: ffmpeg ermöglicht einen Fallback-Reader für Quellen, die MediaMTX nicht nativ lesen kann (z. B. manche OBS-RTSP-Server).",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -669,6 +669,7 @@
     "reconnectStop": "Stop",
     "rtspMobilePlaceholder": "RTSP is not available on this device yet — the streaming engine cannot run on mobile, and a device-native RTSP path is still to come.",
     "engineMissing": "The MediaMTX streaming engine is required for RTSP and isn't installed yet.",
+    "invalidRtspUrl": "That is not an RTSP address — it has to start with rtsp:// (or rtsps://).",
     "engineDownload": "Download MediaMTX",
     "engineReady": "MediaMTX ready",
     "ffmpegFallbackMissing": "Optional: ffmpeg enables a fallback reader for sources MediaMTX can't read natively (e.g. some OBS RTSP servers).",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -648,6 +648,7 @@
     "bufferHint": "0 = latence minimale. Chaque cran ajoute une durée d'image de mise en mémoire tampon — lecture plus fluide sur les liaisons instables, au prix de la latence.",
     "rtspMobilePlaceholder": "RTSP n'est pas encore disponible sur cet appareil — le moteur de streaming ne peut pas fonctionner sur mobile ; une voie RTSP native à l'appareil reste à venir.",
     "engineMissing": "Le moteur de streaming MediaMTX est requis pour RTSP et n'est pas encore installé.",
+    "invalidRtspUrl": "Ce n'est pas une adresse RTSP — elle doit commencer par rtsp:// (ou rtsps://).",
     "engineDownload": "Télécharger MediaMTX",
     "engineReady": "MediaMTX prêt",
     "ffmpegFallbackMissing": "Optionnel : ffmpeg active un lecteur de secours pour les sources que MediaMTX ne peut pas lire nativement (p. ex. certains serveurs RTSP OBS).",

--- a/src/lib/i18n/locales/zh.json
+++ b/src/lib/i18n/locales/zh.json
@@ -666,6 +666,7 @@
     "reconnectStop": "停止",
     "rtspMobilePlaceholder": "RTSP 在此设备上尚不可用——流媒体引擎无法在移动设备上运行，设备原生的 RTSP 方案仍在计划中。",
     "engineMissing": "RTSP需要MediaMTX流媒体引擎，尚未安装。",
+    "invalidRtspUrl": "这不是 RTSP 地址——必须以 rtsp://（或 rtsps://）开头。",
     "engineDownload": "下载 MediaMTX",
     "engineReady": "MediaMTX 就绪",
     "ffmpegFallbackMissing": "可选：ffmpeg 可为 MediaMTX 无法原生读取的源提供备用读取器（例如某些OBS RTSP服务器）。",

--- a/src/lib/stores/video.ts
+++ b/src/lib/stores/video.ts
@@ -1395,6 +1395,12 @@ async function negotiateRtsp(url: string, transport: RtspTransport): Promise<voi
   }
 }
 
+/** Trim, and repair the one typo that is unmistakable: a single slash after the scheme
+ *  (`rtsp:/host` → `rtsp://host`). Anything else is left for the validity check. */
+function normalizeRtspUrl(raw: string): string {
+  return raw.trim().replace(/^(rtsps?):\/(?!\/)/i, '$1://');
+}
+
 /** Open (or re-open) the RTSP feed via the engine, honouring the active transport. Once live, a stall
  *  monitor watches for frame timeouts; any failure/drop enters the infinite reconnect loop (until
  *  frames return or the user stops). `reconnect` distinguishes a loop retry from a fresh start. */
@@ -1403,12 +1409,21 @@ export async function startRtsp(opts?: { reconnect?: boolean }): Promise<void> {
   clearRtspTimers();
   stopTracks(); // release the camera / previous peer connection
   const st = get(videoState);
-  const url = st.rtspUrl.trim();
+  const url = normalizeRtspUrl(st.rtspUrl);
   const transport = st.rtspTransport;
   if (!url) {
     patch({ kind: 'rtsp', enabled: true, status: 'error', error: 'No RTSP URL', reconnecting: false, reconnectAttempt: 0 });
     return;
   }
+  // Not an RTSP address at all: a dead end no reconnect can fix, so it must not enter the loop
+  // (the field case was `rtsp:/host` — the backend refused it and the loop retried it forever,
+  // which read as "the stream never comes up").
+  if (!/^rtsps?:\/\//i.test(url)) {
+    logVideo('warn', `RTSP start refused — not an RTSP URL: ${url}`);
+    patch({ kind: 'rtsp', enabled: true, status: 'error', error: get(t)('video.invalidRtspUrl'), reconnecting: false, reconnectAttempt: 0 });
+    return;
+  }
+  if (url !== st.rtspUrl) patch({ rtspUrl: url }); // the repaired form is what the field shows
   patch({
     kind: 'rtsp',
     enabled: true,
@@ -1430,8 +1445,12 @@ export async function startRtsp(opts?: { reconnect?: boolean }): Promise<void> {
   // RTSP/RTP stack (MJPEG → multipart, H264/HEVC → hardware decode sink).
   if (st.rtspNativeClient) {
     // Toggled over from the classic path mid-run? The engine would keep pulling the
-    // source in the background (a second client on it) — release it first.
+    // source in the background (a second client on it) — release it first. And the image
+    // path's ffmpeg with it: on a WebView without WebRTC (Linux) the classic path IS that
+    // transcode, and it kept running under the native client — a second RTSP session on the
+    // source and two software decodes on one small board (the Pi 5 field report: artefacts).
     void invoke('video_webrtc_stop').catch(() => {});
+    void stopNativeMjpeg();
     if (!reconnect) logVideo('info', `RTSP start ${url} (transport=${transport}, engine=kite-native)`);
     if ((await startKiteRtspPath(url, transport)) === 'retry') scheduleRtspReconnect();
     return;


### PR DESCRIPTION
**Regression: introduced by PR #89 (Linux native RTSP sink) / the native-client toggle, never released** — except the malformed-URL loop, which the classic path has had since 1.0.

Diagnosed on Marc's Pi 5 ("Jarvis", Raspberry Pi OS Trixie, GStreamer 1.26.2, WebKitGTK 2.52.5) from the field logs, `~/.xsession-errors` and gst-launch measurements over SSH. Four separate things, none of them the decoder.

## 1. HEVC aborted the process on stream start

`GStreamer-GL:ERROR: gstglformat.c:273: gst_gl_format_from_video_info: code should not be reached` (twice in `~/.xsession-errors`). The Pi 5 HEVC block (`v4l2slh265dec`, rank primary+1) outputs tiled `NV12_128C8`; GTK3 gives gtkglsink a **desktop GL 3.1 legacy** context (measured with a GtkGLArea: `use_es=False`), which has no direct DMABuf import — gst-gl took the per-plane path and asserted. With `GDK_GL=gles` the context is GLES 3.1 and the same chain imports the buffer directly (`texture-target=external-oes`, `drm-format=NV12:0x0700000000000004`): 720p60 at 60 fps, zero-copy. Set at startup on Linux unless the user set it; nothing else in the process uses GDK's GL (WebKitGTK renders through its own EGL).

## 2. Paced mode collapsed (1 fps at 720p60, multi-second freezes at 720p30, 30–40 % CPU)

The Pi had `rtspBufferFrames: 1` persisted → `sync=true`, and every session logs the sink's QoS warnings. The cushion is judged at the sink *after* decode + GL upload, gtkglsink's `max-lateness` default is 5 ms, and the sink's QoS events made avdec skip frames on top — the cascade. Now a 20 ms processing allowance on top of `depth × interval`, 20 ms late tolerance, `qos=false`. The decoder was never the limit: `avdec_h264` 720p30 = 29.9 fps at 27 % of one core; from a file, decode + the whole GL leg = 60 fps.

## 3. The native-client toggle left the classic ffmpeg transcode running

`startRtsp` stopped only the WebRTC engine; on a WebView without WebRTC the classic path IS the ffmpeg→MJPEG transcode, and the log shows it decoding under the native client for the whole session — a second RTSP session on the source and two software H.264 decodes on four cores. The native pipeline's leaky appsrc then dropped access units before the decoder = broken reference chains = the "massive artefacts". The toggle now calls `stopNativeMjpeg()`, as the reconnect loop already did.

## 4. `rtsp:/host` looped forever

The backend refused the single-slash URL, the frontend treated it as retryable. Every "HEVC" attempt of the first report was this — HEVC was never negotiated. The single slash is repaired (and written back into the field); anything else that is not `rtsp(s)://` is a fatal error with a message (`video.invalidRtspUrl`, five locales), no loop.

Also: the Linux sink logs the decoder decodebin3 settled on (`decoder v4l2slh265dec` / `avdec_h264`), so a Pi log says whether hardware ran.

## Verification

`npm run check` 0/0; `cargo check` on the Windows host (the Linux sink compiles on the Ubuntu CI job). Not yet run on the Pi — the pieces were verified with gst-launch, the assembled build needs the CI arm64 `.deb` on the device: HEVC 60 fps hardware, H.264 smooth with the buffer at 1, decoder line in the log. Still to check on the x86 laptop: `GDK_GL=gles` on Wayland and X11 (the cairo fallback catches a failing GL sink, but that would be a quality regression worth knowing).

Measurements and the Pi test recipe: Dev-Docs `active/RTSP_LINUX.md` → "Pi 5 pass".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
