### PR TITLE
fix(video): Pi 5 HEVC — padded streams stay zero-copy, no start-up drops, keyframe resync after loss

### DIFF
--- a/docs/user/guides/video.md
+++ b/docs/user/guides/video.md
@@ -206,6 +206,14 @@ distribution's GStreamer plugins (the **.deb** installs them automatically; else
 `gstreamer1.0-plugins-base`, `…-good`, `…-bad`, `gstreamer1.0-gtk3` and `gstreamer1.0-libav`, or your
 distro's equivalents) — if one is missing, Kite reports which GStreamer element it could not find.
 
+!!! note "Raspberry Pi 5 and HEVC"
+    The Pi 5's hardware block hands its pictures to the display without a copy only when the stream's
+    coded size equals the picture size. Encoders that pad the height — NVENC at 720p (coded 736
+    rows), every 1080p stream (coded 1088) — make the decoder copy each picture; Kite detects that from
+    the stream and renders such streams through its software compositing path instead (still
+    hardware-decoded, at a higher CPU cost). Streams without padding, e.g. x265 at 720p, keep the
+    zero-copy path.
+
 !!! warning "AppImage: video does not work there"
     The AppImage build cannot play video on either path — the AppImage's launcher environment hides
     the system's GStreamer plugins from every process inside it. Use the **.deb**, **.rpm** or the

--- a/docs/user/guides/video.md
+++ b/docs/user/guides/video.md
@@ -213,6 +213,11 @@ distro's equivalents) — if one is missing, Kite reports which GStreamer elemen
     Kite instead lets the decoder deliver the full padded picture and hides the padding rows under the
     interface, so these streams stay zero-copy as well.
 
+    The Pi 5's decoder also cannot paper over a lost picture: a picture whose reference never arrived
+    stalls it, and the Pi's kernel driver then hangs until a reboot. Kite therefore holds the video
+    after any lost packet until the next keyframe arrives — a short pause instead of a frozen decoder.
+    A **short keyframe interval** at the encoder (1 s) keeps that pause short.
+
 !!! warning "AppImage: video does not work there"
     The AppImage build cannot play video on either path — the AppImage's launcher environment hides
     the system's GStreamer plugins from every process inside it. Use the **.deb**, **.rpm** or the

--- a/docs/user/guides/video.md
+++ b/docs/user/guides/video.md
@@ -207,12 +207,11 @@ distribution's GStreamer plugins (the **.deb** installs them automatically; else
 distro's equivalents) — if one is missing, Kite reports which GStreamer element it could not find.
 
 !!! note "Raspberry Pi 5 and HEVC"
-    The Pi 5's hardware block hands its pictures to the display without a copy only when the stream's
-    coded size equals the picture size. Encoders that pad the height — NVENC at 720p (coded 736
-    rows), every 1080p stream (coded 1088) — make the decoder copy each picture; Kite detects that from
-    the stream and renders such streams through its software compositing path instead (still
-    hardware-decoded, at a higher CPU cost). Streams without padding, e.g. x265 at 720p, keep the
-    zero-copy path.
+    Encoders that pad the picture height to their block size — NVENC at 720p codes 736 rows, every
+    1080p stream codes 1088 — declare the visible part in the stream header. The Pi 5's decoder path in
+    GStreamer would copy every picture to apply that crop, which the zero-copy display cannot take.
+    Kite instead lets the decoder deliver the full padded picture and hides the padding rows under the
+    interface, so these streams stay zero-copy as well.
 
 !!! warning "AppImage: video does not work there"
     The AppImage build cannot play video on either path — the AppImage's launcher environment hides

--- a/src-tauri/src/video/linux_host.rs
+++ b/src-tauri/src/video/linux_host.rs
@@ -52,7 +52,7 @@ thread_local! {
 
 /// The clip paints the letterbox: everything in the hole that the video doesn't cover
 /// must be opaque, or the desktop shows through the transparent window.
-const CSS: &str = ".kite-video-clip { background-color: #000; }";
+const CSS: &str = ".kite-video-clip, .kite-video-base { background-color: #000; }";
 
 /// Re-host the main window's WebView inside a GtkOverlay above the video layer. Call once
 /// from Tauri's setup (the WebView exists by then). Failure leaves the window as it was and
@@ -99,6 +99,9 @@ pub(crate) fn install_tree(
     }
 
     let base = gtk::Layout::new(None::<&gtk::Adjustment>, None::<&gtk::Adjustment>);
+    // Black under the whole hole: letterbox bars outside the clip layer must not show the
+    // window theme colour.
+    base.style_context().add_class("kite-video-base");
     let clip = gtk::Layout::new(None::<&gtk::Adjustment>, None::<&gtk::Adjustment>);
     clip.style_context().add_class("kite-video-clip");
     clip.set_size_request(1, 1);

--- a/src-tauri/src/video/linux_sink.rs
+++ b/src-tauri/src/video/linux_sink.rs
@@ -15,12 +15,17 @@
 //! offers it. That import needs a GLES context (`lib.rs` asks GDK for one: a desktop-GL
 //! context cannot take the Pi 5's tiled `NV12_128C8` and gst-gl aborts on it). When the GL
 //! sink can't come up (no usable GL context) the cairo path `videoconvert → videoflip →
-//! gtksink` takes over for the rest of the process. The cairo path is also chosen per
-//! stream when the V4L2 stateless HEVC decoder would COPY its frames: a conformance-window
-//! crop (coded 1280×736 shown as 720, every 1080p) makes it convert each picture into a
-//! system-memory buffer that still carries DMABuf caps, and gst-gl aborts on that too
-//! (Pi 5, OBS/NVENC, 2026-09-05). Copied frames cost the same on either path; only the
-//! cairo one survives them.
+//! gtksink` takes over for the rest of the process.
+//!
+//! Conformance windows (`rtsp::h265_sps`): the V4L2 stateless HEVC decoder (Pi 5) COPIES
+//! every frame when the SPS crops the coded picture (NVENC 720p = coded 736, every 1080p),
+//! into a system-memory buffer that still carries DMABuf caps — gst-gl aborts on it. So for
+//! that decoder the sink strips the window from every SPS it pushes (the decoder then hands
+//! the full coded frame out zero-copy) and lays the widget out for the CODED picture such
+//! that the display part fills the aspect-fitted rect and the padding rows lie outside the
+//! visible box, hidden under the WebView. Measured on the Pi 5: 60 fps at ~23 % of one core
+//! either way; the copy path was 45–57 fps at a full core. Only an SPS that does not parse
+//! still goes cairo (the one route that survives a copied frame).
 //!
 //! Presentation: smoothing buffer 0 (the latency-first default) = `sync=false`, every
 //! decoded frame renders as soon as it exists. Depths 1–3 = `sync=true` with the frames'
@@ -45,7 +50,7 @@ use std::time::Duration;
 use gst::prelude::*;
 
 use super::linux_host;
-use super::rtsp::VideoCodec;
+use super::rtsp::{strip_window, SpsProbe, VideoCodec, Window};
 
 /// The host places the widget one main-thread hop away; the GL sink needs it there before
 /// it starts (its GL context comes from the realized GtkGLArea).
@@ -114,40 +119,59 @@ pub struct LinuxVideoSink {
     shared: Arc<Shared>,
     pacing: Mutex<Pacing>,
     bus_thread: Option<JoinHandle<()>>,
+    /// Conformance window stripped from this stream's SPS (module docs), if any.
+    window: Option<Window>,
+    geom: Mutex<Geom>,
 }
 
-/// The V4L2 stateless HEVC decoder (Pi 5) copies every frame when the SPS crops the coded
-/// picture; that copy cannot be imported by gst-gl (module docs).
-fn hw_decoder_copies_cropped_frames(codec: VideoCodec, needs_crop: Option<bool>) -> bool {
-    matches!(codec, VideoCodec::H265)
-        && needs_crop == Some(true)
-        && gst::ElementFactory::find("v4l2slh265dec").is_some()
+/// Last rect and orientation from the frontend — re-laid out when either changes.
+#[derive(Default)]
+struct Geom {
+    rect: Option<[i32; 8]>,
+    mirror: bool,
+    rotate180: bool,
 }
 
 impl LinuxVideoSink {
     /// Bring the sink up for `codec`: build the pipeline, hand its widget to the host and
     /// start decoding. GL first, cairo fallback. Decode problems after this surface through
-    /// [`Self::error`] — the same contract as the other sinks. `needs_crop` is the stream's
-    /// SPS verdict (`rtsp::au_needs_crop`); `None` = unknown, treated as no crop.
-    pub fn start(codec: VideoCodec, needs_crop: Option<bool>) -> Result<Self, String> {
+    /// [`Self::error`] — the same contract as the other sinks. `sps` is the stream's SPS
+    /// verdict (`rtsp::probe_au`); see the module docs for what a window means here.
+    pub fn start(codec: VideoCodec, sps: SpsProbe) -> Result<Self, String> {
         gst::init().map_err(|e| format!("gstreamer init: {e}"))?;
+        let v4l2_hevc = matches!(codec, VideoCodec::H265)
+            && gst::ElementFactory::find("v4l2slh265dec").is_some();
         let mut gl = !GL_UNAVAILABLE.load(Ordering::Relaxed);
-        if gl && hw_decoder_copies_cropped_frames(codec, needs_crop) {
-            log::warn!("[video] linux sink: the V4L2 HEVC decoder copies cropped frames — using the cairo sink for this stream");
-            gl = false;
+        let mut window = None;
+        match sps {
+            SpsProbe::Window(w) if v4l2_hevc => {
+                log::info!(
+                    "[video] linux sink: conformance window {}x{} -> {}x{} stripped for the V4L2 decoder; padding hidden under the WebView",
+                    w.coded_w,
+                    w.coded_h,
+                    w.display_w(),
+                    w.display_h()
+                );
+                window = Some(w);
+            }
+            SpsProbe::Unparsed if v4l2_hevc && gl => {
+                log::warn!("[video] linux sink: SPS did not parse — cairo sink for this stream (the V4L2 decoder may copy)");
+                gl = false;
+            }
+            _ => {}
         }
-        match Self::build(codec, gl) {
+        match Self::build(codec, gl, window) {
             Ok(sink) => Ok(sink),
             Err(e) if gl => {
                 log::warn!("[video] linux sink: GL sink unavailable ({e}) — using the cairo sink");
                 GL_UNAVAILABLE.store(true, Ordering::Relaxed);
-                Self::build(codec, false)
+                Self::build(codec, false, window)
             }
             Err(e) => Err(e),
         }
     }
 
-    fn build(codec: VideoCodec, gl: bool) -> Result<Self, String> {
+    fn build(codec: VideoCodec, gl: bool, window: Option<Window>) -> Result<Self, String> {
         let (parser, caps) = match codec {
             VideoCodec::H265 => ("h265parse", "video/x-h265,stream-format=byte-stream,alignment=au"),
             _ => ("h264parse", "video/x-h264,stream-format=byte-stream,alignment=au"),
@@ -295,11 +319,17 @@ impl LinuxVideoSink {
             shared,
             pacing: Mutex::new(Pacing::default()),
             bus_thread,
+            window,
+            geom: Mutex::new(Geom::default()),
         })
     }
 
     /// Queue one access unit (Annex-B) with its unwrapped 90 kHz timestamp.
     pub fn push(&self, au: Vec<u8>, ts90k: u64) {
+        let au = match self.window {
+            Some(_) => strip_window(&au).unwrap_or(au),
+            None => au,
+        };
         let media_ns = ts90k * 100_000 / 9; // 90 kHz → ns
         let pts = self.schedule(media_ns);
         let mut buffer = gst::Buffer::from_mut_slice(au);
@@ -364,7 +394,42 @@ impl LinuxVideoSink {
     /// host lays the widget out in the full box and clips it at the visible edge.
     #[allow(clippy::too_many_arguments)]
     pub fn set_rect(&self, x: i32, y: i32, w: i32, h: i32, cx: i32, cy: i32, cw: i32, ch: i32) {
-        linux_host::set_rect(x, y, w, h, cx, cy, cw, ch);
+        self.geom.lock().unwrap().rect = Some([x, y, w, h, cx, cy, cw, ch]);
+        self.apply_rect();
+    }
+
+    /// Lay the widget out. With a stripped window the DISPLAY picture is aspect-fitted into
+    /// the full box and the widget grown to the CODED picture around it, so the padding rows
+    /// fall outside the visible box; the visible box is also clipped to the fitted picture
+    /// (a letterboxed box would otherwise show the padding in its bars).
+    fn apply_rect(&self) {
+        let g = self.geom.lock().unwrap();
+        let Some([x, y, w, h, cx, cy, cw, ch]) = g.rect else { return };
+        let Some(win) = self.window else {
+            linux_host::set_rect(x, y, w, h, cx, cy, cw, ch);
+            return;
+        };
+        let (dw, dh) = (win.display_w().max(1) as f64, win.display_h().max(1) as f64);
+        let scale = (w as f64 / dw).min(h as f64 / dh);
+        let (fw, fh) = (dw * scale, dh * scale);
+        let (fx, fy) = (x as f64 + (w as f64 - fw) / 2.0, y as f64 + (h as f64 - fh) / 2.0);
+        // Flips move the padding: `horiz` and `180` swap left/right, `180` and `vert` swap
+        // top/bottom (see set_orient).
+        let left = if g.mirror != g.rotate180 { win.right } else { win.left } as f64;
+        let top = if g.rotate180 { win.bottom } else { win.top } as f64;
+        let (vx, vy) = ((cx as f64).max(fx), (cy as f64).max(fy));
+        let (vx2, vy2) = (((cx + cw) as f64).min(fx + fw), ((cy + ch) as f64).min(fy + fh));
+        let r = |v: f64| v.round() as i32;
+        linux_host::set_rect(
+            r(fx - left * scale),
+            r(fy - top * scale),
+            r(win.coded_w as f64 * scale),
+            r(win.coded_h as f64 * scale),
+            r(vx),
+            r(vy),
+            r((vx2 - vx).max(1.0)),
+            r((vy2 - vy).max(1.0)),
+        );
     }
 
     pub fn set_visible(&self, visible: bool) {
@@ -389,6 +454,14 @@ impl LinuxVideoSink {
             (true, true) => "vert", // mirror + 180° = vertical flip
         };
         self.flip.set_property_from_str("video-direction", direction);
+        {
+            let mut g = self.geom.lock().unwrap();
+            g.mirror = mirror;
+            g.rotate180 = rotate180;
+        }
+        if self.window.is_some() {
+            self.apply_rect();
+        }
     }
 
     pub fn frames_presented(&self) -> u64 {
@@ -399,7 +472,11 @@ impl LinuxVideoSink {
     pub fn picture_size(&self) -> Option<(u32, u32)> {
         let w = self.shared.width.load(Ordering::Relaxed);
         let h = self.shared.height.load(Ordering::Relaxed);
-        (w > 0 && h > 0).then_some((w, h))
+        if w == 0 || h == 0 {
+            return None;
+        }
+        // A stripped window: the decoder reports the coded size, the picture is the window.
+        Some(self.window.map_or((w, h), |win| (win.display_w(), win.display_h())))
     }
 }
 

--- a/src-tauri/src/video/linux_sink.rs
+++ b/src-tauri/src/video/linux_sink.rs
@@ -15,7 +15,12 @@
 //! offers it. That import needs a GLES context (`lib.rs` asks GDK for one: a desktop-GL
 //! context cannot take the Pi 5's tiled `NV12_128C8` and gst-gl aborts on it). When the GL
 //! sink can't come up (no usable GL context) the cairo path `videoconvert → videoflip →
-//! gtksink` takes over for the rest of the process.
+//! gtksink` takes over for the rest of the process. The cairo path is also chosen per
+//! stream when the V4L2 stateless HEVC decoder would COPY its frames: a conformance-window
+//! crop (coded 1280×736 shown as 720, every 1080p) makes it convert each picture into a
+//! system-memory buffer that still carries DMABuf caps, and gst-gl aborts on that too
+//! (Pi 5, OBS/NVENC, 2026-09-05). Copied frames cost the same on either path; only the
+//! cairo one survives them.
 //!
 //! Presentation: smoothing buffer 0 (the latency-first default) = `sync=false`, every
 //! decoded frame renders as soon as it exists. Depths 1–3 = `sync=true` with the frames'
@@ -111,13 +116,26 @@ pub struct LinuxVideoSink {
     bus_thread: Option<JoinHandle<()>>,
 }
 
+/// The V4L2 stateless HEVC decoder (Pi 5) copies every frame when the SPS crops the coded
+/// picture; that copy cannot be imported by gst-gl (module docs).
+fn hw_decoder_copies_cropped_frames(codec: VideoCodec, needs_crop: Option<bool>) -> bool {
+    matches!(codec, VideoCodec::H265)
+        && needs_crop == Some(true)
+        && gst::ElementFactory::find("v4l2slh265dec").is_some()
+}
+
 impl LinuxVideoSink {
     /// Bring the sink up for `codec`: build the pipeline, hand its widget to the host and
     /// start decoding. GL first, cairo fallback. Decode problems after this surface through
-    /// [`Self::error`] — the same contract as the other sinks.
-    pub fn start(codec: VideoCodec) -> Result<Self, String> {
+    /// [`Self::error`] — the same contract as the other sinks. `needs_crop` is the stream's
+    /// SPS verdict (`rtsp::au_needs_crop`); `None` = unknown, treated as no crop.
+    pub fn start(codec: VideoCodec, needs_crop: Option<bool>) -> Result<Self, String> {
         gst::init().map_err(|e| format!("gstreamer init: {e}"))?;
-        let gl = !GL_UNAVAILABLE.load(Ordering::Relaxed);
+        let mut gl = !GL_UNAVAILABLE.load(Ordering::Relaxed);
+        if gl && hw_decoder_copies_cropped_frames(codec, needs_crop) {
+            log::warn!("[video] linux sink: the V4L2 HEVC decoder copies cropped frames — using the cairo sink for this stream");
+            gl = false;
+        }
         match Self::build(codec, gl) {
             Ok(sink) => Ok(sink),
             Err(e) if gl => {
@@ -176,6 +194,9 @@ impl LinuxVideoSink {
             (vec![upload, convert, flip.clone(), sink.clone()], flip, sink)
         } else {
             let convert = make("videoconvert")?;
+            // All cores: single-threaded the Pi 5 converts a cropped 720p60 HEVC at 45 fps,
+            // with threads 57 (then the decoder's own copy is the limit).
+            convert.set_property("n-threads", 0u32);
             let flip = make("videoflip")?;
             let sink = make("gtksink")?;
             (vec![convert, flip.clone(), sink.clone()], flip, sink)

--- a/src-tauri/src/video/linux_sink.rs
+++ b/src-tauri/src/video/linux_sink.rs
@@ -190,9 +190,13 @@ impl LinuxVideoSink {
         appsrc.set_format(gst::Format::Time);
         appsrc.set_is_live(true);
         appsrc.set_do_timestamp(false);
-        // A decoder that can't keep up drops the OLDEST queued AUs instead of building a
-        // latency backlog (the client's frame counters make that visible).
-        appsrc.set_property("max-buffers", 8u64);
+        // Bounded: a decoder that can't keep up drops the OLDEST queued AUs instead of
+        // building a latency backlog. The bound must cover the START-UP burst — device open
+        // and negotiation take 100–150 ms, at 60 fps that is 6–9 AUs queued before the first
+        // decode; with 8 the second frame was dropped and the stateless V4L2 decoder hung on
+        // its missing reference (Pi 5, 2026-09-05). A stateless decoder never conceals a
+        // dropped AU; 120 AUs (2 s at 60 fps) only trips on a sustained overload.
+        appsrc.set_property("max-buffers", 120u64);
         appsrc.set_property_from_str("leaky-type", "downstream");
         let parse = make(parser)?;
         let decode = make("decodebin3")?;

--- a/src-tauri/src/video/linux_sink.rs
+++ b/src-tauri/src/video/linux_sink.rs
@@ -124,6 +124,13 @@ pub struct LinuxVideoSink {
     geom: Mutex<Geom>,
 }
 
+/// The machine decodes HEVC on a stateless V4L2 decoder (Pi 5): it cannot conceal a
+/// missing reference — a picture after lost data stalls it, and the stop then hangs the
+/// kernel driver. The RTSP client holds pictures until the next IRAP for such a decoder.
+pub fn hevc_decoder_is_stateless() -> bool {
+    gst::init().is_ok() && gst::ElementFactory::find("v4l2slh265dec").is_some()
+}
+
 /// Last rect and orientation from the frontend — re-laid out when either changes.
 #[derive(Default)]
 struct Geom {

--- a/src-tauri/src/video/rtsp/client.rs
+++ b/src-tauri/src/video/rtsp/client.rs
@@ -51,6 +51,9 @@ pub struct RtspConfig {
     /// Monitor's data source. `run_rtsp`'s final `RtspStats` stays the authoritative
     /// end-of-stream summary.
     pub live: Option<std::sync::Arc<LiveRtspStats>>,
+    /// H.265: after lost data hold pictures until the next IRAP — for a stateless hardware
+    /// decoder that hangs on a missing reference (Pi 5). Concealing decoders leave it off.
+    pub resync_on_loss: bool,
 }
 
 impl Default for RtspConfig {
@@ -63,6 +66,7 @@ impl Default for RtspConfig {
             user_agent: "Kite-GC".into(),
             accept: vec![VideoCodec::Mjpeg, VideoCodec::H264, VideoCodec::H265],
             live: None,
+            resync_on_loss: false,
         }
     }
 }
@@ -654,7 +658,7 @@ fn run_once(
         .to_string();
     let sdp_doc = sdp::parse(&String::from_utf8_lossy(&resp.body));
     let (media, codec, pt) = pick_video(&sdp_doc, &cfg.accept).map_err(RunErr::Msg)?;
-    let mut depack = Depack::new(codec, media.fmtp_of(pt));
+    let mut depack = Depack::new(codec, media.fmtp_of(pt), cfg.resync_on_loss);
     let setup_url = join_control(&base, media.control.as_deref());
     let aggregate_url = join_control(&base, sdp_doc.session_control.as_deref());
     log::info!(
@@ -750,11 +754,11 @@ enum Depack {
 }
 
 impl Depack {
-    fn new(codec: VideoCodec, fmtp: Option<&str>) -> Self {
+    fn new(codec: VideoCodec, fmtp: Option<&str>, resync_on_loss: bool) -> Self {
         match codec {
             VideoCodec::Mjpeg => Depack::Mjpeg(MjpegDepacketizer::new()),
             VideoCodec::H264 => Depack::H264(H264Depacketizer::new(fmtp)),
-            VideoCodec::H265 => Depack::H265(H265Depacketizer::new(fmtp)),
+            VideoCodec::H265 => Depack::H265(H265Depacketizer::new(fmtp).with_resync(resync_on_loss)),
         }
     }
 

--- a/src-tauri/src/video/rtsp/h265.rs
+++ b/src-tauri/src/video/rtsp/h265.rs
@@ -46,8 +46,14 @@ pub struct H265Depacketizer {
     last_seq: Option<u16>,
     /// VPS+SPS+PPS from the sprop-* attributes, Annex-B framed. Empty when absent.
     param_sets: Vec<u8>,
+    /// After lost data, hold every AU until the next IRAP (stateless hardware decoders —
+    /// the Pi 5 — hang on a picture whose reference never arrived; see `linux_sink`).
+    resync_on_loss: bool,
+    awaiting_irap: bool,
     pub aus: u64,
     pub damaged_aus: u64,
+    /// AUs held back while waiting for an IRAP after a loss.
+    pub resynced_aus: u64,
 }
 
 impl H265Depacketizer {
@@ -75,8 +81,24 @@ impl H265Depacketizer {
             frag_open: false,
             last_seq: None,
             param_sets,
+            resync_on_loss: false,
+            awaiting_irap: false,
             aus: 0,
             damaged_aus: 0,
+            resynced_aus: 0,
+        }
+    }
+
+    /// Hold pictures until the next IRAP whenever data was lost (`resync_on_loss`).
+    pub fn with_resync(mut self, on: bool) -> Self {
+        self.resync_on_loss = on;
+        self
+    }
+
+    fn note_loss(&mut self) {
+        if self.resync_on_loss && !self.awaiting_irap {
+            self.awaiting_irap = true;
+            log::warn!("[video] H.265: data lost — holding pictures until the next keyframe");
         }
     }
 
@@ -97,6 +119,8 @@ impl H265Depacketizer {
                 if self.au_open {
                     self.au_damaged = true;
                 }
+                // A gap between AUs is a whole lost picture — no AU gets flagged for it.
+                self.note_loss();
             }
         }
         self.last_seq = Some(pkt.sequence);
@@ -190,11 +214,24 @@ impl H265Depacketizer {
         if self.au_damaged {
             self.au_damaged = false;
             self.damaged_aus += 1;
+            self.note_loss();
             return;
         }
         let has_irap = au
             .windows(5)
             .any(|w| w[..4] == START_CODE && is_irap(nal_type(w[4])));
+        if self.awaiting_irap {
+            if has_irap {
+                self.awaiting_irap = false;
+                log::info!(
+                    "[video] H.265: keyframe reached, {} pictures held back",
+                    self.resynced_aus
+                );
+            } else {
+                self.resynced_aus += 1;
+                return;
+            }
+        }
         let has_sps = contains_nal_type(&au, 33);
         let mut emit = Vec::with_capacity(self.param_sets.len() + au.len());
         if has_irap && !has_sps && !self.param_sets.is_empty() {
@@ -243,6 +280,43 @@ mod tests {
             vec![annexb(&[&aud, &slice])]
         );
         assert_eq!(d.aus, 1);
+    }
+
+    /// IDR_W_RADL slice (type 19): header [0x26, 0x01].
+    fn idr(data: &[u8]) -> Vec<u8> {
+        let mut n = vec![0x26, 0x01];
+        n.extend_from_slice(data);
+        n
+    }
+
+    #[test]
+    fn resync_holds_pictures_until_the_next_irap_after_a_loss() {
+        let mut d = H265Depacketizer::new(None).with_resync(true);
+        let p = trail(&[1]);
+        assert_eq!(d.push(&pkt(1, 10, true, p.clone())).len(), 1);
+        // seq 2 lost between AUs: a whole picture is missing → hold until an IRAP.
+        assert!(d.push(&pkt(3, 20, true, p.clone())).is_empty());
+        assert!(d.push(&pkt(4, 30, true, p.clone())).is_empty());
+        let k = idr(&[7]);
+        assert_eq!(d.push(&pkt(5, 40, true, k.clone())), vec![annexb(&[&k])]);
+        assert_eq!(d.push(&pkt(6, 50, true, p.clone())), vec![annexb(&[&p])]);
+        assert_eq!((d.aus, d.damaged_aus, d.resynced_aus), (3, 0, 2));
+
+        // A torn AU (gap inside it) is dropped AND starts the hold.
+        assert!(d.push(&pkt(7, 60, false, p.clone())).is_empty());
+        assert!(d.push(&pkt(9, 60, true, p.clone())).is_empty());
+        assert!(d.push(&pkt(10, 70, true, p.clone())).is_empty());
+        assert_eq!(d.push(&pkt(11, 80, true, k.clone())), vec![annexb(&[&k])]);
+        assert_eq!((d.damaged_aus, d.resynced_aus), (1, 3));
+    }
+
+    #[test]
+    fn without_resync_a_loss_only_drops_the_torn_au() {
+        let mut d = H265Depacketizer::new(None);
+        let p = trail(&[1]);
+        assert_eq!(d.push(&pkt(1, 10, true, p.clone())).len(), 1);
+        assert_eq!(d.push(&pkt(3, 20, true, p.clone())).len(), 1); // gap between AUs: delivered
+        assert_eq!(d.resynced_aus, 0);
     }
 
     #[test]

--- a/src-tauri/src/video/rtsp/h265_sps.rs
+++ b/src-tauri/src/video/rtsp/h265_sps.rs
@@ -286,6 +286,9 @@ mod tests {
     // x265 1280×730 — coded 736, window bottom 6.
     const X265_730_SPS: &str = "420101016000000300900000030000030078a00280802e1f265ba4a4c2f0168080000003008000001e04";
     const X265_730_SPS_STRIPPED: &str = "420101016000000300900000030000030078a00280802e165ba4a4c2f0168080000003008000001e04";
+    // OBS/NVENC 1280×720 with B-frames off (2026-09-05 evening stream), Python reference.
+    const OBS2_SPS: &str = "420101016000000300900000030000030078a00280802e1f13965d29084645d50c05a80808082000000300200000078c00bbca20001ab3f00002625a08";
+    const OBS2_SPS_STRIPPED: &str = "420101016000000300900000030000030078a00280802e165974a4211917543016a020202080000003008000001e3002ef2880006acfc00009896820";
 
     #[test]
     fn real_encoders() {
@@ -301,7 +304,11 @@ mod tests {
 
     #[test]
     fn strip_matches_the_reference_bytes_and_reprobes_as_no_window() {
-        for (sps, stripped) in [(OBS_SPS, OBS_SPS_STRIPPED), (X265_730_SPS, X265_730_SPS_STRIPPED)] {
+        for (sps, stripped) in [
+            (OBS_SPS, OBS_SPS_STRIPPED),
+            (OBS2_SPS, OBS2_SPS_STRIPPED),
+            (X265_730_SPS, X265_730_SPS_STRIPPED),
+        ] {
             let au = strip_window(&au_with(&hex(sps))).expect("has an SPS");
             assert_eq!(au, au_with(&hex(stripped)));
             assert_eq!(probe_au(&au), SpsProbe::NoWindow);

--- a/src-tauri/src/video/rtsp/h265_sps.rs
+++ b/src-tauri/src/video/rtsp/h265_sps.rs
@@ -1,16 +1,86 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Marc Hoffmann (b14ckyy)
 
-//! H.265 SPS probe: does the sequence carry a conformance-window crop? (Coded 1280×736
-//! shown as 1280×720, every 1080p stream.) The Linux sink needs to know before it builds
-//! the pipeline — see `linux_sink` for why.
+//! H.265 SPS conformance window: probe it, and strip it. An encoder that pads the picture
+//! to its block size (NVENC 720p → coded 1280×736, every 1080p → 1088) declares the visible
+//! part as a window; the Pi 5's V4L2 decoder implements that crop as a CPU copy the GL path
+//! cannot take (see `linux_sink`). Without the window the decoder hands the full coded frame
+//! out zero-copy and the sink hides the padding under the WebView instead.
 
 const START_CODE: [u8; 4] = [0, 0, 0, 1];
 const NAL_SPS: u8 = 33;
 
-/// `Some(true)` when the SPS in this Annex-B access unit crops the coded picture,
-/// `Some(false)` when it does not, `None` without a parseable SPS.
-pub fn au_needs_crop(annexb: &[u8]) -> Option<bool> {
+/// Conformance window of a sequence, in luma pixels.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Window {
+    pub coded_w: u32,
+    pub coded_h: u32,
+    pub left: u32,
+    pub top: u32,
+    pub right: u32,
+    pub bottom: u32,
+}
+
+impl Window {
+    pub fn display_w(&self) -> u32 {
+        self.coded_w.saturating_sub(self.left + self.right)
+    }
+    pub fn display_h(&self) -> u32 {
+        self.coded_h.saturating_sub(self.top + self.bottom)
+    }
+}
+
+/// What an access unit's SPS says about cropping.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpsProbe {
+    /// No SPS in this AU.
+    NoSps,
+    /// An SPS is there but did not parse — treat the stream as unknown.
+    Unparsed,
+    /// The coded picture is the picture.
+    NoWindow,
+    /// The SPS crops the coded picture.
+    Window(Window),
+}
+
+/// Probe the first SPS of an Annex-B access unit.
+pub fn probe_au(annexb: &[u8]) -> SpsProbe {
+    let Some((start, end)) = find_sps(annexb) else { return SpsProbe::NoSps };
+    match parse_sps(&annexb[start..end]) {
+        Some(p) if p.window_flag_bit.is_some() => match p.window {
+            Some(w) if w.left | w.top | w.right | w.bottom != 0 => SpsProbe::Window(w),
+            _ => SpsProbe::NoWindow,
+        },
+        Some(_) => SpsProbe::NoWindow,
+        None => SpsProbe::Unparsed,
+    }
+}
+
+/// The AU with every SPS rewritten to declare no conformance window (the coded size becomes
+/// the picture size). `None` when the AU carries no SPS — push it unchanged.
+pub fn strip_window(annexb: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(annexb.len());
+    let mut pos = 0;
+    let mut touched = false;
+    while let Some((start, end)) = find_sps(&annexb[pos..]) {
+        let (start, end) = (pos + start, pos + end);
+        out.extend_from_slice(&annexb[pos..start]);
+        match rewrite_sps(&annexb[start..end]) {
+            Some(nal) => out.extend_from_slice(&nal),
+            None => out.extend_from_slice(&annexb[start..end]),
+        }
+        touched = true;
+        pos = end;
+    }
+    if !touched {
+        return None;
+    }
+    out.extend_from_slice(&annexb[pos..]);
+    Some(out)
+}
+
+/// Byte range of the first SPS NAL (header included, start code excluded).
+fn find_sps(annexb: &[u8]) -> Option<(usize, usize)> {
     let start = annexb
         .windows(5)
         .position(|w| w[..4] == START_CODE && (w[4] >> 1) & 0x3F == NAL_SPS)?
@@ -21,11 +91,20 @@ pub fn au_needs_crop(annexb: &[u8]) -> Option<bool> {
         .position(|w| w == [0, 0, 1])
         .map(|p| p.saturating_sub(1))
         .unwrap_or(rest.len());
-    sps_needs_crop(&rest[..end])
+    Some((start, start + end))
+}
+
+struct ParsedSps {
+    rbsp: Vec<u8>,
+    /// Bit offset of `conformance_window_flag`, if the header parsed that far.
+    window_flag_bit: Option<usize>,
+    /// Bit offset right after the four window offsets (or after a zero flag).
+    after_window_bit: usize,
+    window: Option<Window>,
 }
 
 /// `nal` = the SPS NAL including its two header bytes.
-fn sps_needs_crop(nal: &[u8]) -> Option<bool> {
+fn parse_sps(nal: &[u8]) -> Option<ParsedSps> {
     let rbsp = strip_emulation(nal.get(2..)?);
     let mut r = BitReader::new(&rbsp);
     r.bits(4)?; // sps_video_parameter_set_id
@@ -33,16 +112,60 @@ fn sps_needs_crop(nal: &[u8]) -> Option<bool> {
     r.bits(1)?; // sps_temporal_id_nesting_flag
     profile_tier_level(&mut r, max_sub_layers_minus1)?;
     r.ue()?; // sps_seq_parameter_set_id
-    if r.ue()? == 3 {
+    let chroma_format_idc = r.ue()?;
+    if chroma_format_idc == 3 {
         r.bits(1)?; // separate_colour_plane_flag
     }
-    r.ue()?; // pic_width_in_luma_samples
-    r.ue()?; // pic_height_in_luma_samples
-    if r.bits(1)? == 0 {
-        return Some(false);
+    let coded_w = r.ue()?;
+    let coded_h = r.ue()?;
+    let window_flag_bit = r.pos;
+    let mut window = None;
+    if r.bits(1)? == 1 {
+        let (sub_w, sub_h) = match chroma_format_idc {
+            1 => (2, 2),
+            2 => (2, 1),
+            _ => (1, 1),
+        };
+        let (left, right, top, bottom) = (r.ue()?, r.ue()?, r.ue()?, r.ue()?);
+        window = Some(Window {
+            coded_w,
+            coded_h,
+            left: left * sub_w,
+            right: right * sub_w,
+            top: top * sub_h,
+            bottom: bottom * sub_h,
+        });
     }
-    let offsets = [r.ue()?, r.ue()?, r.ue()?, r.ue()?];
-    Some(offsets.iter().any(|&o| o != 0))
+    let after_window_bit = r.pos;
+    Some(ParsedSps { rbsp, window_flag_bit: Some(window_flag_bit), after_window_bit, window })
+}
+
+/// The SPS NAL with `conformance_window_flag = 0` and the offsets removed; `None` when it
+/// has no window or does not parse.
+fn rewrite_sps(nal: &[u8]) -> Option<Vec<u8>> {
+    let p = parse_sps(nal)?;
+    p.window?;
+    let flag = p.window_flag_bit?;
+    let total = p.rbsp.len() * 8;
+    // rbsp_trailing_bits: the stop bit is the last 1 in the payload.
+    let stop = (0..total).rev().find(|&i| bit(&p.rbsp, i) == 1)?;
+    if p.after_window_bit > stop {
+        return None;
+    }
+    let mut bits: Vec<u8> = (0..flag).map(|i| bit(&p.rbsp, i)).collect();
+    bits.push(0);
+    bits.extend((p.after_window_bit..=stop).map(|i| bit(&p.rbsp, i)));
+    while bits.len() % 8 != 0 {
+        bits.push(0);
+    }
+    let body: Vec<u8> = bits.chunks(8).map(|c| c.iter().fold(0u8, |acc, &b| (acc << 1) | b)).collect();
+    let mut out = nal[..2].to_vec();
+    out.extend(add_emulation(&body));
+    Some(out)
+}
+
+fn bit(data: &[u8], i: usize) -> u8 {
+    (data[i / 8] >> (7 - i % 8)) & 1
 }
 
 fn profile_tier_level(r: &mut BitReader, max_sub_layers_minus1: usize) -> Option<()> {
@@ -75,6 +198,21 @@ fn strip_emulation(data: &[u8]) -> Vec<u8> {
         if zeros >= 2 && b == 3 {
             zeros = 0;
             continue;
+        }
+        out.push(b);
+        zeros = if b == 0 { zeros + 1 } else { 0 };
+    }
+    out
+}
+
+/// Emulation-prevention insertion: `00 00 {00..03}` → `00 00 03 {..}`.
+fn add_emulation(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len() + 4);
+    let mut zeros = 0usize;
+    for &b in data {
+        if zeros >= 2 && b <= 3 {
+            out.push(3);
+            zeros = 0;
         }
         out.push(b);
         zeros = if b == 0 { zeros + 1 } else { 0 };
@@ -139,31 +277,51 @@ mod tests {
         au
     }
 
-    // OBS (NVENC) 1280×720: coded 1280×736, conformance window bottom offset.
+    // OBS (NVENC) 1280×720: coded 1280×736, window bottom 16.
     const OBS_SPS: &str = "420101016000000300900000030000030078a00280802e1f1396554a4211917543016a02020208000003000800000301e3002ef2880006acfc0000989682";
+    // The same SPS without the window (independent Python bit surgery, ffprobe-verified 1280×736).
+    const OBS_SPS_STRIPPED: &str = "420101016000000300900000030000030078a00280802e16595529084645d50c05a80808082000000300200000078c00bbca20001ab3f00002625a08";
     // x265 1280×720 — coded size equals the picture, no window.
     const X265_720_SPS: &str = "420101016000000300900000030000030078a00280802d165ba4a4c2f0168080000003008000001e04";
-    // x265 1280×730 — coded 736, window crops 6 rows.
+    // x265 1280×730 — coded 736, window bottom 6.
     const X265_730_SPS: &str = "420101016000000300900000030000030078a00280802e1f265ba4a4c2f0168080000003008000001e04";
+    const X265_730_SPS_STRIPPED: &str = "420101016000000300900000030000030078a00280802e165ba4a4c2f0168080000003008000001e04";
 
     #[test]
     fn real_encoders() {
-        assert_eq!(au_needs_crop(&au_with(&hex(OBS_SPS))), Some(true));
-        assert_eq!(au_needs_crop(&au_with(&hex(X265_720_SPS))), Some(false));
-        assert_eq!(au_needs_crop(&au_with(&hex(X265_730_SPS))), Some(true));
+        let obs = Window { coded_w: 1280, coded_h: 736, left: 0, top: 0, right: 0, bottom: 16 };
+        assert_eq!(probe_au(&au_with(&hex(OBS_SPS))), SpsProbe::Window(obs));
+        assert_eq!((obs.display_w(), obs.display_h()), (1280, 720));
+        assert_eq!(probe_au(&au_with(&hex(X265_720_SPS))), SpsProbe::NoWindow);
+        assert_eq!(
+            probe_au(&au_with(&hex(X265_730_SPS))),
+            SpsProbe::Window(Window { coded_w: 1280, coded_h: 736, left: 0, top: 0, right: 0, bottom: 6 })
+        );
     }
 
     #[test]
-    fn no_sps_or_truncated_is_unknown() {
-        assert_eq!(au_needs_crop(&[0, 0, 0, 1, 0x26, 0x01, 0xaf]), None);
+    fn strip_matches_the_reference_bytes_and_reprobes_as_no_window() {
+        for (sps, stripped) in [(OBS_SPS, OBS_SPS_STRIPPED), (X265_730_SPS, X265_730_SPS_STRIPPED)] {
+            let au = strip_window(&au_with(&hex(sps))).expect("has an SPS");
+            assert_eq!(au, au_with(&hex(stripped)));
+            assert_eq!(probe_au(&au), SpsProbe::NoWindow);
+        }
+        // No window → bytes untouched; no SPS → None.
+        let plain = au_with(&hex(X265_720_SPS));
+        assert_eq!(strip_window(&plain), Some(plain.clone()));
+        assert_eq!(strip_window(&[0, 0, 0, 1, 0x26, 0x01, 0xaf]), None);
+    }
+
+    #[test]
+    fn no_sps_or_truncated() {
+        assert_eq!(probe_au(&[0, 0, 0, 1, 0x26, 0x01, 0xaf]), SpsProbe::NoSps);
         let mut short = hex(OBS_SPS);
         short.truncate(14); // ends inside profile_tier_level
-        assert_eq!(au_needs_crop(&au_with(&short)), None);
+        assert_eq!(probe_au(&au_with(&short)), SpsProbe::Unparsed);
     }
 
     #[test]
-    fn a_window_with_zero_offsets_is_no_crop() {
-        // Hand-built SPS, one sub-layer: window flag set, all four offsets zero.
+    fn a_window_with_zero_offsets_is_no_window() {
         let mut w = BitWriter::default();
         w.bits(0x42 << 8 | 0x01, 16); // NAL header
         w.bits(0, 4);
@@ -179,7 +337,7 @@ mod tests {
             w.ue(0);
         }
         w.bits(1, 1); // rbsp trailing
-        assert_eq!(au_needs_crop(&au_with(&w.emulated())), Some(false));
+        assert_eq!(probe_au(&au_with(&w.emulated())), SpsProbe::NoWindow);
     }
 
     #[derive(Default)]
@@ -199,27 +357,13 @@ mod tests {
             self.bits(0, len - 1);
             self.bits(x, len);
         }
-        /// Bytes with emulation-prevention inserted, as an encoder would.
         fn emulated(&self) -> Vec<u8> {
-            let mut raw = Vec::new();
-            for chunk in self.bits.chunks(8) {
-                let mut b = 0u8;
-                for (i, bit) in chunk.iter().enumerate() {
-                    b |= (*bit as u8) << (7 - i);
-                }
-                raw.push(b);
-            }
-            let mut out = Vec::new();
-            let mut zeros = 0;
-            for b in raw {
-                if zeros >= 2 && b <= 3 {
-                    out.push(3);
-                    zeros = 0;
-                }
-                out.push(b);
-                zeros = if b == 0 { zeros + 1 } else { 0 };
-            }
-            out
+            let raw: Vec<u8> = self
+                .bits
+                .chunks(8)
+                .map(|c| c.iter().enumerate().fold(0u8, |acc, (i, b)| acc | ((*b as u8) << (7 - i))))
+                .collect();
+            add_emulation(&raw)
         }
     }
 }

--- a/src-tauri/src/video/rtsp/h265_sps.rs
+++ b/src-tauri/src/video/rtsp/h265_sps.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+//! H.265 SPS probe: does the sequence carry a conformance-window crop? (Coded 1280×736
+//! shown as 1280×720, every 1080p stream.) The Linux sink needs to know before it builds
+//! the pipeline — see `linux_sink` for why.
+
+const START_CODE: [u8; 4] = [0, 0, 0, 1];
+const NAL_SPS: u8 = 33;
+
+/// `Some(true)` when the SPS in this Annex-B access unit crops the coded picture,
+/// `Some(false)` when it does not, `None` without a parseable SPS.
+pub fn au_needs_crop(annexb: &[u8]) -> Option<bool> {
+    let start = annexb
+        .windows(5)
+        .position(|w| w[..4] == START_CODE && (w[4] >> 1) & 0x3F == NAL_SPS)?
+        + 4;
+    let rest = &annexb[start..];
+    let end = rest
+        .windows(3)
+        .position(|w| w == [0, 0, 1])
+        .map(|p| p.saturating_sub(1))
+        .unwrap_or(rest.len());
+    sps_needs_crop(&rest[..end])
+}
+
+/// `nal` = the SPS NAL including its two header bytes.
+fn sps_needs_crop(nal: &[u8]) -> Option<bool> {
+    let rbsp = strip_emulation(nal.get(2..)?);
+    let mut r = BitReader::new(&rbsp);
+    r.bits(4)?; // sps_video_parameter_set_id
+    let max_sub_layers_minus1 = r.bits(3)? as usize;
+    r.bits(1)?; // sps_temporal_id_nesting_flag
+    profile_tier_level(&mut r, max_sub_layers_minus1)?;
+    r.ue()?; // sps_seq_parameter_set_id
+    if r.ue()? == 3 {
+        r.bits(1)?; // separate_colour_plane_flag
+    }
+    r.ue()?; // pic_width_in_luma_samples
+    r.ue()?; // pic_height_in_luma_samples
+    if r.bits(1)? == 0 {
+        return Some(false);
+    }
+    let offsets = [r.ue()?, r.ue()?, r.ue()?, r.ue()?];
+    Some(offsets.iter().any(|&o| o != 0))
+}
+
+fn profile_tier_level(r: &mut BitReader, max_sub_layers_minus1: usize) -> Option<()> {
+    r.skip(88 + 8)?; // general profile + general_level_idc
+    let mut profile_present = [false; 8];
+    let mut level_present = [false; 8];
+    for i in 0..max_sub_layers_minus1 {
+        profile_present[i] = r.bits(1)? == 1;
+        level_present[i] = r.bits(1)? == 1;
+    }
+    if max_sub_layers_minus1 > 0 {
+        r.skip(2 * (8 - max_sub_layers_minus1))?; // reserved_zero_2bits
+    }
+    for i in 0..max_sub_layers_minus1 {
+        if profile_present[i] {
+            r.skip(88)?;
+        }
+        if level_present[i] {
+            r.skip(8)?;
+        }
+    }
+    Some(())
+}
+
+/// Emulation-prevention removal: `00 00 03` → `00 00`.
+fn strip_emulation(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    let mut zeros = 0usize;
+    for &b in data {
+        if zeros >= 2 && b == 3 {
+            zeros = 0;
+            continue;
+        }
+        out.push(b);
+        zeros = if b == 0 { zeros + 1 } else { 0 };
+    }
+    out
+}
+
+struct BitReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> BitReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn bits(&mut self, n: usize) -> Option<u32> {
+        let mut v = 0u32;
+        for _ in 0..n {
+            let byte = *self.data.get(self.pos / 8)?;
+            v = (v << 1) | ((byte >> (7 - self.pos % 8)) & 1) as u32;
+            self.pos += 1;
+        }
+        Some(v)
+    }
+
+    fn skip(&mut self, n: usize) -> Option<()> {
+        if self.pos + n > self.data.len() * 8 {
+            return None;
+        }
+        self.pos += n;
+        Some(())
+    }
+
+    /// Exp-Golomb `ue(v)`.
+    fn ue(&mut self) -> Option<u32> {
+        let mut zeros = 0;
+        while self.bits(1)? == 0 {
+            zeros += 1;
+            if zeros > 31 {
+                return None;
+            }
+        }
+        Some((1u32 << zeros) - 1 + self.bits(zeros)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex(s: &str) -> Vec<u8> {
+        (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap()).collect()
+    }
+
+    fn au_with(sps: &[u8]) -> Vec<u8> {
+        let mut au = vec![0, 0, 0, 1, 0x40, 0x01, 0x0c]; // a VPS first
+        au.extend_from_slice(&START_CODE);
+        au.extend_from_slice(sps);
+        au.extend_from_slice(&[0, 0, 0, 1, 0x26, 0x01, 0xaf]); // then an IDR
+        au
+    }
+
+    // OBS (NVENC) 1280×720: coded 1280×736, conformance window bottom offset.
+    const OBS_SPS: &str = "420101016000000300900000030000030078a00280802e1f1396554a4211917543016a02020208000003000800000301e3002ef2880006acfc0000989682";
+    // x265 1280×720 — coded size equals the picture, no window.
+    const X265_720_SPS: &str = "420101016000000300900000030000030078a00280802d165ba4a4c2f0168080000003008000001e04";
+    // x265 1280×730 — coded 736, window crops 6 rows.
+    const X265_730_SPS: &str = "420101016000000300900000030000030078a00280802e1f265ba4a4c2f0168080000003008000001e04";
+
+    #[test]
+    fn real_encoders() {
+        assert_eq!(au_needs_crop(&au_with(&hex(OBS_SPS))), Some(true));
+        assert_eq!(au_needs_crop(&au_with(&hex(X265_720_SPS))), Some(false));
+        assert_eq!(au_needs_crop(&au_with(&hex(X265_730_SPS))), Some(true));
+    }
+
+    #[test]
+    fn no_sps_or_truncated_is_unknown() {
+        assert_eq!(au_needs_crop(&[0, 0, 0, 1, 0x26, 0x01, 0xaf]), None);
+        let mut short = hex(OBS_SPS);
+        short.truncate(14); // ends inside profile_tier_level
+        assert_eq!(au_needs_crop(&au_with(&short)), None);
+    }
+
+    #[test]
+    fn a_window_with_zero_offsets_is_no_crop() {
+        // Hand-built SPS, one sub-layer: window flag set, all four offsets zero.
+        let mut w = BitWriter::default();
+        w.bits(0x42 << 8 | 0x01, 16); // NAL header
+        w.bits(0, 4);
+        w.bits(0, 3);
+        w.bits(1, 1);
+        w.bits(0, 88 + 8);
+        w.ue(0);
+        w.ue(1);
+        w.ue(1280);
+        w.ue(720);
+        w.bits(1, 1);
+        for _ in 0..4 {
+            w.ue(0);
+        }
+        w.bits(1, 1); // rbsp trailing
+        assert_eq!(au_needs_crop(&au_with(&w.emulated())), Some(false));
+    }
+
+    #[derive(Default)]
+    struct BitWriter {
+        bits: Vec<bool>,
+    }
+
+    impl BitWriter {
+        fn bits(&mut self, v: u32, n: usize) {
+            for i in (0..n).rev() {
+                self.bits.push(i < 32 && (v >> i) & 1 == 1);
+            }
+        }
+        fn ue(&mut self, v: u32) {
+            let x = v + 1;
+            let len = 32 - x.leading_zeros() as usize;
+            self.bits(0, len - 1);
+            self.bits(x, len);
+        }
+        /// Bytes with emulation-prevention inserted, as an encoder would.
+        fn emulated(&self) -> Vec<u8> {
+            let mut raw = Vec::new();
+            for chunk in self.bits.chunks(8) {
+                let mut b = 0u8;
+                for (i, bit) in chunk.iter().enumerate() {
+                    b |= (*bit as u8) << (7 - i);
+                }
+                raw.push(b);
+            }
+            let mut out = Vec::new();
+            let mut zeros = 0;
+            for b in raw {
+                if zeros >= 2 && b <= 3 {
+                    out.push(3);
+                    zeros = 0;
+                }
+                out.push(b);
+                zeros = if b == 0 { zeros + 1 } else { 0 };
+            }
+            out
+        }
+    }
+}

--- a/src-tauri/src/video/rtsp/mod.rs
+++ b/src-tauri/src/video/rtsp/mod.rs
@@ -32,6 +32,6 @@ mod rtp;
 mod sdp;
 
 #[cfg(target_os = "linux")]
-pub use h265_sps::au_needs_crop;
+pub use h265_sps::{probe_au, strip_window, SpsProbe, Window};
 
 pub use client::{run_rtsp, LiveRtspStats, RtspConfig, RtspTransport, VideoCodec};

--- a/src-tauri/src/video/rtsp/mod.rs
+++ b/src-tauri/src/video/rtsp/mod.rs
@@ -25,8 +25,13 @@
 mod client;
 mod h264;
 mod h265;
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+mod h265_sps;
 mod mjpeg;
 mod rtp;
 mod sdp;
+
+#[cfg(target_os = "linux")]
+pub use h265_sps::au_needs_crop;
 
 pub use client::{run_rtsp, LiveRtspStats, RtspConfig, RtspTransport, VideoCodec};

--- a/src-tauri/src/video/rtsp_native.rs
+++ b/src-tauri/src/video/rtsp_native.rs
@@ -47,6 +47,9 @@ type PlatformSink = LinuxVideoSink;
 /// How long `start()` waits for the first frame: RTSP negotiation (incl. a possible 2 s
 /// UDP→TCP fallback) plus the first JPEG.
 const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(12);
+/// Linux/HEVC: AUs to wait for an SPS before starting the sink without a verdict.
+#[cfg(target_os = "linux")]
+const SPS_WAIT_AUS: u32 = 120;
 
 /// One JPEG as an mpjpeg part — byte-compatible with ffmpeg's muxer output (`--ffmpeg`
 /// boundary, `Content-length` on every part), which is what the broadcast framing and all
@@ -248,6 +251,8 @@ impl NativeRtsp {
                 let _ = &sink_first;
                 #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
                 let mut sink_ts: Option<SinkTs> = None;
+                #[cfg(target_os = "linux")]
+                let mut aus_without_sps = 0u32;
                 let stop_flag = stop.clone();
                 let result = run_rtsp(&cfg, &stop, &mut |frame| match frame.codec {
                     VideoCodec::Mjpeg => {
@@ -257,6 +262,23 @@ impl NativeRtsp {
                     }
                     #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
                     VideoCodec::H264 | VideoCodec::H265 => {
+                        // Linux decides its HEVC route from the SPS: hold the start until an
+                        // AU carries one (the depacketizer prepends the sets before an IRAP;
+                        // earlier AUs are undecodable anyway), bounded so a set-less stream
+                        // still gets a sink.
+                        #[cfg(target_os = "linux")]
+                        let needs_crop = if sink_ts.is_none() && frame.codec == VideoCodec::H265 {
+                            match super::rtsp::au_needs_crop(&frame.data) {
+                                Some(v) => Some(v),
+                                None if aus_without_sps < SPS_WAIT_AUS => {
+                                    aus_without_sps += 1;
+                                    return;
+                                }
+                                None => None,
+                            }
+                        } else {
+                            None
+                        };
                         if sink_ts.is_none() {
                             // First AU decides the route: bring the decode sink up. It
                             // starts as a 1×1 layer — invisible until the frontend cuts
@@ -277,7 +299,7 @@ impl NativeRtsp {
                             #[cfg(target_os = "android")]
                             let started_sink = AndroidVideoSink::start(frame.codec);
                             #[cfg(target_os = "linux")]
-                            let started_sink = LinuxVideoSink::start(frame.codec);
+                            let started_sink = LinuxVideoSink::start(frame.codec, needs_crop);
                             match started_sink {
                                 Ok(sink) => {
                                     *sink_slot.lock().unwrap() = Some(sink);

--- a/src-tauri/src/video/rtsp_native.rs
+++ b/src-tauri/src/video/rtsp_native.rs
@@ -215,6 +215,8 @@ impl NativeRtsp {
             },
             accept,
             live: Some(live),
+            #[cfg(target_os = "linux")]
+            resync_on_loss: super::linux_sink::hevc_decoder_is_stateless(),
             ..Default::default()
         };
 

--- a/src-tauri/src/video/rtsp_native.rs
+++ b/src-tauri/src/video/rtsp_native.rs
@@ -267,17 +267,16 @@ impl NativeRtsp {
                         // earlier AUs are undecodable anyway), bounded so a set-less stream
                         // still gets a sink.
                         #[cfg(target_os = "linux")]
-                        let needs_crop = if sink_ts.is_none() && frame.codec == VideoCodec::H265 {
-                            match super::rtsp::au_needs_crop(&frame.data) {
-                                Some(v) => Some(v),
-                                None if aus_without_sps < SPS_WAIT_AUS => {
+                        let sps = if sink_ts.is_none() && frame.codec == VideoCodec::H265 {
+                            match super::rtsp::probe_au(&frame.data) {
+                                super::rtsp::SpsProbe::NoSps if aus_without_sps < SPS_WAIT_AUS => {
                                     aus_without_sps += 1;
                                     return;
                                 }
-                                None => None,
+                                p => p,
                             }
                         } else {
-                            None
+                            super::rtsp::SpsProbe::NoSps
                         };
                         if sink_ts.is_none() {
                             // First AU decides the route: bring the decode sink up. It
@@ -299,7 +298,7 @@ impl NativeRtsp {
                             #[cfg(target_os = "android")]
                             let started_sink = AndroidVideoSink::start(frame.codec);
                             #[cfg(target_os = "linux")]
-                            let started_sink = LinuxVideoSink::start(frame.codec, needs_crop);
+                            let started_sink = LinuxVideoSink::start(frame.codec, sps);
                             match started_sink {
                                 Ok(sink) => {
                                     *sink_slot.lock().unwrap() = Some(sink);

--- a/src-tauri/src/video/rtsp_native.rs
+++ b/src-tauri/src/video/rtsp_native.rs
@@ -47,9 +47,11 @@ type PlatformSink = LinuxVideoSink;
 /// How long `start()` waits for the first frame: RTSP negotiation (incl. a possible 2 s
 /// UDP→TCP fallback) plus the first JPEG.
 const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(12);
-/// Linux/HEVC: AUs to wait for an SPS before starting the sink without a verdict.
+/// Linux/HEVC: AUs to wait for an SPS before starting the sink without a verdict. Nothing
+/// decodes before the first IRAP anyway (the sets ride with it), so this only caps a
+/// set-less stream — it must outlast any keyframe interval (120 was one OBS GOP: a race).
 #[cfg(target_os = "linux")]
-const SPS_WAIT_AUS: u32 = 120;
+const SPS_WAIT_AUS: u32 = 3600;
 
 /// One JPEG as an mpjpeg part — byte-compatible with ffmpeg's muxer output (`--ffmpeg`
 /// boundary, `Content-length` on every part), which is what the broadcast framing and all


### PR DESCRIPTION
## What

Three findings on the Raspberry Pi 5 with the native RTSP client and an OBS/NVENC HEVC stream, all in one branch because each one hid the next:

1. **Abort on cropped streams.** NVENC 720p is coded 1280×736 with a conformance window (every 1080p stream is coded 1088). `v4l2slh265dec` (gst-plugins-bad 1.26, also upstream `main`) applies that crop as a CPU copy into a system-memory buffer whose caps still claim DMABuf; glupload falls through to its Raw-Data-DRM path and gst-gl aborts. QSV codes 720p without a window — that is why earlier tests passed. **Fix:** the sink strips the window from every SPS it pushes (`rtsp/h265_sps.rs`, byte-identical to an independent Python rewrite for three real SPS) so the decoder delivers the full coded frame zero-copy, and lays the widget out for the coded picture so the padding rows hide under the WebView (flip-aware, display size reported to the frontend). The sink start waits for an AU carrying an SPS. Only an SPS that does not parse still takes the cairo path.
2. **Stall right after the keyframe.** The sink's appsrc held 8 AUs, leaky. Decoder open + negotiation take 100–150 ms; at 60 fps the queue overflowed and dropped the frames right after the IDR. A stateless decoder cannot conceal a missing reference: the hardware stalled ("Decoding frame 1 took too long"). **Fix:** bound raised to 120 AUs — load shedding only under sustained overload, never at start-up.
3. **Lockup after any loss.** Stopping a stalled decoder hangs `rpi_hevc_dec` in the kernel until a reboot (proven without Kite: a capture minus one P-frame → stall → D-state on stop; kernel bug to report). In the field 19 lost RTP packets while dragging the floating window triggered it. **Fix:** the H.265 depacketizer resyncs — after any loss (torn AU, or a sequence gap between AUs = a whole missing picture) it holds pictures until the next IRAP. Switched on through `RtspConfig::resync_on_loss` when `v4l2slh265dec` exists; concealing decoders (Windows, Android, software) are unchanged.

`GDK_GL=gles` from PR #110 is confirmed effective and stays. User docs: Pi 5 note in the video guide (padding, keyframe pause, short keyframe interval).

**Measured on the Pi 5:** NVENC 720p60 via the zero-copy path 60 fps at ~35 % of one core (QSV ~25 %); the stripped clips decode on the hardware from file with and without GL; file decode with live-like 60 fps pacing fine; Python replay of Kite's reorderer + depacketizer over a tcpdump capture: 478 clean AUs, 0 damaged.

Regression: introduced by PR #89 / #110 (native Linux client), never released.

## Test
- `cargo test` (SPS probe/strip 4 tests, H.265 depacketizer resync 2 tests) · `cargo check --lib` on the Pi 5 · `cargo test --no-run` · mkdocs strict.
- Device: ec4b836 on the Pi with NVENC — plays, stop/restart clean; the loss-triggered lockup reproduced once (before the resync commit). 9bc2da9 device test DONE (Marc, Pi 5, NVENC 720p60): stable, 60 fps video, floating window dragged, stop/restart/quit clean, no stall, no lockup. Cesium 3D next to it: High-Res 10 fps / Low-Res 15 fps (22 / 35 without video).