### PR TITLE
fix: release builds stamped themselves dirty

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -49,7 +49,19 @@ echo "[1/4] Checking Node.js version..."
 node -v
 
 echo "[2/4] Installing npm dependencies..."
-npm install
+# `npm ci`, not `npm install`: install rewrites package-lock.json, which makes the tree dirty and
+# stamps the About dialog "<hash>-dirty" for a build that changed nothing. See build-macos.sh.
+npm ci
+
+# Anything still modified or untracked here is the maintainer's own and gets stamped into the About
+# dialog, so a released build could not be tied back to a commit anyone else can check out.
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    echo ""
+    echo "[WARN] The working tree is not clean, so this build will be stamped <hash>-dirty:"
+    git status --short | sed 's/^/       /'
+    echo "       Stash or commit these first if this is a build you intend to distribute."
+    echo ""
+fi
 
 echo "[3/4] Building application with Tauri..."
 npm run tauri build

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -46,8 +46,24 @@ echo "[1/4] Ensuring both macOS Rust targets are installed..."
 rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
 echo "[2/4] Installing npm dependencies + fetching bundled ffmpeg..."
-npm install
+# `npm ci`, not `npm install`: install rewrites package-lock.json (it drops "peer" markers, among
+# other churn), which makes the tree dirty and stamps the About dialog "<hash>-dirty" for a build
+# that changed nothing. ci installs exactly what the lockfile pins, never writes it, and fails loudly
+# if the lockfile and package.json disagree, all of which is what a release build wants. It is also
+# what the CI workflows already use.
+npm ci
 bash "$(dirname "$0")/fetch-ffmpeg-macos.sh"
+
+# Anything still modified or untracked at this point is the maintainer's own, and it will be stamped
+# into the About dialog as "-dirty". Say so now rather than letting it ship unnoticed: a released
+# build carrying that suffix cannot be tied back to a commit anyone else can check out.
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    echo ""
+    echo "[WARN] The working tree is not clean, so this build will be stamped <hash>-dirty:"
+    git status --short | sed 's/^/       /'
+    echo "       Stash or commit these first if this is a build you intend to distribute."
+    echo ""
+fi
 
 echo "[3/4] Building universal application with Tauri..."
 # The bundler signs the .app itself (hardened runtime + the entitlements from tauri.conf.json) when

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -40,8 +40,10 @@ if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
 Write-Host "[1/4] Node.js version: $(node -v)"
 
 Write-Host '[2/4] Installing npm dependencies...'
-npm install
-if ($LASTEXITCODE -ne 0) { Write-Host '[ERROR] npm install failed.' -ForegroundColor Red; exit 1 }
+# `npm ci`, not `npm install`: install rewrites package-lock.json, which makes the tree dirty and
+# stamps the About dialog "<hash>-dirty" for a build that changed nothing. See build-macos.sh.
+npm ci
+if ($LASTEXITCODE -ne 0) { Write-Host '[ERROR] npm ci failed.' -ForegroundColor Red; exit 1 }
 
 Write-Host '[3/4] Building application with Tauri...'
 npm run tauri build


### PR DESCRIPTION
## Description

Every locally built release stamps itself `<hash>-dirty` in the About dialog, and it is the build
script that does it, not anything the maintainer left in the tree.

The order inside `build-macos.sh` is:

1. `npm install` runs, and rewrites `package-lock.json` (it drops `"peer": true` markers, among other
   churn)
2. Vite runs and computes the build stamp from `git status --porcelain` (`vite.config.js:20`)
3. it finds a modified tracked file, so the stamp gets `-dirty`

So a pristine checkout dirties itself between step 1 and step 3. Verified here: I checked out
`master` at `d20ea7d`, confirmed `git status --porcelain` was empty, ran the script, and got
`d20ea7d-dirty` with the only change in the tree afterwards being the lockfile.

**This is not cosmetic on macOS.** CI builds unsigned by design, so a signed and notarized `.dmg` has
to be produced locally through this script. That means every signed release Kite ships carries a
stamp that cannot be tied back to any commit a reviewer can check out. Seen in the wild on a
notarized 1.0.0 build: `v1.0.0 · cb2ccc5-dirty`.

The three release scripts now use `npm ci`, which installs exactly what the lockfile pins, never
writes it, and fails loudly if the lockfile and `package.json` disagree. That is what a release build
wants, and it is what `ci.yml` and `release.yml` already do. `npm install` stays in `dev.sh` and the
`just install` recipe, where resolving new dependencies is the whole point.

The two bash scripts additionally warn, listing files, when the tree is genuinely dirty before
building. The remaining causes are real (a local edit, or an untracked tool sitting in the tree) and
worth seeing at build time rather than in a shipped About dialog.

After the fix, same machine, same script:

```
stamp in build/_app/immutable: 27d483d
occurrences of "-dirty":       0
git status --porcelain after the build: empty
```

That build then signed, notarized and stapled clean (`Accepted`, `source=Notarized Developer ID`).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / Code health
- [ ] Documentation
- [x] Build / CI

## Checklist

- [x] `npm run check` passes
- [x] `cargo check` (in `src-tauri`) passes
- [x] I have tested the changes locally (dev + relevant build)
- [x] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes

Build scripts only, so neither check is affected by the change itself. `bash -n` clean on both shell
scripts.

## Notes for reviewer

- `build-windows.ps1` gets the `npm install` to `npm ci` swap only, and no warning block, because I
  cannot run PowerShell here to test one. Untested on Windows: worth a glance, though the swap is
  mechanical and the surrounding `$LASTEXITCODE` check is unchanged apart from its message.
- The warning block is deliberately a warning rather than a hard failure. Refusing to build on a
  dirty tree would be defensible for a release, but it would also break the ordinary
  edit-and-build loop, so that call is yours.
- `npm ci` wipes and reinstalls `node_modules` from scratch, so a release build is a little slower
  than it was. That seemed the right trade for a reproducible one.
- Worth knowing for the next release regardless of this PR: the stamp counts untracked files too, so
  any tool or scratch file in the tree marks the build dirty even with this fix in place. The new
  warning is what makes that visible.
