### PR TITLE
fix: macOS signed release flow, sign during the build so notarization can work

### DIFF
--- a/docs/user/for-developers/building.md
+++ b/docs/user/for-developers/building.md
@@ -66,9 +66,22 @@ sudo apt install -y \
 2. Node.js, Rust and just via their official installers (e.g. `brew install node just`, Rust from rustup).
 
 The macOS build is **universal** (arm64 + x86_64). `just build-macos` adds both Rust targets and fetches
-the bundled ffmpeg for you, then builds the `.app` + `.dmg`. The result is **unsigned**; `just
-notarize-macos` signs + notarizes it for distribution without a Gatekeeper prompt (needs an Apple
-Developer account, credentials read from your environment / keychain — never committed).
+the bundled ffmpeg for you, then builds the `.app` + `.dmg`. The result is **unsigned** unless you
+export a signing identity first.
+
+For a distributable build, signing happens during the build and notarizing after it, in that order.
+The `.dmg` has to wrap an already-signed `.app`, because Apple inspects the app inside the image:
+
+```bash
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+just build-macos      # the bundler signs the .app, then builds the .dmg around it
+just notarize-macos   # notarize + staple, so there is no Gatekeeper prompt
+```
+
+Both steps need an Apple Developer account, and specifically a **Developer ID Application**
+certificate: an "Apple Development" certificate cannot notarize. Credentials are read from your
+environment / keychain and never committed. List your identities with
+`security find-identity -v -p codesigning`.
 
 ### Android / iOS
 Mobile (Tauri Mobile) is **not part of the 1.0 line**. The Android and iOS / iPadOS ports are both

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -50,6 +50,19 @@ npm install
 bash "$(dirname "$0")/fetch-ffmpeg-macos.sh"
 
 echo "[3/4] Building universal application with Tauri..."
+# The bundler signs the .app itself (hardened runtime + the entitlements from tauri.conf.json) when
+# it finds APPLE_SIGNING_IDENTITY, and only then wraps it in the .dmg. That order is what makes
+# notarization possible at all: Apple inspects the app inside the image, so signing has to happen
+# here, before the .dmg exists, not afterwards. Say which kind of build this is, because the two
+# look identical on disk and an unsigned one only reveals itself on someone else's Mac.
+if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+    echo "[INFO] Signing identity found in the environment: the bundle will be SIGNED."
+    echo "       Run 'just notarize-macos' afterwards to notarize + staple it."
+else
+    echo "[INFO] No APPLE_SIGNING_IDENTITY set: the bundle will be UNSIGNED (fine for local use)."
+    echo "       For a distributable build, export it BEFORE this script and re-run:"
+    echo "         export APPLE_SIGNING_IDENTITY=\"Developer ID Application: Your Name (TEAMID)\""
+fi
 npm run tauri build -- --target universal-apple-darwin --bundles app dmg
 
 echo "[4/4] Collecting outputs into release/ (unified naming) ..."

--- a/scripts/notarize-macos.sh
+++ b/scripts/notarize-macos.sh
@@ -2,21 +2,29 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2026 Marc Hoffmann (b14ckyy)
 # ============================================================
-# Kite Ground Control — macOS sign + notarize (LOCAL ONLY)
-# Signs the built universal .app + .dmg with your Developer ID, submits the
-# .dmg to Apple's notary service, and staples the ticket so it opens with no
-# Gatekeeper warning on any Mac.
+# Kite Ground Control — macOS notarize + staple (LOCAL ONLY)
+# Submits the collected .dmg to Apple's notary service and staples the ticket,
+# so it opens with no Gatekeeper warning on any Mac.
 #
-# Recommended: run AFTER "just build-macos", via "just notarize-macos".
+# THE APP IS NOT SIGNED HERE. That happens during the build, because the .dmg
+# has to wrap an ALREADY-SIGNED .app: Apple inspects the app inside the image,
+# so signing a loose .app after the .dmg was built changes nothing the notary
+# service looks at. The Tauri bundler signs the app for us (hardened runtime,
+# --entitlements from tauri.conf.json) whenever it finds a signing identity in
+# the environment. This script only signs the disk image itself, if the bundler
+# did not, since that wrapper signature is independent of the payload. Order:
+#
+#   export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+#   just build-macos      # bundler signs the .app, then builds the .dmg around it
+#   just notarize-macos   # this script: notarize + staple
+#
+# List your identities with: security find-identity -v -p codesigning
+# A "Developer ID Application" certificate is required. An "Apple Development"
+# certificate cannot notarize, and neither can an ad-hoc signature.
 #
 # CREDENTIALS ARE NEVER STORED IN THE REPO. This runs on the maintainer's
 # machine only — GitHub CI builds unsigned (see .github/workflows/release.yml).
-# It reads (never prints) the following from your environment:
-#
-#   APPLE_SIGNING_IDENTITY   e.g. "Developer ID Application: Your Name (TEAMID)"
-#                            (list yours: `security find-identity -v -p codesigning`)
-#
-#   Notarization credentials — EITHER (recommended) a keychain profile:
+# It reads (never prints) EITHER (recommended) a keychain profile:
 #     NOTARY_PROFILE         name you gave `xcrun notarytool store-credentials`
 #   OR the three raw values (used only if NOTARY_PROFILE is unset):
 #     APPLE_ID               your Apple ID email
@@ -26,7 +34,7 @@
 # One-time keychain-profile setup (keeps the password out of your shell/env):
 #   xcrun notarytool store-credentials kite-notary \
 #     --apple-id you@example.com --team-id TEAMID --password <app-specific-pw>
-#   export NOTARY_PROFILE=kite-notary APPLE_SIGNING_IDENTITY="Developer ID Application: ... (TEAMID)"
+#   export NOTARY_PROFILE=kite-notary
 # ============================================================
 
 set -euo pipefail
@@ -34,29 +42,69 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT="$ROOT/release"
 
-: "${APPLE_SIGNING_IDENTITY:?Set APPLE_SIGNING_IDENTITY (see header)}"
-
-APP="$(ls -d "$OUT"/*.app 2>/dev/null | head -1 || true)"
 DMG="$(ls "$OUT"/*.dmg 2>/dev/null | head -1 || true)"
-if [ -z "$APP" ] || [ -z "$DMG" ]; then
-    echo "[notarize] Missing .app or .dmg in $OUT — run 'just build-macos' first."
+if [ -z "$DMG" ]; then
+    echo "[notarize] No .dmg in $OUT — run 'just build-macos' first."
     exit 1
 fi
 
-echo "[1/5] Code-signing the app bundle (hardened runtime)..."
-# --options runtime is required for notarization; --deep signs nested frameworks/helpers.
-# --entitlements is NOT optional here: codesign only embeds the entitlements it is handed, and
-# --force replaces whatever signature the bundler left behind. Signing without it produces a
-# hardened-runtime binary with an EMPTY entitlement set, and the hardened runtime then denies the
-# resources Kite declares in Entitlements.plist: the BLE transport cannot open a CoreBluetooth
-# central, the "Camera (device)" video source gets no device, and the GCS marker gets no location.
-# None of that reproduces in an unsigned local build, so it only ever breaks the released .dmg.
-codesign --force --deep --options runtime --timestamp \
-    --entitlements "$ROOT/src-tauri/Entitlements.plist" \
-    --sign "$APPLE_SIGNING_IDENTITY" "$APP"
+# Refuse early rather than burning a notary submission on a payload Apple will reject.
+# The signature lives on the .app INSIDE the image, so mount it read-only and check there.
+echo "[1/5] Checking the app inside the .dmg is signed for distribution..."
+MNT="$(mktemp -d)"
+cleanup() { hdiutil detach "$MNT" -quiet 2>/dev/null || true; rmdir "$MNT" 2>/dev/null || true; }
+trap cleanup EXIT
+hdiutil attach "$DMG" -mountpoint "$MNT" -nobrowse -readonly -quiet
 
-echo "[2/5] Signing the .dmg..."
-codesign --force --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$DMG"
+APP="$(ls -d "$MNT"/*.app 2>/dev/null | head -1 || true)"
+if [ -z "$APP" ]; then
+    echo "[notarize] No .app inside $DMG. The image is not a Kite bundle."
+    exit 1
+fi
+
+AUTHORITY="$(codesign -dvv "$APP" 2>&1 | grep '^Authority=' | head -1 | cut -d= -f2- || true)"
+if ! printf '%s' "$AUTHORITY" | grep -q '^Developer ID Application'; then
+    echo ""
+    echo "[notarize] The app in the .dmg is NOT signed with a Developer ID certificate."
+    echo "           Signing authority: ${AUTHORITY:-<none: unsigned or ad-hoc>}"
+    echo ""
+    echo "           Apple notarizes only Developer ID signed payloads, and the .dmg has to"
+    echo "           be built AROUND the signed app, so re-signing now would not help."
+    echo "           Rebuild with the identity exported, then run this again:"
+    echo ""
+    echo "             export APPLE_SIGNING_IDENTITY=\"Developer ID Application: Your Name (TEAMID)\""
+    echo "             just build-macos"
+    echo ""
+    exit 1
+fi
+echo "       OK: $AUTHORITY"
+
+# The hardened runtime is a notarization requirement, and the bundler only applies it while
+# signing. Catch a bundle signed by hand without it before Apple does.
+if ! codesign -d --verbose=4 "$APP" 2>&1 | grep -q 'flags=.*runtime'; then
+    echo "[notarize] The app is signed but WITHOUT the hardened runtime, which notarization requires."
+    echo "           Rebuild via 'just build-macos' so the bundler signs it (--options runtime)."
+    exit 1
+fi
+
+cleanup
+trap - EXIT
+
+# The disk image itself should carry a signature too, separate from the app inside it. Whether the
+# bundler already signed it depends on the Tauri version, so check rather than assume: signing the
+# wrapper is idempotent and never touches the payload, unlike re-signing the app.
+echo "[2/5] Checking the .dmg wrapper signature..."
+if codesign -dvv "$DMG" 2>&1 | grep -q '^Authority=Developer ID Application'; then
+    echo "       Already signed by the bundler, leaving it alone."
+elif [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+    echo "       Unsigned, signing the image with APPLE_SIGNING_IDENTITY..."
+    codesign --force --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$DMG"
+else
+    echo "[notarize] The .dmg wrapper is unsigned and APPLE_SIGNING_IDENTITY is not set."
+    echo "           Export it and re-run; the app inside is already signed, so this is"
+    echo "           the only step missing."
+    exit 1
+fi
 
 echo "[3/5] Submitting the .dmg to Apple notary service (this can take a few minutes)..."
 if [ -n "${NOTARY_PROFILE:-}" ]; then
@@ -66,7 +114,6 @@ else
     : "${APPLE_ID:?Set NOTARY_PROFILE, or APPLE_ID/APPLE_TEAM_ID/APPLE_APP_PASSWORD (see header)}"
     : "${APPLE_TEAM_ID:?Set APPLE_TEAM_ID}"
     : "${APPLE_APP_PASSWORD:?Set APPLE_APP_PASSWORD}"
-    # notarytool reads the password from the env var name, not the value on the command line.
     xcrun notarytool submit "$DMG" \
         --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" \
         --password "$APPLE_APP_PASSWORD" --wait
@@ -76,8 +123,8 @@ echo "[4/5] Stapling the notarization ticket to the .dmg..."
 xcrun stapler staple "$DMG"
 
 echo "[5/5] Verifying..."
-spctl --assess --type open --context context:primary-signature -v "$DMG" || true
-codesign --verify --deep --strict --verbose=2 "$APP"
+# What a user's Mac actually evaluates on first open.
+spctl --assess --type open --context context:primary-signature -v "$DMG"
 
 echo ""
 echo "[notarize] Done. Distributable: $DMG"


### PR DESCRIPTION
## Description

Found while trying to produce the signed 1.0 build you asked for: `just build-macos` followed by
`just notarize-macos` cannot produce a notarized build. Two independent reasons.

**1. It always exits before doing any work.** `notarize-macos.sh` looks for `release/*.app`, but
`collect-release.sh` zips the app under the unified name and then deletes `bundle/macos` and
`bundle/dmg`. No `.app` exists anywhere afterwards, so the script prints
`Missing .app or .dmg in .../release` and exits 1. Reproducible on a clean checkout:

```
$ bash scripts/build-macos.sh
[collect-release] Collected into release :
  - KiteGC_macOS_universal_1.0.0_installer.dmg
  - KiteGC_macOS_universal_1.0.0_standalone.zip
$ ls release/*.app
zsh: no matches found
```

**2. The signing order cannot work, so this is not a one-line path fix.** The script signed a loose
`.app` after the `.dmg` had already been built around the unsigned one. Apple inspects the app
*inside* the image, so that signature was never part of what the notary service evaluates and the
submission would be rejected even with the path corrected.

Signing has to happen during the build, before the `.dmg` exists. The bundler already does exactly
that when `APPLE_SIGNING_IDENTITY` is in the environment. Confirmed against the CLI binary actually
in `node_modules`:

```
APPLE_SIGNING_IDENTITY  APPLE_CERTIFICATE  APPLE_DEVELOPMENT_TEAM
APPLE_ID  APPLE_PASSWORD  APPLE_TEAM_ID  APPLE_API_KEY  APPLE_API_ISSUER
--entitlements  --options runtime  --deep  notarytool  stapler
```

So it signs with the hardened runtime and the `tauri.conf.json` entitlements, then wraps the result.
The flow becomes:

```bash
export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
just build-macos      # bundler signs the app, then builds the dmg around it
just notarize-macos   # notarize + staple
```

`notarize-macos.sh` no longer signs the app. It mounts the image read only, reads the real signing
authority off the app inside, and refuses with an explanation unless that authority is a Developer ID
Application certificate and the hardened runtime flag is set. Both are hard notarization
requirements, so checking locally costs a second and saves a rejected submission. It still signs the
disk image itself, but only if the bundler did not, since the wrapper signature is independent of the
payload.

`build-macos.sh` now states whether it is producing a signed or unsigned bundle, because the two look
identical on disk and an unsigned one only reveals itself on someone else's Mac.

This also makes the `--entitlements` flag from #114 redundant, since the bundler applies the
`tauri.conf.json` entitlements while signing. The bug that commit described was real, but this is the
better place to fix it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / Code health
- [x] Documentation
- [x] Build / CI

## Checklist

- [x] `npm run check` passes
- [x] `cargo check` (in `src-tauri`) passes
- [x] I have tested the changes locally (dev + relevant build)
- [x] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes

No Rust or frontend code is touched, so both checks are unaffected, but I ran them anyway: 559 files
0 errors, `cargo check` clean.

## Notes for reviewer

Verified on this machine against a real Developer ID signed universal build:

```
Authority=Developer ID Application: Sebastian Kumor (ZXHB39825K)
TeamIdentifier=ZXHB39825K
flags=0x10000(runtime)
entitlements: device.bluetooth, device.camera, personal-information.location
lipo -archs: x86_64 arm64
codesign --verify --deep --strict: valid on disk, satisfies its Designated Requirement
```

So the build-time path works: the bundler signs the app with the hardened runtime, embeds all three
entitlements from `tauri.conf.json`, and signs the disk image too. That last point answers a question
I had left open: the wrapper-signing branch in step 2 is a no-op on a current Tauri and reports
`Already signed by the bundler, leaving it alone`. It is kept only for older CLI versions, and can be
dropped if you would rather not carry it.

Also verified: the missing `.app` bug reproduces as described, the guard correctly refuses an
unsigned build with `<none: unsigned or ad-hoc>` without contacting Apple, the mount is always
detached including on failure paths, and the no-dmg path errors cleanly.

Testing the guard on a genuinely signed bundle caught a bug in my own first version, worth knowing
about since the pattern appears elsewhere in the repo's scripts: piping `codesign` into `grep -q`
under `set -o pipefail` inverts the result, because grep exits on the first match, codesign dies of
SIGPIPE, and pipefail reports the pipeline as failed. It rejected a valid bundle. Both flag checks
now capture the output first.

**The full path now has a real run behind it.** Signed universal build, guards passed, submitted,
accepted by Apple, stapled, verified:

```
status: Accepted                  (submission 5bc8c219-6c82-48a5-8a38-73ba0389bfe2)
stapler validate: The validate action worked!
spctl --assess:   accepted
source=Notarized Developer ID
origin=Developer ID Application: Sebastian Kumor (ZXHB39825K)
```

Before this change the same repo state could not get there at all, first because no `.app` survives
`collect-release.sh`, then because the payload would have been unsigned.

One behaviour change worth a second opinion: `spctl --assess` lost its `|| true`, so a verification
failure now fails the script. That felt right for a release gate, but it is your call.

Not covered: the `standalone.zip` gets no ticket of its own, since a ticket cannot be shared between
artifacts. The app inside the notarized `.dmg` assesses as `accepted` / `Notarized Developer ID`, so
the installer path is clean, but anyone running the zip directly would still see the Gatekeeper
prompt. Happy to add a second submission for it if you want both frictionless.
