### PR TITLE
chore(rust): clear the three dead-code warnings

### DIFF
--- a/src-tauri/src/link_status.rs
+++ b/src-tauri/src/link_status.rs
@@ -177,6 +177,9 @@ pub fn on_gps(d: &GpsData) {
 }
 
 /// Notification (title, text): vehicle · link, then the values the link carries (metric).
+/// Consumed by the Android foreground service (`android/link_service.rs`); desktop builds only
+/// exercise it in tests.
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
 pub fn notification() -> (String, String) {
     let s = lock();
     let vehicle = if s.vehicle.is_empty() { "Kite Ground Control".to_string() } else { s.vehicle.clone() };

--- a/src-tauri/src/video/rtsp/h264.rs
+++ b/src-tauri/src/video/rtsp/h264.rs
@@ -247,7 +247,7 @@ mod tests {
     use super::*;
 
     fn pkt(seq: u16, ts: u32, marker: bool, payload: Vec<u8>) -> RtpPacket {
-        RtpPacket { payload_type: 96, marker, sequence: seq, timestamp: ts, ssrc: 1, payload }
+        RtpPacket { marker, sequence: seq, timestamp: ts, payload }
     }
 
     fn annexb(nals: &[&[u8]]) -> Vec<u8> {

--- a/src-tauri/src/video/rtsp/h265.rs
+++ b/src-tauri/src/video/rtsp/h265.rs
@@ -248,7 +248,7 @@ mod tests {
     use super::*;
 
     fn pkt(seq: u16, ts: u32, marker: bool, payload: Vec<u8>) -> RtpPacket {
-        RtpPacket { payload_type: 96, marker, sequence: seq, timestamp: ts, ssrc: 1, payload }
+        RtpPacket { marker, sequence: seq, timestamp: ts, payload }
     }
 
     fn annexb(nals: &[&[u8]]) -> Vec<u8> {

--- a/src-tauri/src/video/rtsp/mjpeg.rs
+++ b/src-tauri/src/video/rtsp/mjpeg.rs
@@ -266,7 +266,7 @@ mod tests {
         payload.extend_from_slice(&[jpeg_type, q, 64 / 8, 48 / 8]); // 64x48
         payload.extend_from_slice(extra_header);
         payload.extend_from_slice(scan);
-        RtpPacket { payload_type: 26, marker, sequence: seq, timestamp: 0, ssrc: 1, payload }
+        RtpPacket { marker, sequence: seq, timestamp: 0, payload }
     }
 
     /// Walk the produced JPEG's marker segments up to (and including) SOS.

--- a/src-tauri/src/video/rtsp/rtp.rs
+++ b/src-tauri/src/video/rtsp/rtp.rs
@@ -10,11 +10,9 @@
 
 #[derive(Debug, Clone)]
 pub struct RtpPacket {
-    pub payload_type: u8,
     pub marker: bool,
     pub sequence: u16,
     pub timestamp: u32,
-    pub ssrc: u32,
     pub payload: Vec<u8>,
 }
 
@@ -32,10 +30,10 @@ pub fn parse(buf: &[u8]) -> Option<RtpPacket> {
     let has_extension = b0 & 0x10 != 0;
     let csrc_count = (b0 & 0x0F) as usize;
     let marker = buf[1] & 0x80 != 0;
-    let payload_type = buf[1] & 0x7F;
     let sequence = u16::from_be_bytes([buf[2], buf[3]]);
     let timestamp = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]);
-    let ssrc = u32::from_be_bytes([buf[8], buf[9], buf[10], buf[11]]);
+    // Payload type and SSRC (bytes 1 and 8–11) are not carried: the session negotiates one payload
+    // type per stream and nothing downstream keys on SSRC yet.
 
     let mut offset = 12 + csrc_count * 4;
     if has_extension {
@@ -57,11 +55,9 @@ pub fn parse(buf: &[u8]) -> Option<RtpPacket> {
         return None;
     }
     Some(RtpPacket {
-        payload_type,
         marker,
         sequence,
         timestamp,
-        ssrc,
         payload: buf[offset..end].to_vec(),
     })
 }
@@ -173,11 +169,9 @@ mod tests {
 
     fn pkt(seq: u16) -> RtpPacket {
         RtpPacket {
-            payload_type: 26,
             marker: false,
             sequence: seq,
             timestamp: 0,
-            ssrc: 1,
             payload: vec![0u8; 10],
         }
     }
@@ -192,7 +186,6 @@ mod tests {
         raw.extend_from_slice(b"data");
         let p = parse(&raw).expect("parse");
         assert!(p.marker);
-        assert_eq!(p.payload_type, 26);
         assert_eq!(p.sequence, 0x1234);
         assert_eq!(p.payload, b"data");
     }

--- a/src-tauri/src/video/rtsp_native.rs
+++ b/src-tauri/src/video/rtsp_native.rs
@@ -532,7 +532,8 @@ impl NativeRtsp {
     }
 
     /// `(frames_presented, picture_size, error)` of the active decode sink; `None` while
-    /// no sink runs. The frontend polls this for aspect ratio, fps and stall detection.
+    /// no sink runs. Test hook for the sink end-to-end tests — nothing in the app polls it.
+    #[cfg(test)]
     pub fn sink_stats(&self) -> Option<(u64, Option<(u32, u32)>, Option<String>)> {
         #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
         {


### PR DESCRIPTION
## Description

`cargo check` on development reported three dead-code warnings; this clears them without changing behaviour.

- **`RtpPacket.payload_type` / `ssrc`** — parsed but never read anywhere (the session negotiates one payload type per stream; nothing keys on SSRC yet). Removed from the struct; the parser still validates the fixed 12-byte header. Test constructors updated.
- **`NativeRtsp::sink_stats`** — only the sink end-to-end tests call it; the doc claimed the frontend polls it, which nothing does. Now `#[cfg(test)]` with a corrected doc.
- **`link_status::notification`** — consumed by the Android foreground service and the tests; desktop builds get an explicit `allow(dead_code)` with the reason.

`cargo check` 0 warnings on Windows, `cargo test --no-run` clean, `cargo test rtsp` 35 passed. Clippy's remaining notes are pre-existing style lints (complex type, argument count, `map_or`), untouched.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / Code health
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [x] `npm run check` passes (no frontend change)
- [x] `cargo check` (in `src-tauri`) passes
- [x] I have tested the changes locally (dev + relevant build)
- [x] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes