### PR TITLE
feat(video): macOS native RTSP decode sink — AVSampleBufferDisplayLayer under the WebView (P3, macOS)

### DIFF
--- a/docs/dev/active/RTSP_APPLE.md
+++ b/docs/dev/active/RTSP_APPLE.md
@@ -1,5 +1,39 @@
 # RTSP Apple sink — handover brief for the macOS/iOS session (P3)
 
+> **PROGRESS (2026-09-07, branch `feat/rtsp-apple`, built from the Windows session against Marc's macOS
+> Sequoia VM over SSH — not by Sebastian):** **Stages A–C done on macOS**: H.264 and HEVC decode into
+> `AVSampleBufferDisplayLayer` under the transparent WKWebView, verified in-app (OBS HEVC 720p60 from the
+> LAN, MediaMTX/ffmpeg H.264 720p30 on loopback; 60 fps reported, ~9 % CPU for the whole app with
+> VideoToolbox in SOFTWARE — the VM has no GPU, hardware decode remains Sebastian's check on real hardware).
+> **Stage D (iOS) not started.** Deltas from the brief below:
+> - `apple_host.rs` is **macOS-only** for now (AppKit); the UIKit half comes with Stage D. The container
+>   NSView is added `positioned: below, relativeTo: nil` (bottom of the sibling order) — no need to locate
+>   the WKWebView. The sink's layer is created ON the main thread inside `host::attach(make)` (closure
+>   constructor, like `linux_host::attach`) — an off-main creation + `SendLayer` wrapper was tried first
+>   and dropped: edition-2021 closures capture struct fields individually and defeat such wrappers.
+> - **`macOSPrivateApi: true` is required** next to `transparent: true` in `tauri.macos.conf.json`; without
+>   it wry prints "The window is set to be transparent but the macos-private-api is not enabled" and the
+>   WebView stays opaque. Window shadow/corners unaffected (undecorated window).
+> - API generation: the direct layer methods (`enqueueSampleBuffer`/`flush`/`status`/`error`/
+>   `requiresFlushToResumeDecoding`) — our minimum is macOS 13; `sampleBufferRenderer` is 14+. Marked
+>   `#![allow(deprecated)]` with the reason.
+> - Pacing depths 1–3 use the layer's **control timebase** (host clock, rate 1, re-anchored by the Android
+>   `Pacing` logic in 90 kHz ticks); depth 0 = `kCMSampleAttachmentKey_DisplayImmediately`.
+> - Parameter sets: newest instance per type (VPS/SPS/PPS), description rebuilt only when bytes change,
+>   `picture_size()` = `CMVideoFormatDescriptionGetPresentationDimensions(…, cleanAperture: true)`.
+> - **macOS Local Network trap for DEV builds** (Sequoia): the unbundled `target/debug/kite-gc` sometimes gets
+>   `No route to host (os error 65)` to LAN hosts (RTSP and MAVLink alike) while a shell reaches them;
+>   Marc's workaround: run the release app once, quit, start dev again. Loopback sources unaffected.
+> - **Finding to measure on real hardware:** with the video in the panel or the floating window the VM's
+>   WindowServer sat at 210–235 % CPU and the VNC session crawled (one frame per 6–8 s); with the video
+>   swapped to fullscreen it dropped to a usable ~2 fps. Best explanation: the panel's glass
+>   (`backdrop-filter: blur`) stays live on WebKit and re-samples the 60 Hz video layer beneath it in the
+>   software compositor. Metal should absorb that; if Sebastian still measures a WindowServer delta on
+>   hardware, drop the blur on a panel while it hosts a native sink (Windows loses it there anyway).
+> - Dev loop that worked: edit on Windows, `scp` into `~/src/Kite-GC`, `cargo check` over SSH (~10 s),
+>   `just dev` launched detached (`nohup … < /dev/null & disown`), KiteShot screenshots.
+
+
 > Created 2026-09-01 on the Windows machine, after P2.1 (Windows, PR #85), P2.2 (Android,
 > PR #88) and P2.3 (Linux, PR #89) all merged into `development`. This file is the COMPLETE
 > briefing for a Claude session on the Mac: what exists, what to build, in which order, and

--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -32,8 +32,9 @@ below. The release you are reading the docs for is expanded; click an older vers
 
     ??? info "Native RTSP video client with hardware decode"
         RTSP video no longer needs the external video engine: Kite ships its **own RTSP client** and
-        decodes H.264/H.265 with the **operating system's hardware decoder** on Windows, Android and
-        Linux — lower latency, a fraction of the CPU load, and rock-solid reconnects. [#85] · [#88] · [#89]
+        decodes H.264/H.265 with the **operating system's hardware decoder** on Windows, Android,
+        Linux and macOS — lower latency, a fraction of the CPU load, and rock-solid reconnects.
+        [#85] · [#88] · [#89] · [#126]
 
     ??? info "Telemetry API — live telemetry for other programs"
         Kite can now **serve its live telemetry as JSON** to anything that can read it: an NDJSON
@@ -73,7 +74,7 @@ below. The release you are reading the docs for is expanded; click an older vers
     - **iPhone & iPad support** — native iOS/iPadOS build: phone/tablet layout, touch RC, BLE,
       Wi-Fi MAVLink. Contributed by Sebastian Kumor. [#16]
     - **Native RTSP video client** — Kite's own RTSP client with OS hardware decode (H.264/H.265)
-      on Windows [#85], Android [#88] and Linux [#89].
+      on Windows [#85], Android [#88], Linux [#89] and macOS [#126].
     - **Unobstructed fullscreen video** — aspect-exact video box with a blurred follow-map
       backdrop. [#90]
     - **PX4 ULog import** — the logbook imports `.ulg` flash/SD logs, split into flights like any
@@ -147,3 +148,4 @@ below. The release you are reading the docs for is expanded; click an older vers
 [#111]: https://github.com/b14ckyy/Kite-GC/pull/111
 [#112]: https://github.com/b14ckyy/Kite-GC/pull/112
 [#123]: https://github.com/b14ckyy/Kite-GC/pull/123
+[#126]: https://github.com/b14ckyy/Kite-GC/pull/126

--- a/docs/user/guides/video.md
+++ b/docs/user/guides/video.md
@@ -24,9 +24,9 @@ is remembered between sessions.
     nothing should be converted (see the
     [platform notes](#platform-notes-what-to-expect-per-operating-system)).
     **HEVC/H.265** plays wherever the **Kite RTSP client** does the decoding: always on **Android**,
-    and on **Windows** and **Linux** with the *Native RTSP client* toggle on (hardware decode; Windows
-    additionally needs the free "HEVC Video Extensions" from the Microsoft Store). On macOS, HEVC is
-    not available.
+    and on **Windows**, **Linux** and **macOS** with the *Native RTSP client* toggle on (hardware
+    decode; Windows additionally needs the free "HEVC Video Extensions" from the Microsoft Store).
+    macOS is the one platform whose classic engine path plays HEVC as well.
 
     Other codecs — VP8, VP9, AV1 — are **not supported**. A stream Kite cannot play usually shows up
     as an endless *"Reconnecting…"* rather than a clear error. If you need one of them, please open a
@@ -91,8 +91,8 @@ The RTSP source has a small **connection manager** built in:
   costs exactly that much extra latency, so leave it at 0 when the picture is already smooth. The
   setting takes effect immediately on the running stream and is remembered.
 - **Native RTSP client (experimental)** — Kite's own built-in stream client: no helper downloads,
-  UDP-first connection with automatic TCP fallback, and native hardware H.264/HEVC decode on Windows
-  and Linux (Android always uses it; there is no toggle there). Recommended on Linux — see the
+  UDP-first connection with automatic TCP fallback, and native hardware H.264/HEVC decode on Windows,
+  Linux and macOS (Android always uses it; there is no toggle there). Recommended on Linux — see the
   [platform notes](#platform-notes-what-to-expect-per-operating-system). If a particular source
   misbehaves with it, switch it off to fall back to the classic engine path.
 
@@ -193,6 +193,13 @@ stack, so a network stream is played directly by the system's hardware-accelerat
 low-CPU, low-latency feed is important to you — and especially if you plan to fly with it — those are
 the platforms we can most confidently recommend. For RTSP network streams, Linux joins them once
 the **Native RTSP client** is switched on — see below.
+
+**On macOS both RTSP routes are available.** The classic engine plays H.264 *and* HEVC directly (the
+macOS browser engine is the only one that accepts HEVC on that path), and the **Native RTSP client**
+toggle switches to Kite's own client: H.264 and HEVC are decoded by the system's VideoToolbox and
+drawn straight into the video area — no helper programs, UDP-first with TCP fallback, mirror and
+rotate live. Either route is fine; the native one skips the helper download and the local relay leg.
+The detached Video Window stays Windows-only.
 
 **On Linux, switch on the *Native RTSP client* for network streams.** With that toggle (Video panel →
 RTSP section) Kite plays RTSP itself: **H.264 and HEVC go straight into the machine's hardware

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2583,9 +2583,15 @@ dependencies = [
  "ndk-context",
  "num-traits",
  "objc2 0.6.4",
+ "objc2-app-kit",
+ "objc2-av-foundation",
  "objc2-core-bluetooth 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-core-location",
+ "objc2-core-media",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
@@ -3123,9 +3129,62 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-media",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -3153,13 +3212,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -3170,10 +3242,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3184,6 +3269,47 @@ checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.6.2",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3238,15 +3364,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-metal",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"
 
 [dependencies]
 md-5 = "0.10"
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
@@ -162,4 +162,14 @@ objc2-foundation = { version = "0.3", features = ["NSArray", "NSString", "NSEnum
 # default-features = false on purpose: the crate's default set drags in objc2-contacts (CNPostalAddress,
 # for CLPlacemark geocoding) which a GCS has no business linking.
 objc2-core-location = { version = "0.3", default-features = false, features = ["std", "CLLocation", "CLLocationManager", "CLLocationManagerDelegate", "CLError"] }
+# Native RTSP decode sink for macOS (video/apple_sink.rs + apple_host.rs, MOBILE_RTSP P3): compressed
+# H.264/HEVC access units go into an AVSampleBufferDisplayLayer (VideoToolbox decodes inside it) hosted
+# in a layer-backed NSView BELOW the transparent WKWebView — the hole-punch pattern of the other three
+# ports. Same objc2 generation as above; only the features for the types used.
+objc2-app-kit = { version = "0.3", features = ["NSView", "NSWindow", "NSResponder", "NSGraphics", "objc2-quartz-core"] }
+objc2-quartz-core = { version = "0.3", features = ["CALayer", "CATransform3D", "objc2-core-foundation", "objc2-core-graphics"] }
+objc2-av-foundation = { version = "0.3", default-features = false, features = ["std", "AVSampleBufferDisplayLayer", "AVQueuedSampleBufferRendering", "AVAnimation", "objc2-core-media", "objc2-quartz-core"] }
+objc2-core-media = { version = "0.3", features = ["CMBase", "CMTime", "CMSync", "CMBlockBuffer", "CMFormatDescription", "CMSampleBuffer"] }
+objc2-core-foundation = { version = "0.3", features = ["CFBase", "CFArray", "CFDictionary", "CFNumber", "CFString"] }
+objc2-core-graphics = { version = "0.3", features = ["CGColor", "CGGeometry"] }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -452,6 +452,10 @@ pub fn run() {
             // MOBILE_RTSP.md P2.3). Needs the transparent window from tauri.linux.conf.json.
             #[cfg(target_os = "linux")]
             video::linux_host::install(_app.handle());
+            // macOS: the AppKit video layer below the WebView (hole-punch decode sink,
+            // MOBILE_RTSP.md P3). Needs the transparent window from tauri.macos.conf.json.
+            #[cfg(target_os = "macos")]
+            video::apple_host::install(_app.handle());
 
             // Linux/WebKitGTK: stop trackpad/keyboard gestures from zooming the whole WebView frame.
             // WebKitGTK handles these natively in GTK and ignores any JS `preventDefault`, so they can

--- a/src-tauri/src/video/apple_host.rs
+++ b/src-tauri/src/video/apple_host.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+//! AppKit host for the macOS hole-punch video layer (MOBILE_RTSP.md P3) — the macOS counterpart
+//! of `linux_host` / the Android `NativeVideo` view: one layer-backed NSView BELOW the transparent
+//! WKWebView in the main window's content view, visible wherever the DOM cut its hole.
+//!
+//! View tree (built once at startup, nothing is re-parented — wry keeps its own view tree):
+//!
+//!   NSWindow.contentView
+//!     ├─ container NSView (ours, added `positioned: below` every existing sibling)
+//!     │    layer: opaque black (the letterbox must be opaque — a transparent gap shows the desktop
+//!     │           through the transparent window), `masksToBounds` = the VISIBLE box
+//!     │      └─ the sink's AVSampleBufferDisplayLayer at the FULL box, offset into the container
+//!     └─ WKWebView (wry's) — see-through thanks to `"transparent": true` in tauri.macos.conf.json
+//!
+//! That is the two-rect sink contract: the video is laid out (aspect-fit) in the full box and CUT at
+//! the visible edge — a scrolled panel crops the picture, never shrinks it.
+//!
+//! AppKit is main-thread only: every mutation hops onto the main thread through the app handle
+//! (`run_on_main_thread`); the callers are the RTSP/sink worker threads. Geometry arrives in
+//! PHYSICAL px (the frontend's devicePixelRatio-scaled rects) and is mapped to points through the
+//! window's backing scale factor. AppKit's content view is NOT flipped: y grows upwards, so rects
+//! are converted from the DOM's top-left origin here, in one place.
+
+// The CATransform3D C helpers are flagged as renamed (`CATransform3D::concat` & co.); the C
+// names are what Apple documents and read identically to the AppKit/QuartzCore literature.
+#![allow(deprecated)]
+
+use std::cell::RefCell;
+use std::sync::OnceLock;
+
+use objc2::rc::Retained;
+use objc2::MainThreadMarker;
+use objc2_app_kit::{NSView, NSWindow, NSWindowOrderingMode};
+use objc2_core_foundation::{CGPoint, CGRect, CGSize};
+use objc2_core_graphics::CGColor;
+use objc2_quartz_core::{CALayer, CATransform3D, CATransform3DConcat, CATransform3DIdentity, CATransform3DMakeRotation, CATransform3DMakeScale};
+use tauri::{AppHandle, Manager};
+
+/// Main-thread state; `None` until installed.
+struct Host {
+    window: Retained<NSWindow>,
+    container: Retained<NSView>,
+    /// The sink's display layer, while one is attached.
+    video: Option<Retained<CALayer>>,
+    /// Last rect pushed (physical px: x, y, w, h, cx, cy, cw, ch) — re-applied when a layer is
+    /// attached after the rect arrived.
+    rect: [i32; 8],
+    mirror: bool,
+    rotate180: bool,
+}
+
+thread_local! {
+    static HOST: RefCell<Option<Host>> = const { RefCell::new(None) };
+}
+
+/// The app handle, kept for the main-thread hops (`on_main`).
+static APP: OnceLock<AppHandle> = OnceLock::new();
+
+/// Install the video layer under the main window's WebView. Call once from Tauri's setup (the
+/// window exists by then). Failure leaves the window as it was and only costs the native sink route.
+pub fn install(app: &AppHandle) {
+    let _ = APP.set(app.clone());
+    let handle = app.clone();
+    let hop = app.run_on_main_thread(move || {
+        if let Err(e) = install_main(&handle) {
+            log::warn!("[video] apple host: {e} — the native decode sink is unavailable");
+        }
+    });
+    if let Err(e) = hop {
+        log::warn!("[video] apple host: main-thread hop failed: {e}");
+    }
+}
+
+fn install_main(app: &AppHandle) -> Result<(), String> {
+    let Some(mtm) = MainThreadMarker::new() else {
+        return Err("not on the main thread".into());
+    };
+    if HOST.with(|h| h.borrow().is_some()) {
+        return Ok(());
+    }
+    let window = app.get_webview_window("main").ok_or("no main window")?;
+    let ns_window = window.ns_window().map_err(|e| format!("ns_window: {e}"))?;
+    // SAFETY: tauri hands out the live NSWindow of this window; retaining it keeps it valid for
+    // the host's lifetime (the app's main window lives as long as the app).
+    let ns_window: Retained<NSWindow> = unsafe {
+        Retained::retain(ns_window.cast::<NSWindow>()).ok_or("null NSWindow")?
+    };
+    let content = ns_window.contentView().ok_or("window has no content view")?;
+
+    let container = NSView::initWithFrame(
+        mtm.alloc::<NSView>(),
+        CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(1.0, 1.0)),
+    );
+    container.setWantsLayer(true);
+    if let Some(layer) = container.layer() {
+        let black = CGColor::new_generic_rgb(0.0, 0.0, 0.0, 1.0);
+        layer.setBackgroundColor(Some(&black));
+        layer.setMasksToBounds(true);
+    }
+    container.setHidden(true);
+    // Below every existing sibling — the WebView included — so it paints only where the DOM is
+    // transparent. Nothing is removed or re-parented.
+    content.addSubview_positioned_relativeTo(&container, NSWindowOrderingMode::Below, None);
+
+    log::info!(
+        "[video] apple host: video layer installed (backing scale {})",
+        ns_window.backingScaleFactor()
+    );
+    HOST.with(|h| {
+        *h.borrow_mut() = Some(Host {
+            window: ns_window,
+            container,
+            video: None,
+            rect: [0, 0, 1, 1, 0, 0, 1, 1],
+            mirror: false,
+            rotate180: false,
+        })
+    });
+    Ok(())
+}
+
+/// Run `f` against the host on the main thread. Silently nothing without a host (install failed
+/// / not called — the MJPEG route needs none of this).
+fn on_main(f: impl FnOnce(&mut Host) + Send + 'static) {
+    let Some(app) = APP.get() else { return };
+    let _ = app.run_on_main_thread(move || {
+        HOST.with(|h| {
+            if let Some(host) = h.borrow_mut().as_mut() {
+                f(host);
+            }
+        });
+    });
+}
+
+/// Apply `host.rect` to the container (visible box) and the video layer (full box), converting
+/// physical px with a top-left origin into points with AppKit's bottom-left origin.
+fn layout(host: &Host) {
+    let s = host.window.backingScaleFactor().max(1.0);
+    let p = |v: i32| v as f64 / s;
+    let [x, y, w, h, cx, cy, cw, ch] = host.rect;
+    let Some(content) = host.window.contentView() else { return };
+    let content_h = content.frame().size.height;
+    let (cw_pt, ch_pt) = (p(cw).max(1.0), p(ch).max(1.0));
+    host.container.setFrame(CGRect::new(
+        CGPoint::new(p(cx), content_h - p(cy) - ch_pt),
+        CGSize::new(cw_pt, ch_pt),
+    ));
+    if let Some(video) = &host.video {
+        let (w_pt, h_pt) = (p(w).max(1.0), p(h).max(1.0));
+        // Inside the container's layer (bottom-left origin): the full box offset by the clip.
+        let left = p(x - cx);
+        let bottom = ch_pt - p(y - cy) - h_pt;
+        video.setBounds(CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(w_pt, h_pt)));
+        video.setPosition(CGPoint::new(left + w_pt / 2.0, bottom + h_pt / 2.0));
+        video.setContentsScale(s);
+        video.setTransform(transform(host.mirror, host.rotate180));
+    }
+}
+
+/// Mirror = flip x; rotate-180 = half turn about z; both compose. Around the layer's centre
+/// (anchor point 0.5/0.5), so the picture stays in its box.
+fn transform(mirror: bool, rotate180: bool) -> CATransform3D {
+    let mut t = unsafe { CATransform3DIdentity };
+    if mirror {
+        t = CATransform3DConcat(t, CATransform3DMakeScale(-1.0, 1.0, 1.0));
+    }
+    if rotate180 {
+        t = CATransform3DConcat(t, CATransform3DMakeRotation(std::f64::consts::PI, 0.0, 0.0, 1.0));
+    }
+    t
+}
+
+/// On-screen rect (PHYSICAL px, window client coords, top-left origin): FULL box `x/y/w/h` for the
+/// video's aspect-fit layout, VISIBLE box `cx/cy/cw/ch` for the clip.
+#[allow(clippy::too_many_arguments)]
+pub fn set_rect(x: i32, y: i32, w: i32, h: i32, cx: i32, cy: i32, cw: i32, ch: i32) {
+    on_main(move |host| {
+        host.rect = [x, y, w, h, cx, cy, cw, ch];
+        layout(host);
+    });
+}
+
+/// Show/hide the layer (no DOM surface wants it right now).
+pub fn set_visible(visible: bool) {
+    on_main(move |host| host.container.setHidden(!visible));
+}
+
+/// Mirror / 180° rotation — a transform on the display layer, no decoder involvement.
+pub fn set_orient(mirror: bool, rotate180: bool) {
+    on_main(move |host| {
+        host.mirror = mirror;
+        host.rotate180 = rotate180;
+        layout(host);
+    });
+}
+
+/// Build the sink's display layer ON the main thread (`make` runs there — AppKit/CoreAnimation
+/// objects are created where they are used), put it into the container, replacing any previous
+/// one, and lay it out at the last known rect. Returns once the main thread has done it (`Ok`)
+/// or an error if no host exists.
+pub fn attach(make: impl FnOnce() -> Retained<CALayer> + Send + 'static) -> Result<(), String> {
+    let (tx, rx) = std::sync::mpsc::channel::<bool>();
+    on_main(move |host| {
+        detach_layer(host);
+        let layer = make();
+        if let Some(root) = host.container.layer() {
+            root.addSublayer(&layer);
+        }
+        host.video = Some(layer);
+        layout(host);
+        let _ = tx.send(true);
+    });
+    match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+        Ok(true) => Ok(()),
+        _ => Err("no video host installed (main-thread install failed?)".into()),
+    }
+}
+
+/// Remove the sink's layer (the container stays for the next stream).
+pub fn detach() {
+    on_main(|host| detach_layer(host));
+}
+
+fn detach_layer(host: &mut Host) {
+    if let Some(v) = host.video.take() {
+        v.removeFromSuperlayer();
+    }
+}

--- a/src-tauri/src/video/apple_sink.rs
+++ b/src-tauri/src/video/apple_sink.rs
@@ -1,0 +1,629 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+//! macOS hardware video decode sink (MOBILE_RTSP.md P3) — the AVFoundation counterpart of
+//! `win_sink` / `android_sink`: H.264/HEVC access units from the RTSP client are wrapped as
+//! compressed `CMSampleBuffer`s and enqueued into an `AVSampleBufferDisplayLayer`, which decodes
+//! them through VideoToolbox and renders straight into the hole-punch layer below the WebView
+//! (`apple_host.rs`). One decode thread owns the conversion; the layer lives in the host.
+//!
+//! The real work is the framing conversion: the depacketizer delivers Annex-B (start codes,
+//! in-band parameter sets), CoreMedia wants AVCC/HVCC (4-byte big-endian length prefixes, the
+//! parameter sets in a `CMVideoFormatDescription`). Per AU the NAL units are split, VPS/SPS/PPS
+//! are captured (the description is rebuilt only when their bytes change — encoders resend
+//! identical sets on every keyframe), and the slice/SEI units are re-emitted length-prefixed.
+//!
+//! Presentation: with the smoothing buffer at 0 (the latency-first default) every sample is
+//! tagged `DisplayImmediately`. Depths 1–3 schedule each frame `depth × frame-interval` behind
+//! the media timeline on the layer's control timebase — the Android `Pacing` logic (EMA
+//! interval, anchor, re-anchor on jumps or depth changes).
+//!
+//! Resume on keyframe: after a flush (decode error, `requiresFlushToResumeDecoding`) AUs are
+//! dropped until one carries an IDR/IRAP, so the decoder never restarts mid-GOP.
+
+// API generation: the direct AVSampleBufferDisplayLayer enqueue/flush/status methods are what
+// macOS 13 (our minimum) offers; macOS 14 moved them to `sampleBufferRenderer` and marked these
+// deprecated. One generation, targeted cleanly — revisit when the minimum OS moves to 14.
+// (`CMTimebase::create_with_master_clock` and `CFDictionarySetValue` are renamed-only.)
+#![allow(deprecated)]
+
+use std::ptr::{null, null_mut, NonNull};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use objc2::rc::Retained;
+use objc2_av_foundation::{
+    AVLayerVideoGravityResizeAspect, AVQueuedSampleBufferRenderingStatus, AVSampleBufferDisplayLayer,
+};
+use objc2_core_foundation::{kCFBooleanTrue, CFArray, CFDictionarySetValue, CFMutableDictionary, CFRetained};
+use objc2_core_media::{
+    kCMBlockBufferAssureMemoryNowFlag, kCMSampleAttachmentKey_DisplayImmediately, kCMTimeInvalid,
+    CMBlockBuffer, CMClock, CMFormatDescription, CMSampleBuffer, CMSampleTimingInfo, CMTime, CMTimebase,
+    CMVideoFormatDescriptionCreateFromH264ParameterSets, CMVideoFormatDescriptionCreateFromHEVCParameterSets,
+    CMVideoFormatDescriptionGetPresentationDimensions,
+};
+
+use super::apple_host as host;
+use super::rtsp::VideoCodec;
+
+/// How long the initial layer attach may take (one main-thread hop away) before the sink
+/// declares failure.
+const FIRST_LAYER_TIMEOUT: Duration = Duration::from_secs(10);
+/// RTP video clock — the timestamps `push` receives are 90 kHz ticks.
+const TIMESCALE: i32 = 90_000;
+
+enum Cmd {
+    /// One access unit (Annex-B, in-band parameter sets) + its unwrapped 90 kHz timestamp.
+    Frame(Vec<u8>, u64),
+    Orient { mirror: bool, rotate180: bool },
+    Stop,
+}
+
+#[derive(Default)]
+struct Shared {
+    error: Mutex<Option<String>>,
+    presented: AtomicU64,
+    width: AtomicU32,
+    height: AtomicU32,
+    /// Smoothing-buffer depth in frames (0 = display immediately).
+    buffer_frames: AtomicU32,
+    stopping: AtomicBool,
+    /// No DOM surface on screen — the layer is hidden by the host; decoding continues so the
+    /// picture is there the instant it comes back.
+    hidden: AtomicBool,
+}
+
+impl Shared {
+    fn fail(&self, msg: String) {
+        log::warn!("[video] apple sink: {msg}");
+        self.error.lock().unwrap().get_or_insert(msg);
+    }
+}
+
+/// The display layer, shared between the main thread (tree, geometry) and the decode thread
+/// (enqueue / flush / status — AVFoundation's queued-rendering entry points are thread-safe).
+struct Layer(Retained<AVSampleBufferDisplayLayer>);
+// SAFETY: the layer's tree membership and geometry are only touched on the main thread (host);
+// the decode thread uses the enqueue/flush/status calls, which AVFoundation documents as
+// callable from any thread.
+unsafe impl Send for Layer {}
+unsafe impl Sync for Layer {}
+
+pub struct AppleVideoSink {
+    tx: Sender<Cmd>,
+    thread: Option<JoinHandle<()>>,
+    shared: Arc<Shared>,
+}
+
+impl AppleVideoSink {
+    /// Bring the sink up for `codec`: create the display layer (on the main thread, inside the
+    /// host's container) and start the decode thread. Decoder problems surface later through
+    /// [`Self::error`] — the same contract as the other sinks.
+    pub fn start(codec: VideoCodec) -> Result<Self, String> {
+        let hevc = matches!(codec, VideoCodec::H265);
+        let shared = Arc::new(Shared::default());
+        let (tx, rx) = std::sync::mpsc::channel();
+        let thread = {
+            let shared = shared.clone();
+            std::thread::spawn(move || {
+                decode_loop(hevc, &rx, &shared);
+                host::detach();
+            })
+        };
+        Ok(Self { tx, thread: Some(thread), shared })
+    }
+
+    /// Queue one access unit (Annex-B) with its unwrapped 90 kHz timestamp.
+    pub fn push(&self, au: Vec<u8>, ts90k: u64) {
+        let _ = self.tx.send(Cmd::Frame(au, ts90k));
+    }
+
+    /// First fatal sink error, if any — the stream ends on it (see rtsp_native).
+    pub fn error(&self) -> Option<String> {
+        self.shared.error.lock().unwrap().clone()
+    }
+
+    /// On-screen video rect (PHYSICAL px, window coords): the FULL box `x/y/w/h` for the
+    /// aspect-fit layout plus the VISIBLE part `cx/cy/cw/ch` — the host clips the video at that
+    /// edge (scrolled panels), it never shrinks into the remainder.
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_rect(&self, x: i32, y: i32, w: i32, h: i32, cx: i32, cy: i32, cw: i32, ch: i32) {
+        host::set_rect(x, y, w, h, cx, cy, cw, ch);
+    }
+
+    pub fn set_visible(&self, visible: bool) {
+        self.shared.hidden.store(!visible, Ordering::Relaxed);
+        host::set_visible(visible);
+    }
+
+    /// Smoothing-buffer depth in frames (0 = display immediately — the latency-first default).
+    pub fn set_buffer(&self, frames: u32) {
+        self.shared.buffer_frames.store(frames.min(3), Ordering::Relaxed);
+    }
+
+    /// Mirror / 180° rotation — a layer transform, applied live.
+    pub fn set_orient(&self, mirror: bool, rotate180: bool) {
+        let _ = self.tx.send(Cmd::Orient { mirror, rotate180 });
+    }
+
+    pub fn frames_presented(&self) -> u64 {
+        self.shared.presented.load(Ordering::Relaxed)
+    }
+
+    /// Display picture size (clean aperture, not the coded size), once the parameter sets arrived.
+    pub fn picture_size(&self) -> Option<(u32, u32)> {
+        let w = self.shared.width.load(Ordering::Relaxed);
+        let h = self.shared.height.load(Ordering::Relaxed);
+        (w > 0 && h > 0).then_some((w, h))
+    }
+}
+
+impl Drop for AppleVideoSink {
+    fn drop(&mut self) {
+        self.shared.stopping.store(true, Ordering::SeqCst);
+        let _ = self.tx.send(Cmd::Stop);
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+/// Create the display layer on the main thread (inside the host's attach) and return the shared
+/// handle the decode thread enqueues through.
+fn create_layer() -> Result<Arc<Layer>, String> {
+    let slot: Arc<Mutex<Option<Arc<Layer>>>> = Arc::new(Mutex::new(None));
+    let fill = slot.clone();
+    let (tx, rx) = std::sync::mpsc::channel::<Result<(), String>>();
+    std::thread::spawn(move || {
+        let res = host::attach(move || {
+            // SAFETY: plain AVFoundation object creation + property setup on the main thread.
+            let layer = unsafe { AVSampleBufferDisplayLayer::new() };
+            unsafe {
+                if let Some(g) = AVLayerVideoGravityResizeAspect {
+                    layer.setVideoGravity(g);
+                }
+            }
+            *fill.lock().unwrap() = Some(Arc::new(Layer(layer.clone())));
+            Retained::into_super(layer)
+        });
+        let _ = tx.send(res);
+    });
+    rx.recv_timeout(FIRST_LAYER_TIMEOUT)
+        .map_err(|_| "display layer attach timed out".to_string())??;
+    let layer = slot.lock().unwrap().take();
+    layer.ok_or_else(|| "display layer was not created".into())
+}
+
+/// The decode thread: attach the layer, then convert + enqueue AUs until stop.
+fn decode_loop(hevc: bool, rx: &Receiver<Cmd>, shared: &Shared) {
+    let layer = match create_layer() {
+        Ok(l) => l,
+        Err(e) => {
+            shared.fail(e);
+            return;
+        }
+    };
+    log::info!("[video] apple sink: display layer up ({})", if hevc { "HEVC" } else { "H.264" });
+
+    let mut sets = ParameterSets::default();
+    let mut format: Option<CFRetained<CMFormatDescription>> = None;
+    // The first session starts on the stream's first intra frame; a flush restarts the wait.
+    let mut wait_for_idr = true;
+    let mut pacing = Pacing::default();
+    let mut timebase: Option<CFRetained<CMTimebase>> = None;
+
+    loop {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(Cmd::Stop) | Err(RecvTimeoutError::Disconnected) => {
+                unsafe { layer.0.flushAndRemoveImage() };
+                return;
+            }
+            Ok(Cmd::Orient { mirror, rotate180 }) => host::set_orient(mirror, rotate180),
+            Ok(Cmd::Frame(au, ts90k)) => {
+                // Parameter sets first — a rebuilt description is what makes the next IDR decodable.
+                let changed = sets.absorb(hevc, &au);
+                if changed || format.is_none() {
+                    match sets.format_description(hevc) {
+                        Ok(Some(desc)) => {
+                            // SAFETY: valid description from the create call above.
+                            let dims = unsafe {
+                                CMVideoFormatDescriptionGetPresentationDimensions(&desc, false, true)
+                            };
+                            if dims.width > 0.0 && dims.height > 0.0 {
+                                shared.width.store(dims.width as u32, Ordering::Relaxed);
+                                shared.height.store(dims.height as u32, Ordering::Relaxed);
+                                log::info!("[video] apple sink: picture {}x{}", dims.width as u32, dims.height as u32);
+                            }
+                            format = Some(desc);
+                            if changed {
+                                // New sets mid-stream: the decoder must restart on the next IDR.
+                                wait_for_idr = true;
+                            }
+                        }
+                        Ok(None) => {} // sets incomplete — keep waiting
+                        Err(e) => {
+                            shared.fail(e);
+                            return;
+                        }
+                    }
+                }
+                let Some(desc) = format.as_ref() else { continue };
+                if wait_for_idr && !has_intra_frame(hevc, &au) {
+                    continue;
+                }
+                wait_for_idr = false;
+
+                // A layer that failed decoding needs a flush before it accepts anything again.
+                // SAFETY: thread-safe queued-rendering calls.
+                unsafe {
+                    if layer.0.status() == AVQueuedSampleBufferRenderingStatus::Failed {
+                        let msg = layer
+                            .0
+                            .error()
+                            .map(|e| e.localizedDescription().to_string())
+                            .unwrap_or_else(|| "display layer failed".into());
+                        shared.fail(format!("decode failed: {msg}"));
+                        return;
+                    }
+                    if layer.0.requiresFlushToResumeDecoding() {
+                        log::warn!("[video] apple sink: layer requires a flush — resuming on the next keyframe");
+                        layer.0.flush();
+                        wait_for_idr = true;
+                        pacing.anchor = None;
+                        continue;
+                    }
+                }
+
+                let depth = shared.buffer_frames.load(Ordering::Relaxed);
+                let pts = ts90k as i64;
+                // Depth > 0 paces on the control timebase; depth 0 displays immediately. Switching
+                // depth re-anchors the timeline.
+                if depth == 0 {
+                    if timebase.take().is_some() {
+                        unsafe { layer.0.setControlTimebase(None) };
+                    }
+                } else {
+                    let tb = match timebase.as_ref() {
+                        Some(tb) => tb.clone(),
+                        None => match new_timebase() {
+                            Ok(tb) => {
+                                unsafe { layer.0.setControlTimebase(Some(&tb)) };
+                                timebase = Some(tb.clone());
+                                tb
+                            }
+                            Err(e) => {
+                                shared.fail(e);
+                                return;
+                            }
+                        },
+                    };
+                    pacing.schedule(&tb, pts, depth);
+                }
+
+                let sample = match make_sample(hevc, desc, &au, pts, depth == 0) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        shared.fail(e);
+                        return;
+                    }
+                };
+                // SAFETY: valid sample buffer; enqueue is thread-safe.
+                unsafe { layer.0.enqueueSampleBuffer(&sample) };
+                shared.presented.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+        }
+    }
+}
+
+/// A control timebase on the host clock, running at rate 1 — the layer displays a sample when
+/// the timebase reaches its PTS.
+fn new_timebase() -> Result<CFRetained<CMTimebase>, String> {
+    // SAFETY: CoreMedia create call with an out-pointer; the retained result is taken over below.
+    unsafe {
+        let clock = CMClock::host_time_clock();
+        let mut out: *mut CMTimebase = null_mut();
+        let st = CMTimebase::create_with_master_clock(None, &clock, NonNull::new_unchecked(&mut out));
+        if st != 0 || out.is_null() {
+            return Err(format!("CMTimebaseCreate failed ({st})"));
+        }
+        let tb = CFRetained::from_raw(NonNull::new_unchecked(out));
+        tb.set_rate(1.0);
+        Ok(tb)
+    }
+}
+
+/// Presentation pacing for smoothing-buffer depths > 0 (the Android sink's logic): the
+/// timebase is anchored so that a frame's PTS falls `depth × frame-interval` after now; the EMA
+/// of the media frame interval sizes that cushion; a timeline jump or a changed depth re-anchors.
+#[derive(Default)]
+struct Pacing {
+    /// (media pts at anchor, depth) — once anchored, the timebase runs on its own.
+    anchor: Option<(i64, u32)>,
+    /// EMA of the media-time frame interval (90 kHz ticks); seeds at 60 fps.
+    interval: i64,
+    last_pts: Option<i64>,
+}
+
+impl Pacing {
+    fn schedule(&mut self, tb: &CMTimebase, pts: i64, depth: u32) {
+        if self.interval == 0 {
+            self.interval = 1500; // 60 fps in 90 kHz ticks
+        }
+        if let Some(last) = self.last_pts {
+            let delta = pts - last;
+            if (450..=9000).contains(&delta) {
+                self.interval += (delta - self.interval) / 8;
+            }
+        }
+        self.last_pts = Some(pts);
+        let lead = depth as i64 * self.interval;
+        // SAFETY: plain timebase reads/writes.
+        unsafe {
+            let now = tb.time();
+            let now_ticks = if now.timescale == TIMESCALE { now.value } else { now.value * TIMESCALE as i64 / now.timescale.max(1) as i64 };
+            let re_anchor = match self.anchor {
+                Some((_, d)) if d == depth => {
+                    // Drifted past the cushion or behind the clock: re-anchor (no runaway schedule).
+                    let due_in = pts - now_ticks;
+                    !(0..=lead + 9000).contains(&due_in)
+                }
+                _ => true,
+            };
+            if re_anchor {
+                tb.set_time(CMTime::new(pts - lead, TIMESCALE));
+                self.anchor = Some((pts, depth));
+            }
+        }
+    }
+}
+
+/// VPS/SPS/PPS bytes as last seen (emulation prevention kept — CoreMedia wants raw NAL bytes).
+#[derive(Default)]
+struct ParameterSets {
+    vps: Vec<Vec<u8>>,
+    sps: Vec<Vec<u8>>,
+    pps: Vec<Vec<u8>>,
+}
+
+impl ParameterSets {
+    /// Capture the parameter sets in `au`. Returns true when the set changed byte-wise.
+    fn absorb(&mut self, hevc: bool, au: &[u8]) -> bool {
+        let mut changed = false;
+        for nal in nal_units(au) {
+            let Some(&b0) = nal.first() else { continue };
+            let slot = if hevc {
+                match (b0 >> 1) & 0x3f {
+                    32 => &mut self.vps,
+                    33 => &mut self.sps,
+                    34 => &mut self.pps,
+                    _ => continue,
+                }
+            } else {
+                match b0 & 0x1f {
+                    7 => &mut self.sps,
+                    8 => &mut self.pps,
+                    _ => continue,
+                }
+            };
+            if !slot.iter().any(|s| s == nal) {
+                // A re-sent set with the same id but different content replaces; a genuinely new
+                // one (different id) is added. Ids are not parsed: for the streams a GCS meets,
+                // the newest instance per type is what the encoder uses.
+                slot.clear();
+                slot.push(nal.to_vec());
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    /// Build the format description once all required sets are present.
+    fn format_description(&self, hevc: bool) -> Result<Option<CFRetained<CMFormatDescription>>, String> {
+        let mut all: Vec<&[u8]> = Vec::new();
+        if hevc {
+            if self.vps.is_empty() || self.sps.is_empty() || self.pps.is_empty() {
+                return Ok(None);
+            }
+            all.extend(self.vps.iter().map(Vec::as_slice));
+        } else if self.sps.is_empty() || self.pps.is_empty() {
+            return Ok(None);
+        }
+        all.extend(self.sps.iter().map(Vec::as_slice));
+        all.extend(self.pps.iter().map(Vec::as_slice));
+        let mut ptrs: Vec<NonNull<u8>> = all.iter().map(|s| NonNull::from(&s[0])).collect();
+        let mut sizes: Vec<usize> = all.iter().map(|s| s.len()).collect();
+        let mut out: *const CMFormatDescription = null();
+        // SAFETY: the pointer/size arrays outlive the call; CoreMedia copies the sets.
+        let st = unsafe {
+            if hevc {
+                CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+                    None,
+                    all.len(),
+                    NonNull::new_unchecked(ptrs.as_mut_ptr()),
+                    NonNull::new_unchecked(sizes.as_mut_ptr()),
+                    4,
+                    None,
+                    NonNull::new_unchecked(&mut out),
+                )
+            } else {
+                CMVideoFormatDescriptionCreateFromH264ParameterSets(
+                    None,
+                    all.len(),
+                    NonNull::new_unchecked(ptrs.as_mut_ptr()),
+                    NonNull::new_unchecked(sizes.as_mut_ptr()),
+                    4,
+                    NonNull::new_unchecked(&mut out),
+                )
+            }
+        };
+        if st != 0 || out.is_null() {
+            return Err(format!("format description from parameter sets failed ({st})"));
+        }
+        // SAFETY: a +1 retained object from a Create call.
+        Ok(Some(unsafe { CFRetained::from_raw(NonNull::new_unchecked(out as *mut CMFormatDescription)) }))
+    }
+}
+
+/// One compressed sample: the AU's slice/SEI units with 4-byte length prefixes (parameter sets
+/// and access-unit delimiters dropped — they live in the description / carry nothing).
+fn make_sample(
+    hevc: bool,
+    desc: &CMFormatDescription,
+    au: &[u8],
+    pts: i64,
+    display_immediately: bool,
+) -> Result<CFRetained<CMSampleBuffer>, String> {
+    let mut data: Vec<u8> = Vec::with_capacity(au.len() + 16);
+    for nal in nal_units(au) {
+        let Some(&b0) = nal.first() else { continue };
+        let skip = if hevc {
+            matches!((b0 >> 1) & 0x3f, 32 | 33 | 34 | 35)
+        } else {
+            matches!(b0 & 0x1f, 7 | 8 | 9)
+        };
+        if skip {
+            continue;
+        }
+        data.extend_from_slice(&(nal.len() as u32).to_be_bytes());
+        data.extend_from_slice(nal);
+    }
+    if data.is_empty() {
+        return Err("access unit without slices".into());
+    }
+
+    // SAFETY: CoreMedia create calls with out-pointers; every retained result is taken over.
+    unsafe {
+        let mut bb: *mut CMBlockBuffer = null_mut();
+        let st = CMBlockBuffer::create_with_memory_block(
+            None,
+            null_mut(),
+            data.len(),
+            None,
+            null(),
+            0,
+            data.len(),
+            kCMBlockBufferAssureMemoryNowFlag,
+            NonNull::new_unchecked(&mut bb),
+        );
+        if st != 0 || bb.is_null() {
+            return Err(format!("CMBlockBufferCreate failed ({st})"));
+        }
+        let bb = CFRetained::from_raw(NonNull::new_unchecked(bb));
+        let st = CMBlockBuffer::replace_data_bytes(
+            NonNull::new_unchecked(data.as_ptr() as *mut std::ffi::c_void),
+            &bb,
+            0,
+            data.len(),
+        );
+        if st != 0 {
+            return Err(format!("CMBlockBufferReplaceDataBytes failed ({st})"));
+        }
+
+        let timing = CMSampleTimingInfo {
+            duration: kCMTimeInvalid,
+            presentationTimeStamp: CMTime::new(pts, TIMESCALE),
+            decodeTimeStamp: kCMTimeInvalid,
+        };
+        let size = data.len();
+        let mut sb: *mut CMSampleBuffer = null_mut();
+        let st = CMSampleBuffer::create_ready(
+            None,
+            Some(&bb),
+            Some(desc),
+            1,
+            1,
+            &timing,
+            1,
+            &size,
+            NonNull::new_unchecked(&mut sb),
+        );
+        if st != 0 || sb.is_null() {
+            return Err(format!("CMSampleBufferCreateReady failed ({st})"));
+        }
+        let sb = CFRetained::from_raw(NonNull::new_unchecked(sb));
+
+        if display_immediately {
+            if let Some(atts) = sb.sample_attachments_array(true) {
+                let atts: &CFArray = &atts;
+                let dict = atts.value_at_index(0) as *const CFMutableDictionary;
+                if let (Some(dict), Some(yes)) = (dict.as_ref(), kCFBooleanTrue) {
+                    CFDictionarySetValue(
+                        Some(dict),
+                        (kCMSampleAttachmentKey_DisplayImmediately as *const _) as *const std::ffi::c_void,
+                        (yes as *const _) as *const std::ffi::c_void,
+                    );
+                }
+            }
+        }
+        Ok(sb)
+    }
+}
+
+/// Split an Annex-B byte stream into NAL unit payloads (start codes of 3 or 4 bytes).
+fn nal_units(au: &[u8]) -> Vec<&[u8]> {
+    let mut starts: Vec<usize> = Vec::new();
+    let mut i = 0usize;
+    while i + 3 <= au.len() {
+        if au[i] == 0 && au[i + 1] == 0 && au[i + 2] == 1 {
+            starts.push(i + 3);
+            i += 3;
+        } else {
+            i += 1;
+        }
+    }
+    let mut out = Vec::with_capacity(starts.len());
+    for (k, &s) in starts.iter().enumerate() {
+        let mut e = if k + 1 < starts.len() { starts[k + 1] - 3 } else { au.len() };
+        // A 4-byte start code leaves a trailing zero on the previous unit.
+        while e > s && au[e - 1] == 0 {
+            e -= 1;
+        }
+        if e > s {
+            out.push(&au[s..e]);
+        }
+    }
+    out
+}
+
+/// Does this AU contain an intra frame (H.264 IDR / HEVC IRAP)?
+fn has_intra_frame(hevc: bool, au: &[u8]) -> bool {
+    nal_units(au).iter().any(|nal| {
+        let Some(&b0) = nal.first() else { return false };
+        if hevc {
+            (16..=21).contains(&((b0 >> 1) & 0x3f))
+        } else {
+            b0 & 0x1f == 5
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_annex_b_and_finds_idr() {
+        // SPS (7), PPS (8), IDR (5) with 4- and 3-byte start codes.
+        let au = [
+            0, 0, 0, 1, 0x67, 1, 2, // SPS
+            0, 0, 1, 0x68, 3, // PPS
+            0, 0, 0, 1, 0x65, 9, 9, 9, // IDR
+        ];
+        let units = nal_units(&au);
+        assert_eq!(units.len(), 3);
+        assert_eq!(units[0], &[0x67, 1, 2]);
+        assert_eq!(units[1], &[0x68, 3]);
+        assert_eq!(units[2], &[0x65, 9, 9, 9]);
+        assert!(has_intra_frame(false, &au));
+        assert!(!has_intra_frame(true, &au));
+
+        let mut sets = ParameterSets::default();
+        assert!(sets.absorb(false, &au));
+        assert!(!sets.absorb(false, &au), "identical sets must not count as a change");
+        assert_eq!(sets.sps.len(), 1);
+    }
+}

--- a/src-tauri/src/video/mod.rs
+++ b/src-tauri/src/video/mod.rs
@@ -29,6 +29,10 @@ pub mod linux_host;
 /// Linux GStreamer H264/HEVC sink into that host (MOBILE_RTSP.md P2.3).
 #[cfg(target_os = "linux")]
 pub mod linux_sink;
+#[cfg(target_os = "macos")]
+pub mod apple_host;
+#[cfg(target_os = "macos")]
+pub mod apple_sink;
 
 pub use mediamtx::MediaMtx;
 pub use mjpeg_server::MjpegServer;

--- a/src-tauri/src/video/rtsp_native.rs
+++ b/src-tauri/src/video/rtsp_native.rs
@@ -34,6 +34,8 @@ use super::android_sink::AndroidVideoSink;
 use super::win_sink::{SinkCodec, WinVideoSink};
 #[cfg(target_os = "linux")]
 use super::linux_sink::LinuxVideoSink;
+#[cfg(target_os = "macos")]
+use super::apple_sink::AppleVideoSink;
 
 /// The per-OS decode sink behind the shared routing below — same method surface on all
 /// three (start's signature differs and is branched at the one call site).
@@ -43,6 +45,8 @@ type PlatformSink = WinVideoSink;
 type PlatformSink = AndroidVideoSink;
 #[cfg(target_os = "linux")]
 type PlatformSink = LinuxVideoSink;
+#[cfg(target_os = "macos")]
+type PlatformSink = AppleVideoSink;
 
 /// How long `start()` waits for the first frame: RTSP negotiation (incl. a possible 2 s
 /// UDP→TCP fallback) plus the first JPEG.
@@ -104,14 +108,14 @@ pub enum Started {
 }
 
 /// RTP 32-bit timestamp → monotonic 64-bit 90 kHz ticks for the sink's sample times.
-#[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
 #[derive(Default)]
 struct SinkTs {
     unwrapped: u64,
     last: Option<u32>,
 }
 
-#[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
 impl SinkTs {
     fn unwrap(&mut self, ts: u32) -> u64 {
         if let Some(prev) = self.last {
@@ -128,10 +132,10 @@ pub struct NativeRtsp {
     /// The active decode sink, when the stream selected that route. Lives on `self` (not
     /// in `Running`) so the rect/visibility commands can reach it without teardown
     /// plumbing; cleared together with the stream.
-    #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+    #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
     sink: Arc<Mutex<Option<PlatformSink>>>,
     /// Which codec the active sink decodes ("H.264"/"H.265"), for the start verdict.
-    #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+    #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
     sink_codec: Arc<Mutex<Option<&'static str>>>,
     /// Live counters of the running stream (fresh per start) — the Debug Monitor's feed.
     live: Mutex<Option<Arc<LiveRtspStats>>>,
@@ -190,14 +194,14 @@ impl NativeRtsp {
         } else {
             vec![VideoCodec::Mjpeg]
         };
-        // Android and Linux need no window handle — their sinks reach a host installed at
-        // startup (the SurfaceView over JNI / the GTK layer under the WebView).
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        // Android, Linux and macOS need no window handle — their sinks reach a host installed at
+        // startup (the SurfaceView over JNI / the GTK layer / the AppKit view under the WebView).
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         let accept = {
             let _ = parent_hwnd;
             vec![VideoCodec::Mjpeg, VideoCodec::H264, VideoCodec::H265]
         };
-        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
         let accept = {
             let _ = parent_hwnd;
             vec![VideoCodec::Mjpeg]
@@ -245,15 +249,15 @@ impl NativeRtsp {
         let rtsp = {
             let stop = stop.clone();
             let error_slot = error_slot.clone();
-            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
             let sink_slot = self.sink.clone();
-            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
             let sink_codec_slot = self.sink_codec.clone();
             thread::spawn(move || {
                 let mut first = true;
-                #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+                #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
                 let _ = &sink_first;
-                #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+                #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
                 let mut sink_ts: Option<SinkTs> = None;
                 #[cfg(target_os = "linux")]
                 let mut aus_without_sps = 0u32;
@@ -264,7 +268,7 @@ impl NativeRtsp {
                         first = false;
                         let _ = frame_tx.send(part);
                     }
-                    #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+                    #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
                     VideoCodec::H264 | VideoCodec::H265 => {
                         // Linux decides its HEVC route from the SPS: hold the start until an
                         // AU carries one (the depacketizer prepends the sets before an IRAP;
@@ -303,6 +307,8 @@ impl NativeRtsp {
                             let started_sink = AndroidVideoSink::start(frame.codec);
                             #[cfg(target_os = "linux")]
                             let started_sink = LinuxVideoSink::start(frame.codec, sps);
+                            #[cfg(target_os = "macos")]
+                            let started_sink = AppleVideoSink::start(frame.codec);
                             match started_sink {
                                 Ok(sink) => {
                                     *sink_slot.lock().unwrap() = Some(sink);
@@ -334,7 +340,7 @@ impl NativeRtsp {
                         }
                     }
                     // Not on the accept list — the client never selects such a track.
-                    #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+                    #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
                     _ => {}
                 });
                 match result {
@@ -382,7 +388,7 @@ impl NativeRtsp {
         };
         if let Some(mut msg) = failure {
             teardown(Running { stop, shutdown, rtsp, broadcast, accept });
-            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
             drop(self.sink.lock().unwrap().take());
             // The RTSP thread may have written the real reason while we were giving up.
             if let Some(e) = error_slot.lock().ok().and_then(|s| s.clone()) {
@@ -393,7 +399,7 @@ impl NativeRtsp {
         }
 
         let started = {
-            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
             {
                 if self.sink.lock().unwrap().is_some() {
                     Started::Sink {
@@ -403,7 +409,7 @@ impl NativeRtsp {
                     Started::Mjpeg { port }
                 }
             }
-            #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+            #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
             Started::Mjpeg { port }
         };
         match &started {
@@ -429,7 +435,7 @@ impl NativeRtsp {
             log::info!("[video] native RTSP client stopped");
         }
         // After the joins: the RTSP thread pushed into the sink, so it must be gone first.
-        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
         {
             drop(self.sink.lock().unwrap().take());
             *self.sink_codec.lock().unwrap() = None;
@@ -449,7 +455,7 @@ impl NativeRtsp {
             _ => None,
         };
         let sink = {
-            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+            #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
             {
                 self.sink.lock().unwrap().as_ref().map(|s| {
                     let size = s.picture_size();
@@ -469,7 +475,7 @@ impl NativeRtsp {
                     })
                 })
             }
-            #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+            #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
             None::<serde_json::Value>
         };
         Some(serde_json::json!({
@@ -493,49 +499,49 @@ impl NativeRtsp {
     /// it never shrinks it). No-op without a sink (MJPEG route, other OS, stopped).
     #[allow(clippy::too_many_arguments)]
     pub fn sink_rect(&self, x: i32, y: i32, w: i32, h: i32, cx: i32, cy: i32, cw: i32, ch: i32) {
-        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
         if let Some(s) = self.sink.lock().unwrap().as_ref() {
             s.set_rect(x, y, w, h, cx, cy, cw, ch);
         }
-        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
         let _ = (x, y, w, h, cx, cy, cw, ch);
     }
 
     /// Show/hide the decode sink's native layer (no DOM surface wants it right now).
     pub fn sink_visible(&self, visible: bool) {
-        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
         if let Some(s) = self.sink.lock().unwrap().as_ref() {
             s.set_visible(visible);
         }
-        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
         let _ = visible;
     }
 
     /// Smoothing-buffer depth for the decode sink (frames, 0 = present on decode).
     pub fn sink_buffer(&self, frames: u32) {
-        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
         if let Some(s) = self.sink.lock().unwrap().as_ref() {
             s.set_buffer(frames);
         }
-        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
         let _ = frames;
     }
 
     /// Horizontal mirror / 180° rotation of the decode sink's picture.
     pub fn sink_orient(&self, mirror: bool, rotate180: bool) {
-        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
         if let Some(s) = self.sink.lock().unwrap().as_ref() {
             s.set_orient(mirror, rotate180);
         }
-        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
         let _ = (mirror, rotate180);
     }
 
     /// `(frames_presented, picture_size, error)` of the active decode sink; `None` while
-    /// no sink runs. Test hook for the sink end-to-end tests — nothing in the app polls it.
-    #[cfg(test)]
+    /// no sink runs. Test hook for the Windows/Linux sink end-to-end tests — nothing in the app polls it.
+    #[cfg(all(test, any(target_os = "windows", target_os = "linux")))]
     pub fn sink_stats(&self) -> Option<(u64, Option<(u32, u32)>, Option<String>)> {
-        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos"))]
         {
             self.sink
                 .lock()
@@ -543,7 +549,7 @@ impl NativeRtsp {
                 .as_ref()
                 .map(|s| (s.frames_presented(), s.picture_size(), s.error()))
         }
-        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux")))]
+        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "linux", target_os = "macos")))]
         None
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
     "frontendDist": "../build"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "title": "Kite Ground Control",

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "app": {
-    "macOSPrivateApi": true,
     "windows": [
       {
         "title": "Kite Ground Control",

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,5 +1,18 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "macOSPrivateApi": true,
+    "windows": [
+      {
+        "title": "Kite Ground Control",
+        "width": 1280,
+        "height": 800,
+        "dragDropEnabled": true,
+        "decorations": false,
+        "transparent": true
+      }
+    ]
+  },
   "bundle": {
     "targets": ["app", "dmg"],
     "externalBin": ["binaries/ffmpeg"]


### PR DESCRIPTION
## Description

The Kite RTSP client accepted only MJPEG on macOS because there was no decode sink; H.264 and HEVC now decode natively there too — the fourth port of the hole-punch design after Windows (#85), Android (#88) and Linux (#89). Built against the macOS Sequoia VM over SSH from Sebastian's handover brief (`docs/dev/active/RTSP_APPLE.md`), whose PROGRESS block records every delta; iOS (Stage D) is **not** part of this PR.

**`video/apple_host.rs`** — one layer-backed NSView added below every sibling of the main window's content view (nothing re-parented, wry keeps its view tree), opaque-black clip container at the VISIBLE box, the sink's layer at the FULL box inside it (two-rect contract: scrolled panels crop, never shrink), CATransform3D for mirror / rotate-180 applied live, all mutations hopped to the main thread through the app handle, physical px → points via the backing scale factor.

**`video/apple_sink.rs`** — Annex-B access units become length-prefixed `CMSampleBuffer`s enqueued into an `AVSampleBufferDisplayLayer`, which decodes through VideoToolbox. VPS/SPS/PPS build the `CMVideoFormatDescription` (rebuilt only when their bytes change), slices/SEI are re-emitted with 4-byte lengths, depth 0 tags `DisplayImmediately`, depths 1–3 pace on the layer's control timebase with the Android `Pacing` logic in 90 kHz ticks, a flush resumes on the next IDR/IRAP, `picture_size()` reports the clean-aperture presentation dimensions, and a failed layer surfaces its `localizedDescription` as the sink error (stream ends → frontend reconnects).

**Wiring** — `rtsp_native.rs` platform arms include macOS (accept list MJPEG+H264+H265, `PlatformSink` alias, start arm); `tauri.macos.conf.json` gets `transparent` **and** `macOSPrivateApi` (wry needs both for a see-through WKWebView); `lib.rs` installs the host at setup like the Linux one. API generation: the direct layer methods (macOS 13 is our minimum; `sampleBufferRenderer` is 14+), marked with the reason. The `sink_stats` test hook is gated to the platforms whose tests use it.

**Docs** — `video.md` platform notes: macOS has both routes now (the classic engine is also the only one that plays HEVC on that path), native client = VideoToolbox decode, detached window stays Windows-only.

**Verified in the VM (software VideoToolbox, no GPU):** OBS HEVC 720p60 → "Kite RTSP client → native decode", 60 fps at ~9 % CPU for the app; ffmpeg H.264 720p30 on loopback; mirror/rotate, floating window, widget, map swap, stop/start, classic-toggle both ways, reconnect after a source restart. **Open for real hardware (Sebastian):** hardware decode + latency numbers, smoothing-buffer feel, and one measurement — WindowServer CPU with the video in the panel vs. fullscreen (in the VM the panel glass over the 60 Hz layer saturated the software compositor; if hardware shows a delta too, the fix is to drop the panel blur while it hosts a native sink).

Traps recorded for the next port: edition-2021 closures capture struct fields individually (a `Send` wrapper around a `Retained<CALayer>` is bypassed — the layer is built inside the main-thread attach closure instead); Sequoia's Local Network permission intermittently blocks LAN hosts for the unbundled dev binary (run the release app once).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / Code health
- [x] Documentation
- [ ] Build / CI

## Checklist

- [x] `npm run check` passes (no frontend change)
- [x] `cargo check` (in `src-tauri`) passes on macOS and Windows; `cargo test --no-run` on macOS; clippy clean for the new files
- [x] I have tested the changes locally (dev + relevant build)
- [x] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes
