### PR TITLE
docs: README, install guide and docs deploy after the 1.0.0 release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,10 @@
 #                    and moves "latest" onto it; older minors stay frozen on gh-pages as-is.
 #   docs-only fix  → lands on master (see contributing.md) and redeploys the current minor,
 #                    keeping the published release docs correct between releases.
+#   pre-release    → while package.json carries a pre-release suffix ("1.1.0-dev"), master is the
+#                    NEXT line, not a released one: only "Dev" is deployed and "latest" stays on the
+#                    last released minor. A docs fix for that released minor is deployed from its
+#                    tag / release branch via workflow_dispatch (pick the ref in the Actions UI).
 #
 # Local preview needs no CI: `mkdocs serve` (single version, see docs/requirements.txt) or
 # `mike serve` (the full versioned site from a local gh-pages branch).
@@ -56,12 +60,16 @@ jobs:
       - run: mkdocs build --strict
       - name: Resolve the release minor from package.json
         id: ver
-        run: echo "minor=$(node -p "require('./package.json').version.split('.').slice(0,2).join('.')")" >> "$GITHUB_OUTPUT"
+        run: |
+          v="$(node -p "require('./package.json').version")"
+          echo "minor=$(echo "$v" | cut -d. -f1,2)" >> "$GITHUB_OUTPUT"
+          case "$v" in *-*) echo "prerelease=true" >> "$GITHUB_OUTPUT" ;; *) echo "prerelease=false" >> "$GITHUB_OUTPUT" ;; esac
       - name: Author the gh-pages commits as the Actions bot
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Deploy the release docs (${{ steps.ver.outputs.minor }} = latest)
+        if: steps.ver.outputs.prerelease == 'false'
         run: mike deploy --push --update-aliases "${{ steps.ver.outputs.minor }}" latest
         env:
           # Release channel: the changelog hides "in development" sections (docs/hooks/changelog_channel.py).
@@ -69,6 +77,7 @@ jobs:
       - name: Deploy the development docs (Dev = master tip)
         run: mike deploy --push --title Dev dev
       - name: Point the site root at the latest release
+        if: steps.ver.outputs.prerelease == 'false'
         run: mike set-default --push latest
       # GitHub Pages serves exactly ONE 404 page for the whole site: /404.html at the gh-pages
       # root. mike only manages version folders, so publish it in a throwaway worktree. It

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@
   <a href="LICENSE"><img alt="License: GPL-3.0-or-later" src="https://img.shields.io/badge/License-GPLv3-blue.svg"></a>
   <a href="https://b14ckyy.github.io/Kite-GC/"><img alt="Documentation" src="https://img.shields.io/badge/docs-online-37a8db"></a>
   <img alt="Platform" src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-555">
-  <img alt="Status" src="https://img.shields.io/badge/status-release%20candidate-f5a623">
+  <a href="https://github.com/b14ckyy/Kite-GC/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/b14ckyy/Kite-GC?label=release&color=59aa29"></a>
   <a href="https://paypal.me/b14ckyy"><img alt="Donate via PayPal" src="https://img.shields.io/badge/Donate-PayPal-00457C?logo=paypal&logoColor=white"></a>
 </p>
 
 ---
-## Development State: 
+## Development state
 
-Kite is currently in **feature-freeze** for the 1.0 release, so which branch you target matters:
+**Kite 1.0 is released** — the first stable version, after a summer of betas and release candidates.
+Work on 1.1 (mobile, native video decode, and more) continues on the integration trunk:
 
-- **Bugfixes for 1.0** → pull request against **`master`**, the release line.
-- **New features or functional changes** → pull request against **`development`**, the integration
-  trunk. They are welcome there now, but will not reach `master` until after the final 1.0 release.
+- **All changes** → pull request against **`development`**. Features and fixes alike land there and
+  reach `master` with the next release.
+- **A patch for the released 1.0** is cut from the `v1.0.0` tag when one is needed.
 
 Nobody commits to either branch directly — see
 **[Contributing](https://b14ckyy.github.io/Kite-GC/for-developers/contributing/)** for the full
@@ -70,8 +71,8 @@ Everything you'd expect from a ground station:
 - **Mission planning** — create, upload, download and edit missions; undo/redo; a survey-pattern
   generator; terrain-following / AGL waypoints.
 - **Vehicle control** — arm/disarm, flight-mode changes, takeoff/RTL/loiter and more (ArduPilot/PX4).
-- **Comfort** — a multi-language interface (English, German, French at launch) with persistent window,
-  layout and settings between sessions.
+- **Comfort** — a multi-language interface (English, German, French, Bulgarian and Chinese) with persistent
+  window, layout and settings between sessions.
 
 ## What makes Kite special
 
@@ -103,8 +104,8 @@ Everything you'd expect from a ground station:
 - **Connections:** USB / serial, Bluetooth (SPP & BLE), TCP, UDP.
 - **Link modes:** live control link, **passive** listen-only telemetry, or a **relay** that
   re-broadcasts to other ground stations.
-- **Platforms:** Windows, macOS (universal, unsigned) and Linux (x86-64 / ARM64). Android and iOS are
-  in development for a release after 1.0.
+- **Platforms:** Windows, macOS (universal, signed and notarized) and Linux (x86-64 / ARM64).
+  Android and iOS / iPadOS are in development on `development` and target the 1.1 release.
 
 ## Download
 

--- a/docs/user/getting-started/installation.md
+++ b/docs/user/getting-started/installation.md
@@ -20,14 +20,10 @@ grabbing:
 - **Portable** — the bare executable, zipped **with an empty `.portable` marker** already inside, so all
   data stays in a `data/` folder next to it (see [Installed vs portable mode](#installed-vs-portable-mode)).
 
-!!! warning "macOS: first launch (unsigned build)"
-    The macOS build is **universal** (Apple Silicon + Intel) but **not signed / notarized** yet, so
-    Gatekeeper quarantines it on first launch. Open it once via **right-click → Open**, then **Open** in
-    the dialog — or clear the quarantine flag from a terminal:
-    ```bash
-    xattr -dr com.apple.quarantine "/Applications/Kite Ground Control.app"
-    ```
-    After the first launch it opens normally.
+!!! note "macOS: signed and notarized"
+    The macOS build is **universal** (Apple Silicon + Intel), **signed and notarized** since 1.0.0, so it
+    opens like any other app — no Gatekeeper warning, no right-click → Open. If you are still running a
+    beta or release candidate, replace it with the release build.
 
 !!! warning "macOS 13 (Ventura) or newer"
     The macOS build targets **macOS 13**. Older systems are not supported — on macOS 11 or 12 the app


### PR DESCRIPTION
## Description

Post-release housekeeping on master, to be merged **before #121** (development → master).

- **README:** release badge from GitHub instead of "release candidate"; the feature-freeze section becomes the post-1.0 branching note (all changes target `development`, a 1.0 patch is cut from the `v1.0.0` tag); macOS is signed and notarized; the language list matches the five shipped locales; mobile is on `development` for 1.1.
- **Installation guide:** the macOS Gatekeeper workaround is gone, the 1.0.0 build is notarized.
- **Docs workflow:** the job deployed `<major.minor>` from `package.json` as `latest` on every master push. Once #121 lands, master carries `1.1.0-dev`, which would publish the unreleased 1.1 docs as `latest` and freeze 1.0 on whatever was last deployed. A pre-release version now deploys only `Dev`; the release deploy and the root redirect run for plain release versions only. A docs fix for the released minor is deployed from its tag or release branch via `workflow_dispatch`.

`mkdocs build --strict` passes locally. Merging this redeploys the 1.0 docs with the corrected macOS note.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / Code health
- [x] Documentation
- [x] Build / CI

## Checklist

- [x] `npm run check` passes (no frontend change)
- [x] `cargo check` (in `src-tauri`) passes (no Rust change)
- [x] I have tested the changes locally (dev + relevant build)
- [x] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes
