### PR TITLE
fix(ui): one dropdown look on every platform; macOS logo glued to the traffic lights

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -18,6 +18,22 @@
          here — the panels scroll themselves and the map handles its own gestures. No effect on a
          desktop WebView. */
       body { -webkit-tap-highlight-color: transparent; -webkit-touch-callout: none; }
+
+      /* Dropdowns: one look on every platform. Without this, WKWebView (macOS) draws every <select>
+         as a native NSPopUpButton — light pill, gradient, up/down chevron — ignoring the dark styling
+         the components set; WebView2 and WebKitGTK render a flat box. The chevron is our own; the
+         !important keeps it in front of components that set a `background:` shorthand (which would
+         otherwise clear the image). Component rules still own colour, border, size and text. */
+      select {
+        appearance: none;
+        -webkit-appearance: none;
+        padding-right: 22px !important;
+        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%23949494' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/></svg>") !important;
+        background-repeat: no-repeat !important;
+        background-position: right 7px center !important;
+        background-size: 10px 6px !important;
+      }
+      select:disabled { opacity: 0.5; }
     </style>
     <title>Tauri + SvelteKit + Typescript App</title>
     %sveltekit.head%

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -345,6 +345,12 @@
     gap: 12px;
     min-width: 0;
     overflow: hidden;
+    /* Auto margins, not `space-between` alone, place the three groups: on macOS the traffic lights
+       are a fourth flex child in front of this one, and space-between would hand a third of the free
+       room to the gap between the dots and the logo — the logo drifted towards the centre. With the
+       free room absorbed by these margins the dots stay glued to the logo and the centre group is
+       still centred between left and right on every platform. */
+    margin-right: auto;
   }
 
   .toolbar-center {
@@ -353,6 +359,7 @@
     gap: 10px;
     min-width: 0;
     overflow: hidden;
+    margin: 0 auto; /* see .toolbar-left */
   }
 
   /* Keep every child at its natural size so the group clips as a whole instead of squeezing its


### PR DESCRIPTION
## Description

Two macOS-only visual defects, found on the new macOS VM; both fixes are platform-neutral CSS.

**Dropdowns rendered as native macOS popup buttons.** None of the ~90 `<select>` elements set `appearance: none`. WebView2 and WebKitGTK draw a flat box that honours the dark styling the components set; WKWebView draws the native NSPopUpButton (light pill, gradient, up/down chevron) and ignores it. A global rule in `app.html` sets `appearance: none` and our own chevron as an SVG background; the background properties carry `!important` because many components set a `background:` shorthand that would otherwise clear the image. Colour, border, height and text stay with the components. Result: the same dropdown on all three platforms.

**Logo drifted away from the traffic lights.** The toolbar lays out its groups with `justify-content: space-between`. On macOS the window controls are a fourth flex child in front of the left group, so space-between handed a third of the free room to the gap between the dots and the logo. Auto margins on the left and centre groups absorb the free room instead: the dots stay glued to the logo, the centre group remains centred between left and right, and the three-group layout on Windows/Linux is unchanged. On the tablet toolbar (connection controls wrapped to a second row) the centre group now sits centred in the first row instead of right-aligned.

Verified on the macOS VM with native screenshots (toolbar + Settings); `npm run check` 0/0. Committed on the Mac, pushed from the desktop (the VM has no GitHub credentials).

Affects: v1.0.0 and earlier (macOS only).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / Code health
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [x] `npm run check` passes
- [x] `cargo check` (in `src-tauri`) passes (no Rust change)
- [x] I have tested the changes locally (dev + relevant build)
- [x] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes
