### PR TITLE
fix: macOS signing, location permission and native CoreLocation, GCS marker fallback, toast de-dup

### DIFF
--- a/scripts/notarize-macos.sh
+++ b/scripts/notarize-macos.sh
@@ -45,7 +45,14 @@ fi
 
 echo "[1/5] Code-signing the app bundle (hardened runtime)..."
 # --options runtime is required for notarization; --deep signs nested frameworks/helpers.
+# --entitlements is NOT optional here: codesign only embeds the entitlements it is handed, and
+# --force replaces whatever signature the bundler left behind. Signing without it produces a
+# hardened-runtime binary with an EMPTY entitlement set, and the hardened runtime then denies the
+# resources Kite declares in Entitlements.plist: the BLE transport cannot open a CoreBluetooth
+# central, the "Camera (device)" video source gets no device, and the GCS marker gets no location.
+# None of that reproduces in an unsigned local build, so it only ever breaks the released .dmg.
 codesign --force --deep --options runtime --timestamp \
+    --entitlements "$ROOT/src-tauri/Entitlements.plist" \
     --sign "$APPLE_SIGNING_IDENTITY" "$APP"
 
 echo "[2/5] Signing the .dmg..."

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2468,6 +2468,9 @@ dependencies = [
  "log",
  "mavlink",
  "num-traits",
+ "objc2 0.6.4",
+ "objc2-core-location",
+ "objc2-foundation 0.3.2",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
@@ -3007,6 +3010,16 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -83,4 +83,17 @@ webkit2gtk = "2.0"
 # used to build the device-matching dictionaries and read device properties.
 core-foundation = "0.10"
 core-foundation-sys = "0.8"
+# Native CoreLocation for the GCS marker (location_macos.rs). WKWebView ships no Geolocation API at
+# all (wry implements the permission prompt only for its Android backend, and
+# tauri-plugin-geolocation's desktop backend is a stub that returns a default position), so
+# `navigator.geolocation` can never resolve on macOS and the marker had no source but the vehicle's
+# own GPS. We drive CLLocationManager through the objc2 bindings instead, in-crate and without Swift,
+# the same way the IOKit HID backend above talks to its C API. Only the features for the types used.
+# The 0.6 / 0.3 generation is the one tauri, wry and tao already pull in, so this adds no second
+# objc2 to the binary (btleplug's older 0.5 copy is pre-existing and unrelated).
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSArray", "NSString", "NSEnumerator"] }
+# default-features = false on purpose: the crate's default set drags in objc2-contacts (CNPostalAddress,
+# for CLPlacemark geocoding) which a GCS has no business linking.
+objc2-core-location = { version = "0.3", default-features = false, features = ["std", "CLLocation", "CLLocationManager", "CLLocationManagerDelegate", "CLError"] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -92,7 +92,7 @@ core-foundation-sys = "0.8"
 # The 0.6 / 0.3 generation is the one tauri, wry and tao already pull in, so this adds no second
 # objc2 to the binary (btleplug's older 0.5 copy is pre-existing and unrelated).
 objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSArray", "NSString", "NSEnumerator"] }
+objc2-foundation = { version = "0.3", features = ["NSArray", "NSString", "NSEnumerator", "NSError"] }
 # default-features = false on purpose: the crate's default set drags in objc2-contacts (CNPostalAddress,
 # for CLPlacemark geocoding) which a GCS has no business linking.
 objc2-core-location = { version = "0.3", default-features = false, features = ["std", "CLLocation", "CLLocationManager", "CLLocationManagerDelegate", "CLError"] }

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -5,6 +5,9 @@
   Bluetooth is required for the BLE transport under the hardened runtime; without this entitlement a
   notarized build cannot open a CoreBluetooth central. Camera is required for the video panel's
   "Camera (device)" source (getUserMedia over a USB/UVC capture device) under the hardened runtime.
+  Location pairs with the Info.plist usage string for the GCS marker, which reads the operator's
+  position through native CoreLocation on macOS (location_macos.rs): the hardened runtime denies
+  CoreLocation without this entitlement even when the usage description is present.
   The app is NOT sandboxed (it needs raw serial / IOKit-HID / local-network access like the
   Windows/Linux builds), so no App Sandbox key is set.
 -->
@@ -13,6 +16,8 @@
     <key>com.apple.security.device.bluetooth</key>
     <true/>
     <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.personal-information.location</key>
     <true/>
 </dict>
 </plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -11,6 +11,13 @@
   companion computer, MAVLink over UDP/TCP from a Wi-Fi telemetry bridge. macOS 15 gates that behind a
   consent prompt; without this key the prompt carries a generic system text instead of saying what
   Kite actually wants the network for. (Loopback, i.e. our own MediaMTX, is exempt from the gate.)
+  The location (when-in-use) string is required for the GCS marker: macOS will not authorise
+  CoreLocation for an app that ships no usage description, and cannot even show the consent prompt.
+  On macOS the marker is fed by native CoreLocation (location_macos.rs) rather than the WebView,
+  because WKWebView ships no Geolocation API at all: wry implements the permission prompt only for
+  its Android backend, and tauri-plugin-geolocation's desktop backend is a stub. Windows/WebView2 and
+  Linux/WebKitGTK use the Web API and iOS goes through the native plugin, so neither needs this key
+  on their side. Coarse, city-level accuracy is all the marker needs.
 -->
 <plist version="1.0">
 <dict>
@@ -22,5 +29,7 @@
     <string>Kite Ground Control uses the camera to display an FPV video feed from a connected capture device.</string>
     <key>NSLocalNetworkUsageDescription</key>
     <string>Kite Ground Control connects to devices on your local network — a video stream from an onboard companion computer, or telemetry from a flight controller over Wi-Fi.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>Kite Ground Control uses your location to place the ground-station marker on the map and as the reference point for the radar.</string>
 </dict>
 </plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -539,6 +539,7 @@ pub fn run() {
         .manage(MjpegServer::new())
         .invoke_handler(tauri::generate_handler![
             location::location_os_last,
+            location::location_os_start,
             list_serial_ports,
             scan_ble_devices,
             ble_scan_start,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,15 @@ mod flightmode;
 mod github_release;
 mod hid;
 mod link_stats;
+/// macOS operator location via CoreLocation. macOS is the one desktop target with no Web Geolocation
+/// API, so `navigator.geolocation` cannot resolve there and the GCS marker needs a native source.
+/// Every other target keeps the WebView path and compiles the stub instead.
+#[cfg(target_os = "macos")]
+#[path = "location_macos.rs"]
+mod location;
+#[cfg(not(target_os = "macos"))]
+#[path = "location_stub.rs"]
+mod location;
 mod logging;
 mod mavlink_proto;
 mod mission;
@@ -503,6 +512,12 @@ pub fn run() {
                 }
                 probe_gstreamer_support();
             }
+            // macOS: start CoreLocation for the GCS marker. Kicked off here rather than lazily so
+            // the authorisation prompt lands once, at launch, instead of mid-flight. A denial or
+            // disabled Location Services just logs and leaves the marker on its vehicle-GPS
+            // fallback, so this can never block start-up.
+            #[cfg(target_os = "macos")]
+            location::start(_app.handle());
             Ok(())
         })
         .on_page_load(|_webview, _payload| {
@@ -523,6 +538,7 @@ pub fn run() {
         .manage(std::sync::Arc::new(MediaMtx::new()))
         .manage(MjpegServer::new())
         .invoke_handler(tauri::generate_handler![
+            location::location_os_last,
             list_serial_ports,
             scan_ble_devices,
             ble_scan_start,

--- a/src-tauri/src/location_macos.rs
+++ b/src-tauri/src/location_macos.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+// macOS operator location via CoreLocation, for the GCS marker ("Your Location").
+//
+// Why this exists at all: macOS is the only desktop platform where the Web Geolocation API is
+// unavailable, so `navigator.geolocation` (helpers/userLocation.ts) can never resolve there.
+// WKWebView ships no Geolocation API: wry implements the permission prompt only for its Android
+// backend, WebKit exposes no delegate for it, and tauri-plugin-geolocation's desktop backend is
+// a stub returning a default position. Windows (WebView2) and Linux (WebKitGTK) both support the Web
+// API, and iOS/Android go through the native plugin, which is why only macOS needs this.
+//
+// Implemented in-crate against the objc2 CoreLocation bindings, the same shape as the IOKit HID
+// backend in hid/macos.rs: no Swift, no extra plugin. Coarse accuracy on purpose, because the marker
+// needs to know which town you are in (userLocation.ts documents city-level as plenty), and asking
+// for less precision keeps CoreLocation off the GPS/Wi-Fi-scan fast path.
+//
+// Threading: CLLocationManager must be created on a thread with a live run loop and delivers its
+// delegate callbacks there, so construction is hopped onto the main thread via Tauri. The manager
+// and delegate are parked in a process-global to stay alive for the app's lifetime. `delegate` is a
+// WEAK property on CLLocationManager, so dropping our reference would silently stop the callbacks.
+
+use std::sync::Mutex;
+
+use objc2::rc::Retained;
+use objc2::runtime::{NSObject, NSObjectProtocol, ProtocolObject};
+use objc2::{define_class, AllocAnyThread, DefinedClass};
+use objc2_core_location::{
+    kCLLocationAccuracyKilometer, CLAuthorizationStatus, CLLocation, CLLocationManager,
+    CLLocationManagerDelegate,
+};
+use objc2_foundation::{NSArray, NSError};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+/// Event name the frontend listens on for every fresh OS fix.
+const EVENT: &str = "os-location";
+
+/// Only re-emit once the position moved this far, mirroring the frontend's own anti-jitter gate
+/// (`CONT_MIN_MOVE_M` in stores/gcsLocation.ts). Coarse fixes wander by tens of metres at rest.
+const MIN_MOVE_M: f64 = 20.0;
+
+/// A resolved operator position. Field names match what `helpers/userLocation.ts` expects.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct OsFix {
+    pub lat: f64,
+    pub lon: f64,
+    /// Horizontal accuracy radius in metres, or None when CoreLocation reports it as invalid.
+    pub accuracy_m: Option<f64>,
+}
+
+/// Last fix seen, so a frontend that starts (or reloads) after the fix arrived can still read it.
+static LAST_FIX: Mutex<Option<OsFix>> = Mutex::new(None);
+
+/// Keeps the manager + delegate alive for the process. See the threading note above: the delegate is
+/// a weak property, so this is what stops the callbacks from going silent.
+static KEEPALIVE: Mutex<Option<Keepalive>> = Mutex::new(None);
+
+struct Keepalive {
+    _manager: Retained<CLLocationManager>,
+    _delegate: Retained<LocationDelegate>,
+}
+
+// The CoreLocation objects are `!Send`, but they are only ever touched on the main thread (created
+// there, and the delegate callbacks arrive there). This wrapper exists purely to park them in a
+// static; nothing here dereferences them from another thread.
+unsafe impl Send for Keepalive {}
+
+struct Ivars {
+    /// Emitting goes through the AppHandle, which is Send + Sync and cheap to clone.
+    app: AppHandle,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "KiteLocationDelegate"]
+    #[ivars = Ivars]
+    struct LocationDelegate;
+
+    unsafe impl NSObjectProtocol for LocationDelegate {}
+
+    unsafe impl CLLocationManagerDelegate for LocationDelegate {
+        #[unsafe(method(locationManager:didUpdateLocations:))]
+        fn did_update_locations(
+            &self,
+            _manager: &CLLocationManager,
+            locations: &NSArray<CLLocation>,
+        ) {
+            // CoreLocation batches; the newest fix is last.
+            let Some(loc) = locations.lastObject() else { return };
+            let coord = unsafe { loc.coordinate() };
+            if !unsafe { coord.is_valid() } {
+                return;
+            }
+            let acc = unsafe { loc.horizontalAccuracy() };
+            let fix = OsFix {
+                lat: coord.latitude,
+                lon: coord.longitude,
+                // A negative horizontal accuracy means the coordinate is invalid per Apple's docs.
+                accuracy_m: (acc >= 0.0).then_some(acc),
+            };
+
+            {
+                let mut last = LAST_FIX.lock().unwrap();
+                if let Some(prev) = *last {
+                    if distance_m(prev.lat, prev.lon, fix.lat, fix.lon) < MIN_MOVE_M {
+                        return; // unchanged within the jitter band: keep the event stream quiet
+                    }
+                }
+                *last = Some(fix);
+            }
+
+            log::info!("[location] CoreLocation fix: {:.3}, {:.3}", fix.lat, fix.lon);
+            let _ = self.ivars().app.emit(EVENT, fix);
+        }
+
+        #[unsafe(method(locationManager:didFailWithError:))]
+        fn did_fail(&self, _manager: &CLLocationManager, error: &NSError) {
+            // Denied authorisation and "no fix yet" both land here. Warn rather than error: the GCS
+            // marker is optional and every other feature works without it.
+            log::warn!("[location] CoreLocation failed: {}", error.localizedDescription());
+        }
+
+        #[unsafe(method(locationManagerDidChangeAuthorization:))]
+        fn did_change_authorization(&self, manager: &CLLocationManager) {
+            let status = unsafe { manager.authorizationStatus() };
+            match status {
+                CLAuthorizationStatus::AuthorizedAlways
+                | CLAuthorizationStatus::AuthorizedWhenInUse => {
+                    log::info!("[location] CoreLocation authorised, starting updates");
+                    unsafe { manager.startUpdatingLocation() };
+                }
+                CLAuthorizationStatus::Denied | CLAuthorizationStatus::Restricted => {
+                    log::warn!(
+                        "[location] location access denied. The GCS marker falls back to the \
+                         vehicle's GPS fix (System Settings > Privacy & Security > Location Services)"
+                    );
+                }
+                // NotDetermined: the prompt is still on screen, this fires again once answered.
+                _ => {}
+            }
+        }
+    }
+);
+
+/// Great-circle distance in metres. Only used against the 20 m jitter gate, so the spherical
+/// approximation is far more precision than the comparison needs.
+fn distance_m(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+    const R: f64 = 6_371_000.0;
+    let (p1, p2) = (lat1.to_radians(), lat2.to_radians());
+    let (dp, dl) = ((lat2 - lat1).to_radians(), (lon2 - lon1).to_radians());
+    let a = (dp / 2.0).sin().powi(2) + p1.cos() * p2.cos() * (dl / 2.0).sin().powi(2);
+    2.0 * R * a.sqrt().asin()
+}
+
+/// The most recent OS fix, if CoreLocation has produced one. Lets the frontend read a fix that
+/// arrived before it subscribed (or before a WebView reload) instead of waiting for the next event.
+#[tauri::command]
+pub fn location_os_last() -> Option<OsFix> {
+    *LAST_FIX.lock().unwrap()
+}
+
+/// Start CoreLocation and request authorisation. Idempotent: a second call is a no-op, so this is
+/// safe to call from app setup and again from a manual "detect my location" button.
+///
+/// Not generic over the runtime: the delegate parks an `AppHandle` in its ivars to emit from, and
+/// that has to be one concrete type to live in a `static`. The app builds on the default Wry runtime.
+pub fn start(app: &AppHandle) {
+    if KEEPALIVE.lock().unwrap().is_some() {
+        return;
+    }
+    // Location Services can be off system-wide, in which case authorisation would never resolve.
+    if !unsafe { CLLocationManager::locationServicesEnabled_class() } {
+        log::warn!("[location] Location Services are disabled system-wide. GCS marker will rely on \
+                    the vehicle's GPS fix");
+        return;
+    }
+
+    let handle = app.app_handle().clone();
+    let hop = app.run_on_main_thread(move || {
+        let mut slot = KEEPALIVE.lock().unwrap();
+        if slot.is_some() {
+            return; // raced with another start() while the hop was queued
+        }
+        let delegate = LocationDelegate::alloc().set_ivars(Ivars { app: handle });
+        let delegate: Retained<LocationDelegate> = unsafe { objc2::msg_send![super(delegate), init] };
+
+        let manager = unsafe { CLLocationManager::new() };
+        unsafe {
+            manager.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+            // Coarse is deliberate (see the module note): town-level is all the marker needs.
+            manager.setDesiredAccuracy(kCLLocationAccuracyKilometer);
+            manager.setDistanceFilter(MIN_MOVE_M);
+            // Fires locationManagerDidChangeAuthorization once answered, which is where updates
+            // actually start. Already-authorised apps get that callback immediately.
+            manager.requestWhenInUseAuthorization();
+        }
+        *slot = Some(Keepalive { _manager: manager, _delegate: delegate });
+        log::info!("[location] CoreLocation started, awaiting authorisation");
+    });
+    if let Err(e) = hop {
+        log::warn!("[location] could not reach the main thread to start CoreLocation: {e}");
+    }
+}

--- a/src-tauri/src/location_macos.rs
+++ b/src-tauri/src/location_macos.rs
@@ -160,6 +160,16 @@ pub fn location_os_last() -> Option<OsFix> {
     *LAST_FIX.lock().unwrap()
 }
 
+/// Start (or retry starting) CoreLocation from the frontend, behind the "Detect my location" button.
+///
+/// Needed because `start()` gives up when Location Services are off system-wide, and app setup is the
+/// only other caller: a user who enables Location Services or grants the permission after launch
+/// would otherwise have to restart the app. `start()` is idempotent, so this is free once running.
+#[tauri::command]
+pub fn location_os_start(app: AppHandle) {
+    start(&app);
+}
+
 /// Start CoreLocation and request authorisation. Idempotent: a second call is a no-op, so this is
 /// safe to call from app setup and again from a manual "detect my location" button.
 ///

--- a/src-tauri/src/location_stub.rs
+++ b/src-tauri/src/location_stub.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+// Non-macOS stand-in for the CoreLocation module (location_macos.rs), so the command exists on every
+// target and `generate_handler!` needs no platform branches.
+//
+// Nothing to implement here on purpose: Windows (WebView2) and Linux (WebKitGTK) both expose the Web
+// Geolocation API, so `helpers/userLocation.ts` resolves the operator's position in the WebView and
+// never calls this. macOS is the only desktop target where that API is missing.
+
+/// Always `None` off macOS: the frontend uses `navigator.geolocation` there instead.
+#[tauri::command]
+pub fn location_os_last() -> Option<()> {
+    None
+}

--- a/src-tauri/src/location_stub.rs
+++ b/src-tauri/src/location_stub.rs
@@ -13,3 +13,7 @@
 pub fn location_os_last() -> Option<()> {
     None
 }
+
+/// No-op off macOS. Only the macOS build has a native location source to (re)start.
+#[tauri::command]
+pub fn location_os_start() {}

--- a/src/lib/components/StatusTextToasts.svelte
+++ b/src/lib/components/StatusTextToasts.svelte
@@ -31,6 +31,7 @@
         <div class="msg-line {msg.level}">
           <span class="m-icon">{ICON[msg.level]}</span>
           <span class="m-text">{msg.text}</span>
+          {#if msg.repeats > 1}<span class="m-count">×{msg.repeats}</span>{/if}
         </div>
       {/each}
     </div>
@@ -85,6 +86,8 @@
   }
   .m-icon { font-size: 11px; line-height: 1; flex: 0 0 auto; }
   .m-text { overflow: hidden; text-overflow: ellipsis; }
+  /* Repeat tally for a message the FC keeps re-sending. Dimmed so it reads as metadata, not content. */
+  .m-count { flex: 0 0 auto; margin-left: auto; padding-left: 8px; font-size: 11px; opacity: 0.55; font-variant-numeric: tabular-nums; }
 
   .msg-line.info    { color: #cfe7f3; }
   .msg-line.info .m-icon { color: #37a8db; }

--- a/src/lib/helpers/userLocation.ts
+++ b/src/lib/helpers/userLocation.ts
@@ -5,13 +5,20 @@
 // precise — city-level is plenty. Sources, in order: a persisted last-known value (restored on
 // launch), an OS/browser geo check (on start + a manual button), and a connected UAV's GPS fix.
 // It deliberately never tracks the live map/camera — orbiting the globe must not change it.
+//
+// The OS check is per-platform: Windows (WebView2) and Linux (WebKitGTK) use the Web Geolocation
+// API, while macOS goes through native CoreLocation (location_macos.rs) because WKWebView ships no
+// Geolocation API at all, so `navigator.geolocation` can never resolve there.
 
 import { writable, get } from 'svelte/store';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import { telemetry } from '$lib/stores/telemetry';
 import { homePosition } from '$lib/stores/home';
 import { connection } from '$lib/stores/connection';
 import { settings } from '$lib/stores/settings';
 import { isValidGpsCoordinate } from '$lib/helpers/telemetry';
+import { isMacOS } from '$lib/platform';
 
 export interface LatLon { lat: number; lon: number; }
 
@@ -33,7 +40,24 @@ export function setUserLocation(lat: number, lon: number, source: string, accura
   console.log(`[geo] user location set via ${source}: ${lat.toFixed(3)}, ${lon.toFixed(3)}`);
 }
 
+/** macOS: read the newest CoreLocation fix from the backend (location_macos.rs). WKWebView has no
+ *  Geolocation API at all, so the Web path below can never resolve there. The native module is the
+ *  only source, and it pushes an `os-location` event as well for the live updates. */
+async function runGeoCheckMacOs(): Promise<void> {
+  try {
+    const fix = await invoke<{ lat: number; lon: number; accuracy_m: number | null } | null>(
+      'location_os_last',
+    );
+    if (fix) setUserLocation(fix.lat, fix.lon, 'os-corelocation', fix.accuracy_m);
+    // No fix yet is normal, not an error: CoreLocation is still resolving, or the permission prompt
+    // is unanswered. The event listener below delivers it whenever it arrives.
+  } catch (err) {
+    console.warn('[geo] CoreLocation read failed, keeping last known:', err);
+  }
+}
+
 function runGeoCheck(): void {
+  if (isMacOS) { void runGeoCheckMacOs(); return; }
   if (typeof navigator === 'undefined' || !navigator.geolocation) {
     console.warn('[geo] navigator.geolocation unavailable');
     return;
@@ -59,6 +83,16 @@ export function ensureUserLocation(): void {
 /** Manual trigger (settings button) — always runs a fresh OS geo check. */
 export function requestUserLocation(): void {
   runGeoCheck();
+}
+
+// ── macOS: live CoreLocation updates ──
+// The native module emits on every fix that moved more than its jitter threshold, which is what makes
+// `gcsMode: continuous` track on macOS, where there is no watchPosition to drive it. Subscribed at
+// import; the backend only emits when it has an authorised, valid fix.
+if (isMacOS) {
+  void listen<{ lat: number; lon: number; accuracy_m: number | null }>('os-location', (e) => {
+    setUserLocation(e.payload.lat, e.payload.lon, 'os-corelocation', e.payload.accuracy_m);
+  });
 }
 
 // ── Auto-update from a connected UAV's GPS (coarse is fine) ──

--- a/src/lib/helpers/userLocation.ts
+++ b/src/lib/helpers/userLocation.ts
@@ -45,6 +45,10 @@ export function setUserLocation(lat: number, lon: number, source: string, accura
  *  only source, and it pushes an `os-location` event as well for the live updates. */
 async function runGeoCheckMacOs(): Promise<void> {
   try {
+    // Start first, and on every manual check. The backend gives up when Location Services are off
+    // system-wide, so without this a user who turns them on (or grants the permission) after launch
+    // would have to restart the app to get a marker. The call is idempotent once running.
+    await invoke('location_os_start');
     const fix = await invoke<{ lat: number; lon: number; accuracy_m: number | null } | null>(
       'location_os_last',
     );

--- a/src/lib/stores/gcsLocation.ts
+++ b/src/lib/stores/gcsLocation.ts
@@ -9,6 +9,8 @@
 //  - manual:     the resolved OS location, which the user may override by dragging / "set GCS here";
 //                "Reset" clears the override and snaps back to the OS location (no re-detect).
 //  - continuous: follows the OS location API live; the marker only moves on a > 20 m change (anti-jitter).
+//                Falls back to the last known position while the watch has delivered nothing, so a
+//                platform that denies or lacks the Geolocation API still shows a marker.
 
 import { writable, get } from 'svelte/store';
 import { settings, type GcsMode } from '$lib/stores/settings';
@@ -33,7 +35,8 @@ function clearWatch() {
   watchId = null;
 }
 
-/** Recompute the GCS position for off / manual (continuous is driven by the watch). */
+/** Recompute the GCS position for off / manual, and seed continuous when its watch has produced
+ *  nothing yet (see the fallback rationale below). */
 function recompute() {
   const mode = get(settings).gcsMode;
   if (mode === 'off') {
@@ -47,6 +50,15 @@ function recompute() {
       gcsLocation.set(get(userGeoLocation));
       gcsAccuracyM.set(get(userGeoAccuracyM));
     }
+  } else if (mode === 'continuous' && !get(gcsLocation)) {
+    // Continuous normally owns the marker through its watch, but the watch can never deliver on a
+    // platform where the Geolocation API is denied or unimplemented. `continuous` is also the DEFAULT
+    // mode, so the marker was then missing for the whole session even though `userGeoLocation` already
+    // held a position: a one-shot OS fix, the value persisted from the last session, or the connected
+    // UAV's own GPS fix (see helpers/userLocation.ts). Seed from it so the marker exists at all; the
+    // first real watch fix overwrites this, and a position the watch DID deliver is left alone.
+    gcsLocation.set(get(userGeoLocation));
+    gcsAccuracyM.set(get(userGeoAccuracyM));
   }
 }
 
@@ -70,7 +82,10 @@ function startContinuous() {
 function applyGcsMode(mode: GcsMode) {
   clearWatch();
   if (mode === 'continuous') startContinuous();
-  else recompute();
+  // recompute() runs for continuous too, not just off/manual: it is what seeds the marker from the
+  // last known position while the watch has produced nothing (off → continuous clears the marker,
+  // and on a platform without a working Geolocation API the watch never refills it).
+  recompute();
 }
 
 /** Manual placement (drag end / "Set GCS here") — overrides the OS location until Reset. */

--- a/src/lib/stores/gcsLocation.ts
+++ b/src/lib/stores/gcsLocation.ts
@@ -29,13 +29,17 @@ const CONT_MIN_MOVE_M = 20; // continuous: ignore sub-20 m jitter
 
 let manualOverride: LatLon | null = null; // session-only hand placement (drag / "set GCS here")
 let watchId: number | null = null;
+/** True once the Web watch has delivered at least one position, i.e. it owns the marker from here on.
+ *  While false, continuous follows `userGeoLocation` instead (see recompute()). */
+let watchDelivered = false;
 
 function clearWatch() {
   if (watchId != null && typeof navigator !== 'undefined') navigator.geolocation.clearWatch(watchId);
   watchId = null;
+  watchDelivered = false;
 }
 
-/** Recompute the GCS position for off / manual, and seed continuous when its watch has produced
+/** Recompute the GCS position for off / manual, and drive continuous while its watch has produced
  *  nothing yet (see the fallback rationale below). */
 function recompute() {
   const mode = get(settings).gcsMode;
@@ -50,14 +54,21 @@ function recompute() {
       gcsLocation.set(get(userGeoLocation));
       gcsAccuracyM.set(get(userGeoAccuracyM));
     }
-  } else if (mode === 'continuous' && !get(gcsLocation)) {
+  } else if (mode === 'continuous' && !watchDelivered) {
     // Continuous normally owns the marker through its watch, but the watch can never deliver on a
     // platform where the Geolocation API is denied or unimplemented. `continuous` is also the DEFAULT
     // mode, so the marker was then missing for the whole session even though `userGeoLocation` already
-    // held a position: a one-shot OS fix, the value persisted from the last session, or the connected
-    // UAV's own GPS fix (see helpers/userLocation.ts). Seed from it so the marker exists at all; the
-    // first real watch fix overwrites this, and a position the watch DID deliver is left alone.
-    gcsLocation.set(get(userGeoLocation));
+    // held a position: a one-shot OS fix, the value persisted from the last session, the connected
+    // UAV's own GPS fix, or on macOS every fix from native CoreLocation (see helpers/userLocation.ts).
+    // Follow that position until the watch delivers its first fix, which is what makes continuous
+    // actually track on macOS. Gating on `watchDelivered` rather than on an empty marker matters: a
+    // null check stops after the first seed, leaving the marker frozen wherever the operator happened
+    // to be when it arrived. Same 20 m anti-jitter gate as the watch below.
+    const next = get(userGeoLocation);
+    const cur = get(gcsLocation);
+    if (next && (!cur || haversineDistance(cur.lat, cur.lon, next.lat, next.lon) > CONT_MIN_MOVE_M)) {
+      gcsLocation.set(next);
+    }
     gcsAccuracyM.set(get(userGeoAccuracyM));
   }
 }
@@ -67,6 +78,7 @@ function startContinuous() {
   if (typeof navigator === 'undefined' || !navigator.geolocation) return;
   watchId = navigator.geolocation.watchPosition(
     (pos) => {
+      watchDelivered = true; // the watch owns the marker from here; recompute() stops driving it
       const next = { lat: pos.coords.latitude, lon: pos.coords.longitude };
       const cur = get(gcsLocation);
       if (!cur || haversineDistance(cur.lat, cur.lon, next.lat, next.lon) > CONT_MIN_MOVE_M) {

--- a/src/lib/stores/statusText.ts
+++ b/src/lib/stores/statusText.ts
@@ -18,6 +18,7 @@ export interface StatusTextMsg {
   level: StatusTextLevel; // collapsed for colour/sound
   text: string;
   expiresAt: number;     // epoch ms when this line fades out (per-message lifetime)
+  repeats: number;       // how many times this identical text has arrived while on screen (1 = once)
 }
 
 const MAX_BUFFER = 12;          // lines kept (the banner shows a few and scrolls to the newest)
@@ -70,7 +71,6 @@ function trackPrearm(text: string): void {
 let nextId = 1;
 let sweepTimer: ReturnType<typeof setTimeout> | null = null;
 let lastSoundAt = 0;
-let lastText = '';
 let unlisten: UnlistenFn | null = null;
 
 /** Drop every message whose per-line lifetime has elapsed, then re-arm for the next-earliest expiry.
@@ -99,19 +99,26 @@ function push(severity: number, text: string): void {
   if (!levelAllowed(level)) return; // filtered out by the "System Messages" setting
 
   const expiresAt = Date.now() + CLEAR_AFTER_MS;
+  let repeated = false;
   statusTexts.update((list) => {
-    // Light de-dup: a repeated identical last line just refreshes its own lifetime, no duplicate row.
-    if (list.length && list[list.length - 1].text === clean) {
+    // De-dup against the WHOLE buffer, not just the last line. An FC that nags with two alternating
+    // messages (INAV's "UNABLE TO ARM" / "WAITING FOR GPS FIX" while it waits for a fix) never repeats
+    // its *last* line, so a last-line-only check appends a fresh row for every nag and fills the banner
+    // within seconds. A repeat instead refreshes the existing line's lifetime and bumps its counter,
+    // keeping its position so the banner doesn't reshuffle while you're reading it.
+    const idx = list.findIndex((m) => m.text === clean);
+    if (idx !== -1) {
+      repeated = true;
       const refreshed = [...list];
-      refreshed[refreshed.length - 1] = { ...refreshed[refreshed.length - 1], expiresAt };
+      refreshed[idx] = { ...refreshed[idx], severity, level, expiresAt, repeats: refreshed[idx].repeats + 1 };
       return refreshed;
     }
-    return [...list, { id: nextId++, severity, level, text: clean, expiresAt }].slice(-MAX_BUFFER);
+    return [...list, { id: nextId++, severity, level, text: clean, expiresAt, repeats: 1 }].slice(-MAX_BUFFER);
   });
   scheduleSweep();
 
-  if (clean !== lastText || level !== 'info') playTone(level); // always cue errors; rate-limit info
-  lastText = clean;
+  // Always cue errors/warnings; an INFO line already on screen never re-cues, so a nag loop stays silent.
+  if (!repeated || level !== 'info') playTone(level);
 }
 
 // ── Audio cue (Web Audio) — gentle for info, discreetly alarming for warnings/errors ──
@@ -182,5 +189,4 @@ export function stopStatusText(): void {
   prearmLines = [];
   statusTexts.set([]);
   prearmReason.set(null);
-  lastText = '';
 }


### PR DESCRIPTION
## Description

Five fixes found while testing the macOS end of 1.0.0. Each is its own commit and they are
independent, so any subset can be taken. Opened as a draft against `master` rather than
`development`, because the first one only affects the signed release artifact and the second and
third only affect macOS.

**1. Notarized builds shipped with an empty entitlement set** (`scripts/notarize-macos.sh`)

`codesign --force` replaces the bundler's signature, and codesign only embeds the entitlements it is
explicitly handed. Signing without `--entitlements` produced a hardened-runtime binary that declares
nothing, so the runtime denied everything `Entitlements.plist` asks for: no CoreBluetooth central for
the BLE transport, no device for the "Camera (device)" video source, no CoreLocation. Unsigned local
builds are unaffected, which is why this never shows up in testing.

Verified by signing a bundle both ways and dumping the result:

```
--force --deep --options runtime --sign ...          ->  no entitlements embedded
same + --entitlements src-tauri/Entitlements.plist   ->  bluetooth, camera, location all present
```

**2. macOS never declared the location permission** (`src-tauri/Info.plist`, `Entitlements.plist`)

No `NSLocationWhenInUseUsageDescription` and no location entitlement, so macOS would not authorise
CoreLocation and could not even show a consent prompt. This is the prerequisite for commit 5.

**3. Continuous GCS mode discarded a position it already had** (`src/lib/stores/gcsLocation.ts`)

`recompute()` handled only `off` and `manual`, so `continuous` relied entirely on its location watch.
Where that watch cannot deliver, the marker stayed null even though `userGeoLocation` held a usable
position: a one-shot OS fix, the value persisted from last session, or the connected UAV's own GPS
fix that `helpers/userLocation.ts` captures once per connection. `continuous` is the default, so the
app knew where the operator was and showed nothing. Going from `off` to `continuous` had the same
effect, since `off` clears the marker and nothing re-seeded it.

`recompute()` now also seeds `continuous` from the last known position while the watch has produced
nothing, and runs on every mode change. The first real fix overwrites the seed and a delivered
position is left alone, so live tracking is unchanged wherever it already worked.

**4. Toast de-dup only compared the last line** (`statusText.ts`, `StatusTextToasts.svelte`)

An FC nagging with two alternating messages never matched. INAV does exactly that while waiting for a
fix ("UNABLE TO ARM" / "WAITING FOR GPS FIX"): neither is ever the previous line, so every nag
appended a row, the banner hit its 12-line cap within seconds, and the tone re-cued each time. A
repeat now refreshes the matching line wherever it sits and bumps a dimmed `xN` counter, keeping its
position so the banner does not reshuffle while being read.

**5. Native CoreLocation source for the GCS marker** (new `src-tauri/src/location_macos.rs`)

macOS is the only desktop platform with no Web Geolocation API, so `navigator.geolocation` could
never resolve there and the marker had no source at all. WKWebView ships no Geolocation API (wry
implements the permission prompt only for its Android backend, WebKit exposes no delegate), and
`tauri-plugin-geolocation`'s desktop backend is a stub returning a default position. Windows
(WebView2) and Linux (WebKitGTK) support the Web API and mobile uses the native plugin, so only macOS
needed this.

Adds a `CLLocationManager` plus delegate in Rust via objc2, the same in-crate approach `hid/macos.rs`
already uses for its C API: no Swift, no extra plugin. `helpers/userLocation.ts` routes macOS to it
and subscribes to an `os-location` event, which is what lets `continuous` track without a
`watchPosition`. Every other target compiles a stub so `generate_handler!` needs no platform branch.

Confirmed working on a real Mac: permission prompt appears, marker resolves, `Continuous (live)`
tracks.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactoring / Code health
- [ ] Documentation
- [x] Build / CI

## Checklist

- [x] `npm run check` passes
- [x] `cargo check` (in `src-tauri`) passes
- [x] I have tested the changes locally (dev + relevant build)
- [ ] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes

`npm run check`: 559 files, 0 errors, 0 warnings. `cargo check`: clean. Release bundle rebuilt and
installed; `otool -L` confirms CoreLocation linked and Contacts absent.

No changelog entry: the 1.0.0 section is a prose summary with no itemised fix list, so there is
nowhere natural for these. Happy to add entries if you would rather have them.

## Notes for reviewer

- Written directly against `master`, not cherry-picked, so nothing from `development` rides along.
  Fixes 2 and 4 also exist there (the plist key via #16, the de-dup via earlier work), so expect a
  trivial conflict or a no-op when master next merges up.
- Commits 3 and 4 are cross-platform, not macOS-only. Commit 3 changes when `recompute()` runs for
  `continuous` on every platform, which is the part most worth your eyes even though live tracking
  should be unaffected.
- Commit 5 is the only one adding a dependency: `objc2-core-location 0.3.2`. `objc2 0.6` and
  `objc2-foundation 0.3` were already in the tree via tauri, wry and tao, so no second objc2
  generation enters the binary. Taken with `default-features = false` because the default set pulls
  in `objc2-contacts` for `CLPlacemark` geocoding. Checked against the RustSec advisory database: no
  advisories for any of the three.
- Commit 5 is a feature rather than a fix, so if you want `master` strictly frozen it is the one to
  drop; commits 2 and 3 then still leave the marker working off the vehicle's GPS fix.
- Three details in `location_macos.rs` worth knowing before touching it: the manager is created on
  the main thread because it needs a live run loop, `delegate` is a WEAK property so the manager and
  delegate are parked in a process-global, and a denial or disabled Location Services only logs so
  start-up can never block.
- All five bugs are present in `v1.0.0-rc2` and earlier, confirmed against the tag.
