### PR TITLE
fix: notarize script rejected valid signed builds and died on an open dmg

### DIFF
--- a/scripts/notarize-macos.sh
+++ b/scripts/notarize-macos.sh
@@ -51,10 +51,36 @@ fi
 # Refuse early rather than burning a notary submission on a payload Apple will reject.
 # The signature lives on the .app INSIDE the image, so mount it read-only and check there.
 echo "[1/5] Checking the app inside the .dmg is signed for distribution..."
-MNT="$(mktemp -d)"
-cleanup() { hdiutil detach "$MNT" -quiet 2>/dev/null || true; rmdir "$MNT" 2>/dev/null || true; }
+# An image can only be attached once, so a maintainer who already opened the .dmg in Finder would
+# otherwise hit a bare "hdiutil: attach failed" and, under set -e, a silent exit. Reuse the existing
+# mount instead, and only detach what this script attached itself.
+# hdiutil info prints "image-path : <path>" then tab-separated "/dev/diskNsM <uuid> <mountpoint>"
+# lines for that image. Split on tabs, not spaces: volume names contain them ("Kite Ground Control"),
+# so a last-field match would only ever see the final word.
+MNT="$(hdiutil info | awk -F'\t' -v dmg="$(cd "$(dirname "$DMG")" && pwd)/$(basename "$DMG")" '
+    /^image-path/ { p = $0; sub(/^image-path[[:space:]]*:[[:space:]]*/, "", p); mine = (p == dmg) }
+    mine && $1 ~ /^\/dev\/disk/ && $3 ~ /^\/Volumes\// { print $3; exit }')"
+OURS=0
+# Leave a mount we did not create alone: ejecting Finder's copy out from under the user would be
+# rude, and detaching is only our business when we attached it.
+cleanup() {
+    [ "$OURS" = 1 ] || return 0
+    hdiutil detach "$MNT" -quiet 2>/dev/null || true
+    rmdir "$MNT" 2>/dev/null || true
+    OURS=0
+}
 trap cleanup EXIT
-hdiutil attach "$DMG" -mountpoint "$MNT" -nobrowse -readonly -quiet
+
+if [ -n "$MNT" ]; then
+    echo "       (already mounted at $MNT, reusing it)"
+else
+    MNT="$(mktemp -d)"
+    OURS=1
+    if ! hdiutil attach "$DMG" -mountpoint "$MNT" -nobrowse -readonly -quiet; then
+        echo "[notarize] Could not mount $DMG. If it is open in Finder, eject it and re-run."
+        exit 1
+    fi
+fi
 
 APP="$(ls -d "$MNT"/*.app 2>/dev/null | head -1 || true)"
 if [ -z "$APP" ]; then
@@ -81,7 +107,11 @@ echo "       OK: $AUTHORITY"
 
 # The hardened runtime is a notarization requirement, and the bundler only applies it while
 # signing. Catch a bundle signed by hand without it before Apple does.
-if ! codesign -d --verbose=4 "$APP" 2>&1 | grep -q 'flags=.*runtime'; then
+# Capture first, then match: piping codesign straight into `grep -q` makes grep exit on the first
+# hit, codesign die of SIGPIPE, and `set -o pipefail` report the whole pipeline as failed, which
+# inverts the test and rejects a perfectly good bundle.
+APP_FLAGS="$(codesign -d --verbose=4 "$APP" 2>&1 || true)"
+if ! printf '%s' "$APP_FLAGS" | grep -q 'flags=.*runtime'; then
     echo "[notarize] The app is signed but WITHOUT the hardened runtime, which notarization requires."
     echo "           Rebuild via 'just build-macos' so the bundler signs it (--options runtime)."
     exit 1
@@ -94,7 +124,8 @@ trap - EXIT
 # bundler already signed it depends on the Tauri version, so check rather than assume: signing the
 # wrapper is idempotent and never touches the payload, unlike re-signing the app.
 echo "[2/5] Checking the .dmg wrapper signature..."
-if codesign -dvv "$DMG" 2>&1 | grep -q '^Authority=Developer ID Application'; then
+DMG_SIG="$(codesign -dvv "$DMG" 2>&1 || true)"   # captured, not piped: see the SIGPIPE note above
+if printf '%s' "$DMG_SIG" | grep -q '^Authority=Developer ID Application'; then
     echo "       Already signed by the bundler, leaving it alone."
 elif [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
     echo "       Unsigned, signing the image with APPLE_SIGNING_IDENTITY..."


### PR DESCRIPTION
## Description

Follow-up to #117. That PR merged one commit too early: this fix was already written but landed on
the branch just after you merged, so master carries the bug. Sorry for the extra PR, my force-push
raced your merge.

**1. The hardened-runtime guard rejects every valid build.** It piped `codesign` straight into
`grep -q`:

```bash
if ! codesign -d --verbose=4 "$APP" 2>&1 | grep -q 'flags=.*runtime'; then
```

Under `set -o pipefail` that inverts the result. `grep -q` exits as soon as it matches, `codesign`
then dies of SIGPIPE and returns 141, and pipefail reports the whole pipeline as failed even though
the pattern *did* match. The effect is that a correctly signed bundle gets rejected:

```
[1/5] Checking the app inside the .dmg is signed for distribution...
       OK: Developer ID Application: Sebastian Kumor (ZXHB39825K)
[notarize] The app is signed but WITHOUT the hardened runtime, which notarization requires.
```

on an app that plainly carries `flags=0x10000(runtime)`. As merged, the script refuses every valid
build, which is worse than the state before #117 in that one respect.

The `.dmg` wrapper check had the same shape. There the failure is quieter: it would fall through and
re-sign an image the bundler had already signed, rather than reporting `Already signed by the
bundler, leaving it alone`.

Both now capture the command output into a variable and match against that.

**2. The script dies silently if the .dmg is already open in Finder.** A disk image can only be
attached once, so `hdiutil attach` fails, and under `set -e` the script exits immediately after
printing step 1 with no message whatsoever. It now looks for an existing mount and reuses it, and
detaches only images it attached itself, so a Finder mount is left alone:

```
[1/5] Checking the app inside the .dmg is signed for distribution...
       (already mounted at /Volumes/Kite Ground Control, reusing it)
       OK: Developer ID Application: Sebastian Kumor (ZXHB39825K)
```

That lookup has to split `hdiutil info` on tabs rather than whitespace, because volume names contain
spaces and a last-field match sees only `Control`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / Code health
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [x] `npm run check` passes
- [x] `cargo check` (in `src-tauri`) passes
- [x] I have tested the changes locally (dev + relevant build)
- [x] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes

Shell only, so neither check is affected. `bash -n` clean.

## Notes for reviewer

Verified with the fix in place, on a real Developer ID signed universal build:

```
[1/5] OK: Developer ID Application: Sebastian Kumor (ZXHB39825K)
[2/5] Already signed by the bundler, leaving it alone.
[3/5] status: Accepted        (submission 5bc8c219-6c82-48a5-8a38-73ba0389bfe2)
[4/5] The staple and validate action worked!
[5/5] accepted, source=Notarized Developer ID
```

So the notarized 1.0.0 dmg that came out of this is real, and it is what the merged script would
have refused to produce.

Bug 1 isolated on the same signed app, so the inversion is not inferred:

```
flags=0x10000(runtime)          <- the flag IS present
master's form, under pipefail:  -> FAIL (wrongly rejected)
captured form, under pipefail:  -> PASS
```

Bug 2 reproduced by leaving the notarized dmg mounted in Finder and running the script, which is how
I found it.

I grepped the rest of `scripts/` for the same shape, since any `cmd | grep -q` under
`set -o pipefail` has this defect: no other occurrences, the only three are in this file and all
three now match against a captured variable.
