### PR TITLE
Native decode sink keeps step with its hole — control off the frame queue, coalesced IPC, armed layer

### DIFF
--- a/src-tauri/src/video/win_sink.rs
+++ b/src-tauri/src/video/win_sink.rs
@@ -85,17 +85,6 @@ pub enum SinkCodec {
 enum Cmd {
     /// One Annex-B access unit + its (unwrapped) RTP timestamp in 90 kHz ticks.
     Frame(Vec<u8>, u64),
-    /// `full` = the surface's whole box (video layout / aspect fit), `clip` = the visible
-    /// part after scroll-container clipping — the window sits at `clip` and the picture is
-    /// shifted + source-cropped so it gets CUT at the container edge, never shrunk.
-    Rect { full: (i32, i32, i32, i32), clip: (i32, i32, i32, i32) },
-    Visible(bool),
-    /// Smoothing-buffer depth in frames (0 = present on decode, the latency-first
-    /// default). See `SinkState::pump_queue`.
-    Buffer(u32),
-    /// Horizontal mirror / 180° rotation, pre-combined into the two flip axes the video
-    /// processor takes (mirror = flip-H; rotate180 = flip-H+flip-V; both = flip-V).
-    Orient { flip_h: bool, flip_v: bool },
     Stop,
 }
 
@@ -106,6 +95,46 @@ struct Shared {
     size: Mutex<Option<(u32, u32)>>,
     error: Mutex<Option<String>>,
     stopped: AtomicBool,
+    /// Geometry / visibility / orientation, LATEST WINS — deliberately NOT on the frame
+    /// channel. The sink thread handles one channel message per loop pass and each pass
+    /// presents (vsync-paced, ~16 ms), so ~60 control messages a second — what a window drag
+    /// produces — queued up behind the frames and drained at frame rate: the layer trailed
+    /// the DOM by the whole backlog, and a park/unpark landed a second or two late (Marc,
+    /// 2026-09-08). Here a burst collapses to its newest value, applied once per pass.
+    ctrl: Mutex<Ctrl>,
+    ctrl_dirty: AtomicBool,
+}
+
+/// Pending control state (`None` = unchanged since the thread last applied it).
+#[derive(Default)]
+struct Ctrl {
+    /// `full` = the surface's whole box (video layout / aspect fit), `clip` = the visible
+    /// part after scroll-container clipping — the window sits at `clip` and the picture is
+    /// shifted + source-cropped so it gets CUT at the container edge, never shrunk.
+    rect: Option<((i32, i32, i32, i32), (i32, i32, i32, i32))>,
+    visible: Option<bool>,
+    /// Smoothing-buffer depth in frames (0 = present on decode, the latency-first
+    /// default). See `SinkState::pump_queue`.
+    buffer: Option<u32>,
+    /// Horizontal mirror / 180° rotation, pre-combined into the two flip axes the video
+    /// processor takes (mirror = flip-H; rotate180 = flip-H+flip-V; both = flip-V).
+    orient: Option<(bool, bool)>,
+}
+
+impl Shared {
+    /// Queue a control change for the sink thread (latest wins).
+    fn ctrl(&self, f: impl FnOnce(&mut Ctrl)) {
+        f(&mut self.ctrl.lock().unwrap());
+        self.ctrl_dirty.store(true, Ordering::Release);
+    }
+
+    /// Everything queued since the last call, or `None` when nothing changed.
+    fn take_ctrl(&self) -> Option<Ctrl> {
+        if !self.ctrl_dirty.swap(false, Ordering::Acquire) {
+            return None;
+        }
+        Some(std::mem::take(&mut *self.ctrl.lock().unwrap()))
+    }
 }
 
 /// Handle to the sink thread. Dropping stops it.
@@ -149,22 +178,22 @@ impl WinVideoSink {
     /// Full box `x/y/w/h` for the video layout, visible part `cx/cy/cw/ch` for the clip.
     #[allow(clippy::too_many_arguments)]
     pub fn set_rect(&self, x: i32, y: i32, w: i32, h: i32, cx: i32, cy: i32, cw: i32, ch: i32) {
-        let _ = self.tx.send(Cmd::Rect { full: (x, y, w, h), clip: (cx, cy, cw, ch) });
+        self.shared.ctrl(|c| c.rect = Some(((x, y, w, h), (cx, cy, cw, ch))));
     }
 
     pub fn set_visible(&self, visible: bool) {
-        let _ = self.tx.send(Cmd::Visible(visible));
+        self.shared.ctrl(|c| c.visible = Some(visible));
     }
 
     /// Smoothing-buffer depth in frames (0 = present on decode). Capped small — the DXVA
     /// decoder's surface pool is finite and held frames come out of it.
     pub fn set_buffer(&self, frames: u32) {
-        let _ = self.tx.send(Cmd::Buffer(frames.min(3)));
+        self.shared.ctrl(|c| c.buffer = Some(frames.min(3)));
     }
 
     /// Horizontal mirror / 180° rotation of the presented picture.
     pub fn set_orient(&self, mirror: bool, rotate180: bool) {
-        let _ = self.tx.send(Cmd::Orient { flip_h: mirror != rotate180, flip_v: rotate180 });
+        self.shared.ctrl(|c| c.orient = Some((mirror != rotate180, rotate180)));
     }
 
     pub fn frames_presented(&self) -> u64 {
@@ -234,12 +263,37 @@ fn run_sink(
     };
 
     loop {
+        // `stop()` flips this before its channel message, which would otherwise wait out a
+        // frame backlog.
+        if shared.stopped.load(Ordering::Acquire) {
+            break;
+        }
         // Pump the child window's messages (it lives on this thread).
         unsafe {
             let mut msg = MSG::default();
             while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
                 let _ = TranslateMessage(&msg);
                 DispatchMessageW(&msg);
+            }
+        }
+        // Geometry / visibility FIRST and off the frame channel: the newest values win, so a
+        // drag's 60 rect updates a second cost one SetWindowPos per pass instead of queueing
+        // behind the frames (see `Shared::ctrl`). The layer then lands within a pass of the
+        // DOM hole, and show/hide is immediate.
+        if let Some(c) = shared.take_ctrl() {
+            if let Some((full, clip)) = c.rect {
+                unsafe { state.set_rect(full, clip) };
+            }
+            if let Some(v) = c.visible {
+                unsafe {
+                    let _ = ShowWindow(state.hwnd, if v { SW_SHOWNA } else { SW_HIDE });
+                }
+            }
+            if let Some(frames) = c.buffer {
+                state.buffer_frames = frames as usize;
+            }
+            if let Some((flip_h, flip_v)) = c.orient {
+                unsafe { state.set_orient(flip_h, flip_v) };
             }
         }
         match rx.recv_timeout(Duration::from_millis(5)) {
@@ -252,12 +306,6 @@ fn run_sink(
                     *shared.error.lock().unwrap() = Some(e);
                 }
             }
-            Ok(Cmd::Rect { full, clip }) => unsafe { state.set_rect(full, clip) },
-            Ok(Cmd::Visible(v)) => unsafe {
-                let _ = ShowWindow(state.hwnd, if v { SW_SHOWNA } else { SW_HIDE });
-            },
-            Ok(Cmd::Buffer(frames)) => state.buffer_frames = frames as usize,
-            Ok(Cmd::Orient { flip_h, flip_v }) => unsafe { state.set_orient(flip_h, flip_v) },
             Ok(Cmd::Stop) | Err(RecvTimeoutError::Disconnected) => break,
             Err(RecvTimeoutError::Timeout) => {}
         }

--- a/src/lib/controllers/nativeVideo.ts
+++ b/src/lib/controllers/nativeVideo.ts
@@ -109,12 +109,68 @@ export function nativeSurface(el: HTMLElement, id: NativeSurfaceId): { destroy()
   };
 }
 
+// ── Arming ───────────────────────────────────────────────────────────────────────────────────
+// The native layer is a separate compositor surface: the DOM paints its new position in the very
+// frame it is asked to, the layer follows an IPC hop and a window move later. Standing still that is
+// invisible — but a hole that opens before the layer has arrived shows the page behind it, which is
+// how a stream coming back (start, unpark, a panel scrolling into view) used to flash.
+//
+// So the layer is ARMED before any hole is cut: rect and show are sent first, and only once the
+// backend has taken both does a surface go transparent. The picture is then already there when the
+// transparency arrives; at worst it is briefly covered by the opaque DOM, which nobody sees.
+/** False while the sink is hidden or still moving into place — the DOM must stay opaque. */
+let armed = true;
+let armPending = false;
+
+/** Bumped whenever the sink is taken away again — an arming round that started before that
+ *  must not report success and open a hole over a hidden layer. */
+let armGen = 0;
+
+/** Position the layer and show it; the DOM opens its hole only once both have landed. */
+function armSurface(phys: Record<string, number>): void {
+  if (armPending) return;
+  armPending = true;
+  const gen = armGen;
+  lastRectKey = rectKey(phys);
+  lastVisible = true;
+  Promise.all([
+    invoke('video_rtsp_native_sink_rect', phys),
+    invoke('video_rtsp_native_sink_visible', { visible: true }),
+  ])
+    .catch(() => {})
+    .finally(() => {
+      armPending = false;
+      if (gen === armGen) armed = true;
+    });
+}
+
+function rectKey(p: Record<string, number>): string {
+  return `${p.x},${p.y},${p.w},${p.h},${p.cx},${p.cy},${p.cw},${p.ch}`;
+}
+
+/** Hide the layer and take every hole back (no surface on screen). */
+function hideSink(): void {
+  if (lastVisible !== false) {
+    lastVisible = false;
+    sendVisible(false);
+  }
+  if (get(activeNativeSurface) !== null) activeNativeSurface.set(null);
+  if (armed || armPending) armGen++;
+  armed = false;
+  clearClips();
+  lastRectKey = '';
+}
+
 /** Start following surfaces (call when the sink route reports live). Idempotent. */
 export function startNativeSurfaceRouter(): void {
   if (running || typeof window === 'undefined') return;
   running = true;
   lastRectKey = '';
   lastVisible = null;
+  // The first appearance takes the same route as the return from a gesture: place the layer,
+  // show it, and only then let a surface cut its hole.
+  armed = false;
+  armPending = false;
   raf = requestAnimationFrame(tick);
 }
 
@@ -214,6 +270,49 @@ function visibleRect(el: HTMLElement, rect: DOMRect, id: NativeSurfaceId): DOMRe
 /** Dev diagnostics: which ancestor produced each clipped edge in the last visibleRect. */
 let lastClipBy = '';
 
+// Rect / visibility are pushed over IPC, which is a QUEUE: a drag produces a new rect every
+// animation frame, and anything that cannot keep up (the WebView's message pump, the backend's
+// sink thread) turns that stream into a growing backlog — the layer then trails the DOM by the
+// whole queue instead of by a frame. So only ever ONE call of each kind is in flight; while it
+// is, the newest value is remembered and sent when it settles. Older values are simply dropped:
+// nobody wants a position the window has already left.
+let rectInFlight = false;
+let pendingRect: Record<string, number> | null = null;
+let visibleInFlight = false;
+let pendingVisible: boolean | null = null;
+
+function sendRect(phys: Record<string, number>): void {
+  if (rectInFlight) {
+    pendingRect = phys;
+    return;
+  }
+  rectInFlight = true;
+  void invoke('video_rtsp_native_sink_rect', phys)
+    .catch(() => {})
+    .finally(() => {
+      rectInFlight = false;
+      const next = pendingRect;
+      pendingRect = null;
+      if (next) sendRect(next);
+    });
+}
+
+function sendVisible(visible: boolean): void {
+  if (visibleInFlight) {
+    pendingVisible = visible;
+    return;
+  }
+  visibleInFlight = true;
+  void invoke('video_rtsp_native_sink_visible', { visible })
+    .catch(() => {})
+    .finally(() => {
+      visibleInFlight = false;
+      const next = pendingVisible;
+      pendingVisible = null;
+      if (next !== null && next !== visible) sendVisible(next);
+    });
+}
+
 /** Viewport-x (css px) beyond which no surface is visible — the phone's widget column edge; null
  *  = no bound. Set by +page (it owns the column width and its replay-player slide). */
 let rightBound: number | null = null;
@@ -237,16 +336,13 @@ function coverBox(el: HTMLElement, rect: DOMRect): DOMRect {
 function tick(): void {
   if (!running) return;
   const c = chosen();
-  if (get(activeNativeSurface) !== (c?.id ?? null)) activeNativeSurface.set(c?.id ?? null);
   const vis = c ? visibleRect(c.el, c.rect, c.id) : null;
+  if (armed && get(activeNativeSurface) !== (c && vis ? c.id : null)) {
+    activeNativeSurface.set(c && vis ? c.id : null);
+  }
   if (!c || !vis) {
     // No surface — or the active one is scrolled entirely out of its container.
-    if (lastVisible !== false) {
-      lastVisible = false;
-      void invoke('video_rtsp_native_sink_visible', { visible: false }).catch(() => {});
-    }
-    clearClips();
-    lastRectKey = '';
+    hideSink();
     if (import.meta.env.DEV) nativeHoleDebug.set(null); // no hole → no stale readout
   } else {
     // Two rects go to the sink: the surface's FULL box for video layout (aspect fit), and
@@ -269,14 +365,22 @@ function tick(): void {
       cw: Math.round(hole.width * dpr),
       ch: Math.round(hole.height * dpr),
     };
+    if (!armed) {
+      // The layer is hidden (stream just came up, surface scrolled back in): move it into place
+      // and show it, and leave the DOM opaque until the backend has both. Nothing else this pass —
+      // the clips below would cut a hole the layer is not behind yet.
+      armSurface(phys);
+      raf = requestAnimationFrame(tick);
+      return;
+    }
     if (lastVisible !== true) {
       lastVisible = true;
-      void invoke('video_rtsp_native_sink_visible', { visible: true }).catch(() => {});
+      sendVisible(true);
     }
-    const key = `${phys.x},${phys.y},${phys.w},${phys.h},${phys.cx},${phys.cy},${phys.cw},${phys.ch}`;
+    const key = rectKey(phys);
     if (key !== lastRectKey) {
       lastRectKey = key;
-      void invoke('video_rtsp_native_sink_rect', phys).catch(() => {});
+      sendRect(phys);
     }
     // Clip with the rect the NATIVE layer actually got (device-pixel-snapped): a hole a
     // fraction wider than the native layer exposes a hairline of whatever is behind it.


### PR DESCRIPTION
## Native decode sink keeps step with its hole

Follow-up to #127 (merged before this landed). The hardware video layer trailed the DOM hole badly while the floating window was dragged, a park or unpark landed **one to two seconds** late, and a quick hide/show flickered — the picture vanished, came back, vanished again. Marc, 2026-09-08.

### What was wrong

1. **Windows: control shared the frame queue.** Rect, visibility, buffer depth and orientation travelled on the sink thread's **frame channel**, and that loop applies **one message per pass** — a pass that decodes an access unit and moves a child window whose parent belongs to the (busy) UI thread, so it is not free. The ~60 rect updates a second a drag produces could not be absorbed: they queued behind the video, the layer trailed by the whole backlog, and a visibility change waited behind it. They are shared **latest-wins** state now (`Shared::ctrl`), applied at the top of every pass — a burst collapses to its newest value and costs one window move. `stop()` no longer waits out a frame backlog either. The other platforms already bypassed the channel.

2. **Every platform: the IPC is a queue too.** Exactly one rect and one visibility call is in flight at a time; while one runs the newest value is remembered and sent when it settles. Positions the window has already left are dropped instead of replayed.

3. **The layer is armed before a hole is cut.** It is positioned and shown first, and a surface only goes transparent once the backend has taken both (`armed` / `armGen`). A hole can no longer open over a layer that has not arrived — which is what made a starting stream, an unpark or a surface scrolling back into view flash the page behind it.

### Was it a regression?

Not one commit's doing. Both the one-message-per-pass control path and the unthrottled per-frame IPC date from the first sink (f1baa98 / b897585) and never changed; the swapchain was always presented with sync interval 0, so nothing was ever vsync-blocked. What grew is the cost of a **single** update: the visible/clip box arrived later, so a rect now **resizes** the child window as well as moving it (a size change rebuilds the swapchain buffers), and more surfaces register. The design degraded as the feature grew.

`Regression: introduced by f1baa98, never released` — the native sink is 1.1 work, so this never reached a user and does not belong in release notes.

### Testing

Verified by Marc on Windows with the native RTSP client (HEVC, loopback): the video no longer trails the frame; the frame now trails the video by about a frame, which he accepts. Park, unpark and quick toggling are immediate. The DOM video paths (camera, MJPEG) are untouched — they have no hole to keep in step.

A freeze-frame fallback (gestures suspend the sink, surfaces paint an opaque box) was built alongside and **removed again** on Marc's call once the numbers were good. Decisions and the archaeology are recorded in the private Dev-Docs (`PHONE_VIDEO.md` D10.11).
