### PR TITLE
macOS: several video surfaces at once, and the detached window

### DIFF
--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -48,7 +48,7 @@ below. The release you are reading the docs for is expanded; click an older vers
         place and, if you left it that way, in fullscreen. The detached window has no title bar: the
         buttons appear when the pointer is over it — top-left brings the picture home, bottom-right
         goes fullscreen. Drag the picture to move it, the top-right corner resizes it, and the frame
-        keeps the stream's aspect ratio. Windows and macOS. [#130] · [#131]
+        keeps the stream's aspect ratio. Windows and macOS. [#130] · [#132]
 
     ??? info "Telemetry API — live telemetry for other programs"
         Kite can now **serve its live telemetry as JSON** to anything that can read it: an NDJSON
@@ -125,10 +125,10 @@ below. The release you are reading the docs for is expanded; click an older vers
       window when you hover it; the detached window's own hover buttons bring the picture back
       (top-left) and switch to fullscreen (bottom-right). Where it stands — including fullscreen —
       is remembered; if that screen is gone next time, it opens on Kite's own. Needs the Native RTSP
-      client, Windows and macOS. [#130] · [#131]
+      client, Windows and macOS. [#130] · [#132]
     - **The video shows in two places at once** — with Kite's own RTSP client the picture now runs
       in the Video widget **and** the floating window (or the fullscreen swap) at the same time,
-      as it always did with the other sources. One decode feeds both. [#129] · [#131]
+      as it always did with the other sources. One decode feeds both. [#129] · [#132]
     - **Desktop video window with a park button** — Start slides the window in, the camera button
       beside it parks and recalls it while the source runs; glass bezel, resize corner, no ✕. The
       Video panel replaces its preview with a status block (state, resolution, fps, codec, bitrate). [#127]
@@ -196,4 +196,4 @@ below. The release you are reading the docs for is expanded; click an older vers
 [#127]: https://github.com/b14ckyy/Kite-GC/pull/127
 [#129]: https://github.com/b14ckyy/Kite-GC/pull/129
 [#130]: https://github.com/b14ckyy/Kite-GC/pull/130
-[#131]: https://github.com/b14ckyy/Kite-GC/pull/131
+[#132]: https://github.com/b14ckyy/Kite-GC/pull/132

--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -48,7 +48,7 @@ below. The release you are reading the docs for is expanded; click an older vers
         place and, if you left it that way, in fullscreen. The detached window has no title bar: the
         buttons appear when the pointer is over it — top-left brings the picture home, bottom-right
         goes fullscreen. Drag the picture to move it, the top-right corner resizes it, and the frame
-        keeps the stream's aspect ratio. Windows for now. [#130]
+        keeps the stream's aspect ratio. Windows and macOS. [#130] · [#131]
 
     ??? info "Telemetry API — live telemetry for other programs"
         Kite can now **serve its live telemetry as JSON** to anything that can read it: an NDJSON
@@ -125,10 +125,10 @@ below. The release you are reading the docs for is expanded; click an older vers
       window when you hover it; the detached window's own hover buttons bring the picture back
       (top-left) and switch to fullscreen (bottom-right). Where it stands — including fullscreen —
       is remembered; if that screen is gone next time, it opens on Kite's own. Needs the Native RTSP
-      client, Windows for now. [#130]
+      client, Windows and macOS. [#130] · [#131]
     - **The video shows in two places at once** — with Kite's own RTSP client the picture now runs
       in the Video widget **and** the floating window (or the fullscreen swap) at the same time,
-      as it always did with the other sources. One decode feeds both. [#129]
+      as it always did with the other sources. One decode feeds both. [#129] · [#131]
     - **Desktop video window with a park button** — Start slides the window in, the camera button
       beside it parks and recalls it while the source runs; glass bezel, resize corner, no ✕. The
       Video panel replaces its preview with a status block (state, resolution, fps, codec, bitrate). [#127]
@@ -196,3 +196,4 @@ below. The release you are reading the docs for is expanded; click an older vers
 [#127]: https://github.com/b14ckyy/Kite-GC/pull/127
 [#129]: https://github.com/b14ckyy/Kite-GC/pull/129
 [#130]: https://github.com/b14ckyy/Kite-GC/pull/130
+[#131]: https://github.com/b14ckyy/Kite-GC/pull/131

--- a/docs/user/guides/video.md
+++ b/docs/user/guides/video.md
@@ -136,9 +136,9 @@ The same feed can appear in several places at once (they all share one stream):
   It **can't host the map** (double-click does nothing there), and where it stands — including
   fullscreen — is remembered: quit while detached and it comes back detached, on the same screen. If
   that screen is gone, it opens at a default size on Kite's own screen.
-  Requires the **Native RTSP client** and, for now, **Windows** — see the
-  [platform notes](#platform-notes-what-to-expect-per-operating-system); the button is simply absent
-  elsewhere.
+  Requires the **Native RTSP client**, on **Windows and macOS** — see the
+  [platform notes](#platform-notes-what-to-expect-per-operating-system); on Linux the button is
+  simply absent.
 
 ![The floating video window and the video widget](../assets/guides/video/video_floating_widget.png)
 /// caption
@@ -206,7 +206,7 @@ macOS browser engine is the only one that accepts HEVC on that path), and the **
 toggle switches to Kite's own client: H.264 and HEVC are decoded by the system's VideoToolbox and
 drawn straight into the video area — no helper programs, UDP-first with TCP fallback, mirror and
 rotate live. Either route is fine; the native one skips the helper download and the local relay leg.
-The detached video window is not available on macOS yet.
+The detached video window works here too, and so does showing the picture in two places at once.
 
 **On Linux, switch on the *Native RTSP client* for network streams.** With that toggle (Video panel →
 RTSP section) Kite plays RTSP itself: **H.264 and HEVC go straight into the machine's hardware
@@ -273,8 +273,9 @@ cannot fix from its side on that classic path:
   Kite works around the worst cases (it caps the automatic resolution and frame rate, and routes the
   advanced capture path around that layer entirely), but a camera the system itself can't open cleanly
   is out of reach.
-- **The detached video window is Windows-only for now.** On Linux and macOS the video layer Kite
-  draws the picture on lives in the main window, so a second window has nowhere to put it yet. All
+- **The detached video window is not available on Linux.** The video layer Kite draws the picture
+  on lives in the main window there, so a second window has nowhere to put it — and for the same
+  reason Linux shows the picture on one surface at a time, not two. Windows and macOS do both. All
   the in-app surfaces (widget, floating window, full-screen swap) work everywhere.
 
 None of this means Linux is unusable — with the **Native RTSP client** it is a first-class platform

--- a/src-tauri/src/commands/video.rs
+++ b/src-tauri/src/commands/video.rs
@@ -505,6 +505,11 @@ pub fn video_detached_open(
             }
         });
         let _ = win.show();
+        // Re-assert it after the window is realised: the builder flag is applied during creation,
+        // and this is the one property the window exists for (D12).
+        let _ = win.set_always_on_top(true);
+        #[cfg(target_os = "macos")]
+        crate::video::apple_host::float_window(DETACHED_LABEL.to_string());
         log::info!("[video] detached window opened at {x},{y} {w}x{h} (fullscreen={fullscreen})");
         Ok(())
     }
@@ -512,6 +517,32 @@ pub fn video_detached_open(
     {
         let _ = (app, x, y, w, h, fullscreen);
         Err("the detached video window is desktop-only".to_string())
+    }
+}
+
+/// Put the detached video window back above the others. Needed after every fullscreen toggle:
+/// tao ends its borderless-fullscreen mode by setting `NSNormalWindowLevel` unconditionally, so a
+/// window that was pinned comes back out of fullscreen at the normal level and sinks behind
+/// whatever the user clicks next (Marc, macOS, 2026-09-08). The viewer calls this itself, because
+/// it is the only side that knows a toggle happened.
+#[tauri::command(async)]
+pub fn video_detached_pin_top(app: AppHandle) -> Result<(), String> {
+    #[cfg(desktop)]
+    {
+        use tauri::Manager;
+
+        if let Some(win) = app.get_webview_window(DETACHED_LABEL) {
+            let _ = win.set_always_on_top(true);
+        }
+        // ...and on macOS at the level AppKit actually means — see `float_window`.
+        #[cfg(target_os = "macos")]
+        crate::video::apple_host::float_window(DETACHED_LABEL.to_string());
+        Ok(())
+    }
+    #[cfg(not(desktop))]
+    {
+        let _ = app;
+        Ok(())
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,7 +97,7 @@ use commands::video::{
     video_rtsp_native_sink_surfaces, video_rtsp_native_stats,
     video_linux_hole_spike,
     video_rtsp_native_sink_buffer, video_rtsp_native_sink_orient,
-    video_detached_open, video_detached_close,
+    video_detached_open, video_detached_close, video_detached_pin_top,
 };
 use video::{MediaMtx, MjpegServer};
 use commands::logging::{set_log_level, get_log_path, log_session_settings, log_frontend};
@@ -779,6 +779,7 @@ pub fn run() {
             video_native_mjpeg_stop,
             video_detached_open,
             video_detached_close,
+            video_detached_pin_top,
             radar_configure,
             radar_set_center,
             radar_set_node_pos,

--- a/src-tauri/src/video/apple_host.rs
+++ b/src-tauri/src/video/apple_host.rs
@@ -2,12 +2,18 @@
 // Copyright (C) 2026 Marc Hoffmann (b14ckyy)
 
 //! AppKit host for the macOS hole-punch video layer (MOBILE_RTSP.md P3) — the macOS counterpart
-//! of `linux_host` / the Android `NativeVideo` view: one layer-backed NSView BELOW the transparent
-//! WKWebView in the main window's content view, visible wherever the DOM cut its hole.
+//! of `linux_host` / the Android `NativeVideo` view: a layer-backed NSView BELOW the transparent
+//! WKWebView, visible wherever the DOM cut its hole.
 //!
-//! View tree (built once at startup, nothing is re-parented — wry keeps its own view tree):
+//! Since VIDEO_MULTISINK_WINDOW.md §4.2 there is one such view **per surface**, keyed by the
+//! surface's `window/id` — the video widget and the floating window at the same time, and (PR B)
+//! a surface that lives in the DETACHED video window, which is a different NSWindow entirely. The
+//! window a container belongs to is looked up by its Tauri label, so nothing here is bound to the
+//! main window any more.
 //!
-//!   NSWindow.contentView
+//! View tree per output (created on demand, nothing is re-parented — wry keeps its own view tree):
+//!
+//!   NSWindow.contentView                      ← the window the surface was published from
 //!     ├─ container NSView (ours, added `positioned: below` every existing sibling)
 //!     │    layer: opaque black (the letterbox must be opaque — a transparent gap shows the desktop
 //!     │           through the transparent window), `masksToBounds` = the VISIBLE box
@@ -27,8 +33,11 @@
 // names are what Apple documents and read identically to the AppKit/QuartzCore literature.
 #![allow(deprecated)]
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::sync::mpsc::channel;
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use objc2::rc::Retained;
 use objc2::MainThreadMarker;
@@ -38,8 +47,10 @@ use objc2_core_graphics::CGColor;
 use objc2_quartz_core::{CALayer, CATransform3D, CATransform3DConcat, CATransform3DIdentity, CATransform3DMakeRotation, CATransform3DMakeScale};
 use tauri::{AppHandle, Manager};
 
-/// Main-thread state; `None` until installed.
-struct Host {
+/// One on-screen output: the clip container under one window's WebView, plus the display layer the
+/// sink enqueues into. Main-thread state throughout.
+struct Output {
+    /// The window the container hangs in — kept for the backing scale factor and the content box.
     window: Retained<NSWindow>,
     container: Retained<NSView>,
     /// The sink's display layer, while one is attached.
@@ -47,43 +58,50 @@ struct Host {
     /// Last rect pushed (physical px: x, y, w, h, cx, cy, cw, ch) — re-applied when a layer is
     /// attached after the rect arrived.
     rect: [i32; 8],
-    mirror: bool,
-    rotate180: bool,
 }
 
 thread_local! {
-    static HOST: RefCell<Option<Host>> = const { RefCell::new(None) };
+    /// Outputs by surface key (`window/id`). Only ever touched on the main thread.
+    static OUTPUTS: RefCell<HashMap<String, Output>> = RefCell::new(HashMap::new());
+    /// Picture orientation — a property of the STREAM, so it applies to every output and to any
+    /// output created later.
+    static ORIENT: Cell<(bool, bool)> = const { Cell::new((false, false)) };
 }
 
-/// The app handle, kept for the main-thread hops (`on_main`).
+/// The app handle, kept for the main-thread hops (`on_main`) and for resolving window labels.
 static APP: OnceLock<AppHandle> = OnceLock::new();
 
-/// Install the video layer under the main window's WebView. Call once from Tauri's setup (the
-/// window exists by then). Failure leaves the window as it was and only costs the native sink route.
+/// Remember the app handle. Call once from Tauri's setup; the containers themselves are created
+/// per surface when the sink attaches a layer, because a surface can be in a window that does not
+/// exist yet (the detached video window).
 pub fn install(app: &AppHandle) {
     let _ = APP.set(app.clone());
-    let handle = app.clone();
-    let hop = app.run_on_main_thread(move || {
-        if let Err(e) = install_main(&handle) {
-            log::warn!("[video] apple host: {e} — the native decode sink is unavailable");
-        }
-    });
-    if let Err(e) = hop {
-        log::warn!("[video] apple host: main-thread hop failed: {e}");
-    }
 }
 
-fn install_main(app: &AppHandle) -> Result<(), String> {
+/// Run `f` against the output map on the main thread. Silently nothing without an app handle
+/// (install not called — the MJPEG route needs none of this).
+fn on_main(f: impl FnOnce(&mut HashMap<String, Output>) + Send + 'static) {
+    let Some(app) = APP.get() else { return };
+    let _ = app.run_on_main_thread(move || {
+        OUTPUTS.with(|m| f(&mut m.borrow_mut()));
+    });
+}
+
+/// Build the container view for `label`'s window and hang it under that window's WebView.
+/// Main thread only.
+fn create_container(label: &str) -> Result<Output, String> {
     let Some(mtm) = MainThreadMarker::new() else {
         return Err("not on the main thread".into());
     };
-    if HOST.with(|h| h.borrow().is_some()) {
-        return Ok(());
-    }
-    let window = app.get_webview_window("main").ok_or("no main window")?;
+    let app = APP.get().ok_or("no app handle")?;
+    let window = app
+        .get_webview_window(label)
+        .ok_or_else(|| format!("no window labelled {label}"))?;
     let ns_window = window.ns_window().map_err(|e| format!("ns_window: {e}"))?;
     // SAFETY: tauri hands out the live NSWindow of this window; retaining it keeps it valid for
-    // the host's lifetime (the app's main window lives as long as the app).
+    // as long as the output exists. That matters for the detached video window, whose outputs are
+    // dropped a moment AFTER it closed (its surfaces are withdrawn by the destroy hook, and the
+    // decode thread acts on the next push) — the retain is what makes that ordering harmless.
     let ns_window: Retained<NSWindow> = unsafe {
         Retained::retain(ns_window.cast::<NSWindow>()).ok_or("null NSWindow")?
     };
@@ -99,55 +117,36 @@ fn install_main(app: &AppHandle) -> Result<(), String> {
         layer.setBackgroundColor(Some(&black));
         layer.setMasksToBounds(true);
     }
-    container.setHidden(true);
     // Below every existing sibling — the WebView included — so it paints only where the DOM is
     // transparent. Nothing is removed or re-parented.
     content.addSubview_positioned_relativeTo(&container, NSWindowOrderingMode::Below, None);
 
     log::info!(
-        "[video] apple host: video layer installed (backing scale {})",
+        "[video] apple host: container in window {label} (backing scale {})",
         ns_window.backingScaleFactor()
     );
-    HOST.with(|h| {
-        *h.borrow_mut() = Some(Host {
-            window: ns_window,
-            container,
-            video: None,
-            rect: [0, 0, 1, 1, 0, 0, 1, 1],
-            mirror: false,
-            rotate180: false,
-        })
-    });
-    Ok(())
+    Ok(Output {
+        window: ns_window,
+        container,
+        video: None,
+        rect: [0, 0, 1, 1, 0, 0, 1, 1],
+    })
 }
 
-/// Run `f` against the host on the main thread. Silently nothing without a host (install failed
-/// / not called — the MJPEG route needs none of this).
-fn on_main(f: impl FnOnce(&mut Host) + Send + 'static) {
-    let Some(app) = APP.get() else { return };
-    let _ = app.run_on_main_thread(move || {
-        HOST.with(|h| {
-            if let Some(host) = h.borrow_mut().as_mut() {
-                f(host);
-            }
-        });
-    });
-}
-
-/// Apply `host.rect` to the container (visible box) and the video layer (full box), converting
+/// Apply an output's rect to its container (visible box) and video layer (full box), converting
 /// physical px with a top-left origin into points with AppKit's bottom-left origin.
-fn layout(host: &Host) {
-    let s = host.window.backingScaleFactor().max(1.0);
+fn layout(out: &Output) {
+    let s = out.window.backingScaleFactor().max(1.0);
     let p = |v: i32| v as f64 / s;
-    let [x, y, w, h, cx, cy, cw, ch] = host.rect;
-    let Some(content) = host.window.contentView() else { return };
+    let [x, y, w, h, cx, cy, cw, ch] = out.rect;
+    let Some(content) = out.window.contentView() else { return };
     let content_h = content.frame().size.height;
     let (cw_pt, ch_pt) = (p(cw).max(1.0), p(ch).max(1.0));
-    host.container.setFrame(CGRect::new(
+    out.container.setFrame(CGRect::new(
         CGPoint::new(p(cx), content_h - p(cy) - ch_pt),
         CGSize::new(cw_pt, ch_pt),
     ));
-    if let Some(video) = &host.video {
+    if let Some(video) = &out.video {
         let (w_pt, h_pt) = (p(w).max(1.0), p(h).max(1.0));
         // Inside the container's layer (bottom-left origin): the full box offset by the clip.
         let left = p(x - cx);
@@ -155,7 +154,8 @@ fn layout(host: &Host) {
         video.setBounds(CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(w_pt, h_pt)));
         video.setPosition(CGPoint::new(left + w_pt / 2.0, bottom + h_pt / 2.0));
         video.setContentsScale(s);
-        video.setTransform(transform(host.mirror, host.rotate180));
+        let (mirror, rotate180) = ORIENT.with(|o| o.get());
+        video.setTransform(transform(mirror, rotate180));
     }
 }
 
@@ -172,59 +172,139 @@ fn transform(mirror: bool, rotate180: bool) -> CATransform3D {
     t
 }
 
-/// On-screen rect (PHYSICAL px, window client coords, top-left origin): FULL box `x/y/w/h` for the
-/// video's aspect-fit layout, VISIBLE box `cx/cy/cw/ch` for the clip.
-#[allow(clippy::too_many_arguments)]
-pub fn set_rect(x: i32, y: i32, w: i32, h: i32, cx: i32, cy: i32, cw: i32, ch: i32) {
-    on_main(move |host| {
-        host.rect = [x, y, w, h, cx, cy, cw, ch];
-        layout(host);
+/// Create output `key`'s display layer ON the main thread (`make` runs there — AppKit and
+/// CoreAnimation objects are created where they are used), building the container in `window`'s
+/// NSWindow first if this is the surface's first appearance, and lay it out at the last known
+/// rect. Returns once the main thread is done, so the caller can start enqueueing.
+pub fn attach(
+    key: String,
+    window: String,
+    make: impl FnOnce() -> Retained<CALayer> + Send + 'static,
+) -> Result<(), String> {
+    let (tx, rx) = channel::<Result<(), String>>();
+    on_main(move |outs| {
+        let built = match outs.entry(key.clone()) {
+            std::collections::hash_map::Entry::Occupied(e) => Ok(e.into_mut()),
+            std::collections::hash_map::Entry::Vacant(e) => {
+                create_container(&window).map(|out| e.insert(out))
+            }
+        };
+        let res = match built {
+            Ok(out) => {
+                if let Some(old) = out.video.take() {
+                    old.removeFromSuperlayer();
+                }
+                let layer = make();
+                if let Some(root) = out.container.layer() {
+                    root.addSublayer(&layer);
+                }
+                out.video = Some(layer);
+                layout(out);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        };
+        let _ = tx.send(res);
     });
+    match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(res) => res,
+        Err(_) => Err("display layer attach timed out".into()),
+    }
 }
 
-/// Show/hide the layer (no DOM surface wants it right now).
-pub fn set_visible(visible: bool) {
-    on_main(move |host| host.container.setHidden(!visible));
-}
-
-/// Mirror / 180° rotation — a transform on the display layer, no decoder involvement.
-pub fn set_orient(mirror: bool, rotate180: bool) {
-    on_main(move |host| {
-        host.mirror = mirror;
-        host.rotate180 = rotate180;
-        layout(host);
-    });
-}
-
-/// Build the sink's display layer ON the main thread (`make` runs there — AppKit/CoreAnimation
-/// objects are created where they are used), put it into the container, replacing any previous
-/// one, and lay it out at the last known rect. Returns once the main thread has done it (`Ok`)
-/// or an error if no host exists.
-pub fn attach(make: impl FnOnce() -> Retained<CALayer> + Send + 'static) -> Result<(), String> {
-    let (tx, rx) = std::sync::mpsc::channel::<bool>();
-    on_main(move |host| {
-        detach_layer(host);
-        let layer = make();
-        if let Some(root) = host.container.layer() {
-            root.addSublayer(&layer);
+/// On-screen rect of one output (PHYSICAL px, ITS window's client coords, top-left origin):
+/// FULL box `x/y/w/h` for the video's aspect-fit layout, VISIBLE box `cx/cy/cw/ch` for the clip.
+pub fn place(key: String, rect: [i32; 8]) {
+    on_main(move |outs| {
+        if let Some(out) = outs.get_mut(&key) {
+            out.rect = rect;
+            layout(out);
         }
-        host.video = Some(layer);
-        layout(host);
-        let _ = tx.send(true);
     });
-    match rx.recv_timeout(std::time::Duration::from_secs(5)) {
-        Ok(true) => Ok(()),
-        _ => Err("no video host installed (main-thread install failed?)".into()),
-    }
 }
 
-/// Remove the sink's layer (the container stays for the next stream).
-pub fn detach() {
-    on_main(|host| detach_layer(host));
+/// Drop one output: its layer leaves the tree and its container leaves the window. macOS does NOT
+/// cache a hidden output the way the Windows sink does — there, a hidden output costs nothing
+/// because one decoder feeds every output; here each layer decodes for itself, so keeping one for
+/// a surface that is not on screen would burn a whole VideoToolbox session for nothing.
+pub fn remove(key: String) {
+    on_main(move |outs| {
+        if let Some(out) = outs.remove(&key) {
+            if let Some(v) = &out.video {
+                v.removeFromSuperlayer();
+            }
+            out.container.removeFromSuperview();
+        }
+    });
 }
 
-fn detach_layer(host: &mut Host) {
-    if let Some(v) = host.video.take() {
-        v.removeFromSuperlayer();
-    }
+/// Drop every output (the stream ended).
+pub fn remove_all() {
+    on_main(|outs| {
+        for (_, out) in outs.drain() {
+            if let Some(v) = &out.video {
+                v.removeFromSuperlayer();
+            }
+            out.container.removeFromSuperview();
+        }
+    });
+}
+
+/// The real `NSFloatingWindowLevel`. Worth spelling out: tao defines its `NSFloatingWindowLevel`
+/// as `kCGFloatingWindowLevelKey`, and the `kCG*WindowLevelKey` constants are KEYS to be passed to
+/// `CGWindowLevelForKey()`, not levels — so `always_on_top` lands the window at 5 instead of 3.
+/// Both are above normal (0), which is why it mostly works, but it is not the level AppKit means.
+const NS_FLOATING_WINDOW_LEVEL: isize = 3;
+
+/// macOS: pin `label`'s window above ordinary windows so it stays visible over other applications
+/// (the detached video window's whole point on a multi-monitor desk). Re-asserted here, after the
+/// window is realised and shown, because the builder flag is applied during creation.
+pub fn float_window(label: String) {
+    on_main(move |_| {
+        let Some(app) = APP.get() else { return };
+        let Some(window) = app.get_webview_window(&label) else { return };
+        let Ok(ptr) = window.ns_window() else { return };
+        // SAFETY: tauri hands out the live NSWindow of this window.
+        let Some(ns_window) = (unsafe { Retained::retain(ptr.cast::<NSWindow>()) }) else { return };
+        let before = ns_window.level();
+        ns_window.setLevel(NS_FLOATING_WINDOW_LEVEL);
+        // Only worth a line when it actually moved: this is re-asserted after every fullscreen
+        // toggle, and a no-op pin is not news.
+        if before != NS_FLOATING_WINDOW_LEVEL {
+            log::info!("[video] apple host: {label} window level {before} -> {NS_FLOATING_WINDOW_LEVEL}");
+        }
+    });
+}
+
+/// Stack the containers the way the DOM stacks their surfaces. `keys` arrives highest-priority
+/// FIRST (`main` > `floating` > `widget`), and DOM stacking is the reverse of that — the widget dock
+/// paints over the floating window, which paints over the fullscreen swap. So the list is walked
+/// BACKWARDS and each container sent below all its siblings: the last one moved ends up lowest,
+/// which leaves the first entry at the bottom and the widget on top. `Below` with no reference view
+/// also keeps every container under the WebView, which is what makes the hole punch work at all.
+///
+/// Only called when the order actually changed (re-adding a subview moves it, which is a real
+/// compositing update), and per window — containers in different windows never compete.
+pub fn restack(keys: Vec<String>) {
+    on_main(move |outs| {
+        for key in keys.iter().rev() {
+            let Some(out) = outs.get(key) else { continue };
+            let Some(content) = out.window.contentView() else { continue };
+            content.addSubview_positioned_relativeTo(
+                &out.container,
+                NSWindowOrderingMode::Below,
+                None,
+            );
+        }
+    });
+}
+
+/// Mirror / 180° rotation — a transform on every display layer, no decoder involvement.
+pub fn set_orient(mirror: bool, rotate180: bool) {
+    on_main(move |outs| {
+        ORIENT.with(|o| o.set((mirror, rotate180)));
+        for out in outs.values() {
+            layout(out);
+        }
+    });
 }

--- a/src-tauri/src/video/apple_sink.rs
+++ b/src-tauri/src/video/apple_sink.rs
@@ -5,7 +5,18 @@
 //! `win_sink` / `android_sink`: H.264/HEVC access units from the RTSP client are wrapped as
 //! compressed `CMSampleBuffer`s and enqueued into an `AVSampleBufferDisplayLayer`, which decodes
 //! them through VideoToolbox and renders straight into the hole-punch layer below the WebView
-//! (`apple_host.rs`). One decode thread owns the conversion; the layer lives in the host.
+//! (`apple_host.rs`). One decode thread owns the conversion; the layers live in the host.
+//!
+//! **One layer per surface** (VIDEO_MULTISINK_WINDOW.md §4.2): the video widget and the floating
+//! window at once, or a surface in the detached video window. AVFoundation decodes inside the
+//! layer, so a second surface means a second VideoToolbox session — accepted (D9); a shared
+//! `VTDecompressionSession` feeding both would be a large block of code for a few percent of GPU.
+//! Everything that belongs to a session is therefore per output: the resume-on-keyframe wait, the
+//! control timebase and its pacing anchor. The format description is immutable and shared.
+//!
+//! An output that leaves the published list is DROPPED, not hidden: unlike the Windows sink (one
+//! decoder, N cheap presents) a kept layer here would decode the whole stream for a picture nobody
+//! sees. The price is that a surface coming back waits for the next keyframe.
 //!
 //! The real work is the framing conversion: the depacketizer delivers Annex-B (start codes,
 //! in-band parameter sets), CoreMedia wants AVCC/HVCC (4-byte big-endian length prefixes, the
@@ -50,11 +61,13 @@ use super::apple_host as host;
 use super::rtsp::VideoCodec;
 use super::surface::SinkSurface;
 
-/// How long the initial layer attach may take (one main-thread hop away) before the sink
-/// declares failure.
-const FIRST_LAYER_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long a layer attach may take (one main-thread hop away) before the output is given up on.
+const LAYER_ATTACH_TIMEOUT: Duration = Duration::from_secs(10);
 /// RTP video clock — the timestamps `push` receives are 90 kHz ticks.
 const TIMESCALE: i32 = 90_000;
+/// Surfaces served at once (D1: the widget tile plus one large surface). Each costs a decode here,
+/// so the cap is a real budget, not just politeness.
+const MAX_OUTPUTS: usize = 2;
 
 enum Cmd {
     /// One access unit (Annex-B, in-band parameter sets) + its unwrapped 90 kHz timestamp.
@@ -72,9 +85,12 @@ struct Shared {
     /// Smoothing-buffer depth in frames (0 = display immediately).
     buffer_frames: AtomicU32,
     stopping: AtomicBool,
-    /// No DOM surface on screen — the layer is hidden by the host; decoding continues so the
-    /// picture is there the instant it comes back.
-    hidden: AtomicBool,
+    /// What the router last published, latest-wins, plus a revision the decode thread compares
+    /// against its own. Deliberately NOT a channel message: geometry arrives once per animation
+    /// frame during a drag, and anything queued behind the frames would make the layer trail the
+    /// hole by the whole backlog (the lesson `win_sink` learned in PR #128).
+    surfaces: Mutex<Vec<SinkSurface>>,
+    rev: AtomicU64,
 }
 
 impl Shared {
@@ -111,7 +127,7 @@ impl AppleVideoSink {
             let shared = shared.clone();
             std::thread::spawn(move || {
                 decode_loop(hevc, &rx, &shared);
-                host::detach();
+                host::remove_all();
             })
         };
         Ok(Self { tx, thread: Some(thread), shared })
@@ -127,34 +143,23 @@ impl AppleVideoSink {
         self.shared.error.lock().unwrap().clone()
     }
 
-    /// The surfaces to present into (VIDEO_MULTISINK_WINDOW.md §4.1). This platform drives ONE
-    /// output for now, so the first entry wins — the router publishes them highest-priority first —
-    /// and an empty list hides the layer. Two outputs here are the follow-up (§4.2).
-    ///
-    /// Only the MAIN window's surfaces are servable: the AppKit host view lives there, so a surface published by
-    /// the detached video window has nowhere to go here and must not be drawn into the main window
-    /// instead (a second host is the same follow-up).
+    /// The surfaces to present into (VIDEO_MULTISINK_WINDOW.md §4.1), highest priority first and
+    /// capped at [`MAX_OUTPUTS`]. Each is served by its own layer in its own window; an empty list
+    /// means nothing is on screen and every output goes away. Cheap: the decode thread picks the
+    /// list up on its next pass (see `Shared::surfaces`).
     pub fn set_surfaces(&self, surfaces: &[SinkSurface]) {
-        match surfaces.iter().find(|s| s.window == "main") {
-            Some(s) => {
-                self.set_rect(s.full.0, s.full.1, s.full.2, s.full.3, s.clip.0, s.clip.1, s.clip.2, s.clip.3);
-                self.set_visible(true);
-            }
-            None => self.set_visible(false),
+        let mut want: Vec<SinkSurface> = surfaces.iter().take(MAX_OUTPUTS).cloned().collect();
+        if surfaces.len() > MAX_OUTPUTS {
+            log::debug!(
+                "[video] apple sink: {} surfaces published, {MAX_OUTPUTS} served",
+                surfaces.len()
+            );
         }
-    }
-
-    /// On-screen video rect (PHYSICAL px, window coords): the FULL box `x/y/w/h` for the
-    /// aspect-fit layout plus the VISIBLE part `cx/cy/cw/ch` — the host clips the video at that
-    /// edge (scrolled panels), it never shrinks into the remainder.
-    #[allow(clippy::too_many_arguments)]
-    fn set_rect(&self, x: i32, y: i32, w: i32, h: i32, cx: i32, cy: i32, cw: i32, ch: i32) {
-        host::set_rect(x, y, w, h, cx, cy, cw, ch);
-    }
-
-    fn set_visible(&self, visible: bool) {
-        self.shared.hidden.store(!visible, Ordering::Relaxed);
-        host::set_visible(visible);
+        let mut slot = self.shared.surfaces.lock().unwrap();
+        if *slot != want {
+            std::mem::swap(&mut *slot, &mut want);
+            self.shared.rev.fetch_add(1, Ordering::Release);
+        }
     }
 
     /// Smoothing-buffer depth in frames (0 = display immediately — the latency-first default).
@@ -189,14 +194,28 @@ impl Drop for AppleVideoSink {
     }
 }
 
-/// Create the display layer on the main thread (inside the host's attach) and return the shared
-/// handle the decode thread enqueues through.
-fn create_layer() -> Result<Arc<Layer>, String> {
+/// One live output: the surface it serves plus everything that belongs to its VideoToolbox
+/// session, which a second layer has a second of.
+struct Out {
+    key: String,
+    layer: Arc<Layer>,
+    /// This session starts on an intra frame; a flush or new parameter sets restart the wait.
+    wait_for_idr: bool,
+    timebase: Option<CFRetained<CMTimebase>>,
+    pacing: Pacing,
+    /// Last rect handed to the host — placing is a main-thread hop, so it happens on change only.
+    rect: [i32; 8],
+}
+
+/// Create a display layer for surface `key` in `window`, on the main thread (inside the host's
+/// attach, which builds the container view there if this is the surface's first appearance), and
+/// return the shared handle the decode thread enqueues through.
+fn create_layer(key: String, window: String) -> Result<Arc<Layer>, String> {
     let slot: Arc<Mutex<Option<Arc<Layer>>>> = Arc::new(Mutex::new(None));
     let fill = slot.clone();
     let (tx, rx) = std::sync::mpsc::channel::<Result<(), String>>();
     std::thread::spawn(move || {
-        let res = host::attach(move || {
+        let res = host::attach(key, window, move || {
             // SAFETY: plain AVFoundation object creation + property setup on the main thread.
             let layer = unsafe { AVSampleBufferDisplayLayer::new() };
             unsafe {
@@ -209,34 +228,91 @@ fn create_layer() -> Result<Arc<Layer>, String> {
         });
         let _ = tx.send(res);
     });
-    rx.recv_timeout(FIRST_LAYER_TIMEOUT)
+    rx.recv_timeout(LAYER_ATTACH_TIMEOUT)
         .map_err(|_| "display layer attach timed out".to_string())??;
     let layer = slot.lock().unwrap().take();
     layer.ok_or_else(|| "display layer was not created".into())
 }
 
-/// The decode thread: attach the layer, then convert + enqueue AUs until stop.
-fn decode_loop(hevc: bool, rx: &Receiver<Cmd>, shared: &Shared) {
-    let layer = match create_layer() {
-        Ok(l) => l,
-        Err(e) => {
-            shared.fail(e);
-            return;
+/// Bring `outs` in line with what the router published: a surface that appeared gets a container,
+/// a layer and its rect; one that moved gets the new rect; one that left is dropped entirely (see
+/// the module docs — a kept layer would keep decoding).
+///
+/// A surface whose window has no NSWindow (a detached window that is already closing) simply gets
+/// no output and is retried on the next push; nothing here can fail the stream.
+fn sync_outputs(outs: &mut Vec<Out>, want: &[SinkSurface], order: &mut Vec<String>) {
+    outs.retain(|out| {
+        if want.iter().any(|s| s.key == out.key) {
+            return true;
         }
-    };
-    log::info!("[video] apple sink: display layer up ({})", if hevc { "HEVC" } else { "H.264" });
+        // SAFETY: thread-safe queued-rendering call.
+        unsafe { out.layer.0.flushAndRemoveImage() };
+        host::remove(out.key.clone());
+        log::info!("[video] apple sink: output {} gone", out.key);
+        false
+    });
+    for s in want {
+        let rect = [s.full.0, s.full.1, s.full.2, s.full.3, s.clip.0, s.clip.1, s.clip.2, s.clip.3];
+        if let Some(out) = outs.iter_mut().find(|o| o.key == s.key) {
+            if out.rect != rect {
+                out.rect = rect;
+                host::place(s.key.clone(), rect);
+            }
+            continue;
+        }
+        match create_layer(s.key.clone(), s.window.clone()) {
+            Ok(layer) => {
+                host::place(s.key.clone(), rect);
+                log::info!("[video] apple sink: output for surface {} created", s.key);
+                outs.push(Out {
+                    key: s.key.clone(),
+                    layer,
+                    wait_for_idr: true,
+                    timebase: None,
+                    pacing: Pacing::default(),
+                    rect,
+                });
+            }
+            Err(e) => log::warn!("[video] apple sink: no output for surface {}: {e}", s.key),
+        }
+    }
+    // Stack them the way the DOM stacks their surfaces — matters wherever two overlap, e.g. the
+    // floating window dragged over the video widget, where the widget has to stay on top.
+    let want_order: Vec<String> = want
+        .iter()
+        .filter(|s| outs.iter().any(|o| o.key == s.key))
+        .map(|s| s.key.clone())
+        .collect();
+    if *order != want_order {
+        host::restack(want_order.clone());
+        *order = want_order;
+    }
+}
+
+/// The decode thread: follow the published surfaces, then convert + enqueue AUs until stop.
+/// Layers come and go with the surfaces — there is none until the DOM asks for one.
+fn decode_loop(hevc: bool, rx: &Receiver<Cmd>, shared: &Shared) {
+    log::info!("[video] apple sink: decode thread up ({})", if hevc { "HEVC" } else { "H.264" });
 
     let mut sets = ParameterSets::default();
     let mut format: Option<CFRetained<CMFormatDescription>> = None;
-    // The first session starts on the stream's first intra frame; a flush restarts the wait.
-    let mut wait_for_idr = true;
-    let mut pacing = Pacing::default();
-    let mut timebase: Option<CFRetained<CMTimebase>> = None;
+    let mut outs: Vec<Out> = Vec::new();
+    let mut order: Vec<String> = Vec::new();
+    let mut applied_rev = u64::MAX; // force one sync before the first frame
 
     loop {
+        // Surfaces first, so a frame always lands in the layout the DOM published last.
+        let rev = shared.rev.load(Ordering::Acquire);
+        if rev != applied_rev {
+            applied_rev = rev;
+            let want = shared.surfaces.lock().unwrap().clone();
+            sync_outputs(&mut outs, &want, &mut order);
+        }
         match rx.recv_timeout(Duration::from_millis(100)) {
             Ok(Cmd::Stop) | Err(RecvTimeoutError::Disconnected) => {
-                unsafe { layer.0.flushAndRemoveImage() };
+                for out in &outs {
+                    unsafe { out.layer.0.flushAndRemoveImage() };
+                }
                 return;
             }
             Ok(Cmd::Orient { mirror, rotate180 }) => host::set_orient(mirror, rotate180),
@@ -257,8 +333,10 @@ fn decode_loop(hevc: bool, rx: &Receiver<Cmd>, shared: &Shared) {
                             }
                             format = Some(desc);
                             if changed {
-                                // New sets mid-stream: the decoder must restart on the next IDR.
-                                wait_for_idr = true;
+                                // New sets mid-stream: every session must restart on the next IDR.
+                                for out in &mut outs {
+                                    out.wait_for_idr = true;
+                                }
                             }
                         }
                         Ok(None) => {} // sets incomplete — keep waiting
@@ -269,68 +347,90 @@ fn decode_loop(hevc: bool, rx: &Receiver<Cmd>, shared: &Shared) {
                     }
                 }
                 let Some(desc) = format.as_ref() else { continue };
-                if wait_for_idr && !has_intra_frame(hevc, &au) {
-                    continue;
+                if outs.is_empty() {
+                    continue; // nothing on screen — no session to feed, so nothing to decode
                 }
-                wait_for_idr = false;
-
-                // A layer that failed decoding needs a flush before it accepts anything again.
-                // SAFETY: thread-safe queued-rendering calls.
-                unsafe {
-                    if layer.0.status() == AVQueuedSampleBufferRenderingStatus::Failed {
-                        let msg = layer
-                            .0
-                            .error()
-                            .map(|e| e.localizedDescription().to_string())
-                            .unwrap_or_else(|| "display layer failed".into());
-                        shared.fail(format!("decode failed: {msg}"));
-                        return;
-                    }
-                    if layer.0.requiresFlushToResumeDecoding() {
-                        log::warn!("[video] apple sink: layer requires a flush — resuming on the next keyframe");
-                        layer.0.flush();
-                        wait_for_idr = true;
-                        pacing.anchor = None;
-                        continue;
-                    }
-                }
-
                 let depth = shared.buffer_frames.load(Ordering::Relaxed);
                 let pts = ts90k as i64;
-                // Depth > 0 paces on the control timebase; depth 0 displays immediately. Switching
-                // depth re-anchors the timeline.
-                if depth == 0 {
-                    if timebase.take().is_some() {
-                        unsafe { layer.0.setControlTimebase(None) };
+                // Computed at most once per AU, and only while some session is waiting for one.
+                let mut intra: Option<bool> = None;
+                // ONE sample per frame, enqueued into every live layer: CMSampleBuffer is
+                // immutable and reference-counted, and each layer decodes it for itself (D9).
+                let mut sample = None;
+
+                for out in &mut outs {
+                    // A layer that failed decoding needs a flush before it accepts anything again.
+                    // SAFETY: thread-safe queued-rendering calls.
+                    unsafe {
+                        if out.layer.0.status() == AVQueuedSampleBufferRenderingStatus::Failed {
+                            let msg = out
+                                .layer
+                                .0
+                                .error()
+                                .map(|e| e.localizedDescription().to_string())
+                                .unwrap_or_else(|| "display layer failed".into());
+                            shared.fail(format!("decode failed ({}): {msg}", out.key));
+                            return;
+                        }
+                        if out.layer.0.requiresFlushToResumeDecoding() {
+                            log::warn!(
+                                "[video] apple sink: {} requires a flush — resuming on the next keyframe",
+                                out.key
+                            );
+                            out.layer.0.flush();
+                            out.wait_for_idr = true;
+                            out.pacing.anchor = None;
+                            continue;
+                        }
                     }
-                } else {
-                    let tb = match timebase.as_ref() {
-                        Some(tb) => tb.clone(),
-                        None => match new_timebase() {
-                            Ok(tb) => {
-                                unsafe { layer.0.setControlTimebase(Some(&tb)) };
-                                timebase = Some(tb.clone());
-                                tb
-                            }
+                    if out.wait_for_idr {
+                        if !*intra.get_or_insert_with(|| has_intra_frame(hevc, &au)) {
+                            continue;
+                        }
+                        out.wait_for_idr = false;
+                    }
+
+                    // Depth > 0 paces on this session's control timebase; depth 0 displays
+                    // immediately. Switching depth re-anchors the timeline.
+                    if depth == 0 {
+                        if out.timebase.take().is_some() {
+                            unsafe { out.layer.0.setControlTimebase(None) };
+                        }
+                    } else {
+                        let tb = match out.timebase.as_ref() {
+                            Some(tb) => tb.clone(),
+                            None => match new_timebase() {
+                                Ok(tb) => {
+                                    unsafe { out.layer.0.setControlTimebase(Some(&tb)) };
+                                    out.timebase = Some(tb.clone());
+                                    tb
+                                }
+                                Err(e) => {
+                                    shared.fail(e);
+                                    return;
+                                }
+                            },
+                        };
+                        out.pacing.schedule(&tb, pts, depth);
+                    }
+
+                    if sample.is_none() {
+                        match make_sample(hevc, desc, &au, pts, depth == 0) {
+                            Ok(s) => sample = Some(s),
                             Err(e) => {
                                 shared.fail(e);
                                 return;
                             }
-                        },
-                    };
-                    pacing.schedule(&tb, pts, depth);
-                }
-
-                let sample = match make_sample(hevc, desc, &au, pts, depth == 0) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        shared.fail(e);
-                        return;
+                        }
                     }
-                };
-                // SAFETY: valid sample buffer; enqueue is thread-safe.
-                unsafe { layer.0.enqueueSampleBuffer(&sample) };
-                shared.presented.fetch_add(1, Ordering::Relaxed);
+                    let Some(buf) = sample.as_ref() else { continue };
+                    // SAFETY: valid sample buffer; enqueue is thread-safe.
+                    unsafe { out.layer.0.enqueueSampleBuffer(buf) };
+                }
+                // Per FRAME, not per surface — it is what the panel shows as fps.
+                if sample.is_some() {
+                    shared.presented.fetch_add(1, Ordering::Relaxed);
+                }
             }
             Err(RecvTimeoutError::Timeout) => {}
         }

--- a/src-tauri/src/video/rtsp_native.rs
+++ b/src-tauri/src/video/rtsp_native.rs
@@ -512,7 +512,9 @@ impl NativeRtsp {
         }))
     }
 
-    #[cfg(desktop)]
+    /// Windows only: the AppKit and GTK hosts find a window by its Tauri LABEL, so only the
+    /// Windows sink — which parents a child window to a native handle — needs this.
+    #[cfg(target_os = "windows")]
     /// Register `window`'s native handle so surfaces published from it can be hosted
     /// (VIDEO_MULTISINK_WINDOW.md §5.1). Called when the detached video window is created — before
     /// its page can publish anything, so its first surface list already resolves to a parent.

--- a/src/lib/components/video/DetachedVideoFrame.svelte
+++ b/src/lib/components/video/DetachedVideoFrame.svelte
@@ -23,6 +23,7 @@
   import { t } from 'svelte-i18n';
   import { getCurrentWindow, PhysicalSize } from '@tauri-apps/api/window';
   import { emitTo, listen, type UnlistenFn } from '@tauri-apps/api/event';
+  import { invoke } from '@tauri-apps/api/core';
   import {
     nativeSurface,
     activeNativeSurfaces,
@@ -163,6 +164,9 @@
     if (next) await readBox(); // keep the windowed box; fullscreen must not overwrite it
     fullscreen = next;
     await win.setFullscreen(next);
+    // macOS drops the window's level on the way out of fullscreen (see video_detached_pin_top),
+    // so the always-on-top promise has to be renewed on every toggle.
+    void invoke('video_detached_pin_top').catch(() => {});
     if (!next) await readBox(); // back in a window — that box is the truth again
     if (box) void emitTo('main', 'video-detached-geometry', { ...box, fullscreen: next }).catch(() => {});
   }

--- a/src/lib/components/video/FloatingVideoWindow.svelte
+++ b/src/lib/components/video/FloatingVideoWindow.svelte
@@ -43,7 +43,7 @@
   } from '$lib/stores/video';
   import { canvasSink, mjpegSink } from '$lib/controllers/mjpegSink';
   import { detachVideo } from '$lib/controllers/detachedVideo';
-  import { isWindows } from '$lib/platform';
+  import { isMacOS, isWindows } from '$lib/platform';
   import { nativeSurface, activeNativeSurfaces } from '$lib/controllers/nativeVideo';
   import { doubleTap, mouseDoubleClick } from '$lib/helpers/doubleTap';
   import { beginFloatMove, startFloatMove, startFloatResize } from '$lib/helpers/floatWindowGestures';
@@ -68,9 +68,9 @@
   const live = $derived($videoState.status === 'live');
   /** The unplug button: take the picture out of the app into its own window (D3). Native decode
    *  sink only (D2) — the DOM paths render into THIS WebView and cannot be handed to another one.
-   *  Windows only for now: the macOS/Linux hosts live in the main window, so a second window has
-   *  nowhere to put the picture until they grow one (VIDEO_MULTISINK_WINDOW.md §4.2). */
-  const canDetach = $derived(isWindows && live && $videoState.nativeSink);
+   *  Not on Linux: its GStreamer host still lives in the main window, so a second window has
+   *  nowhere to put the picture until it grows one (VIDEO_MULTISINK_WINDOW.md §4.2). */
+  const canDetach = $derived((isWindows || isMacOS) && live && $videoState.nativeSink);
   /** Narrow derived, not a raw store read in the effect below (that would re-run it on every
    *  telemetry patch): detaching must skip the slide-out — see there. */
   const detached = $derived($videoState.undocked);


### PR DESCRIPTION
## macOS catches up: several surfaces at once, and the detached window

The two follow-ups D16 left open on macOS (`active/VIDEO_MULTISINK_WINDOW.md` §8). They are one piece of work, because both need the same change: `apple_host` was a single slot bound to the main window holding one `CALayer`, and `apple_sink` a decode loop with one layer. Both are keyed by the surface's `window/id` now — the shape `win_sink` took in #129 — and that single map answers both questions at once: **two surfaces in one window**, and **one surface in a window of its own**.

Built and verified against Marc's macOS VM (15.7.9 x86_64) over SSH.

### apple_host — a container per surface

- `Output { window, container, video, rect }` in a map instead of one `Host`. `install` only remembers the app handle; containers are built **on demand** in the NSWindow of the surface's own Tauri label — the detached window does not exist at startup, so nothing can be bound eagerly any more.
- `attach(key, window, make)` / `place` / `remove` / `remove_all`, and `set_orient` applies to every output and is remembered for outputs created later (orientation belongs to the stream, not to a surface).

### apple_sink — a layer per surface

- The decode loop keeps one `Out` per surface and reconciles against the published list at the top of each pass. The list arrives as **latest-wins shared state**, never as a channel message: geometry changes once per animation frame during a drag, and anything queued behind the frames would make the layer trail the hole by the whole backlog — #128's lesson.
- Per output, i.e. per VideoToolbox session (D9): the resume-on-keyframe wait, the control timebase and its pacing anchor. Shared: parameter sets, format description, and ONE `CMSampleBuffer` per frame enqueued into every layer. `frames_presented` still counts frames, not surfaces.

### Where macOS deliberately differs from Windows

**An output that leaves the published list is dropped, not cached.** On Windows a hidden output costs nothing — one decoder feeds every output and a hidden one merely skips its blit — so they are cached and park/unpark costs no rebuild. Here the layer **is** the decoder: a cached one would decode the whole stream for a picture nobody sees, and a stale one (the detached window's, after docking) would do it forever. The price is that a surface coming back waits for the next keyframe.

### Two defects the runtime test found

Both diagnosed by reading tao rather than by experiment:

- **Z-order.** Containers stacked in creation order, so the floating window's video covered the widget's where they overlap — the DOM stacks them the other way round. The Windows sink solves this explicitly by walking the published list backwards and sending each child window to `HWND_BOTTOM`; that half had simply not been ported. `restack` now does the same with `addSubview:positioned:below:`, and only when the order actually changed (re-adding a subview is a real compositing update; a drag changes geometry, not order).
- **Always-on-top did not hold**, for two independent reasons. tao defines `NSFloatingWindowLevel` as `kCGFloatingWindowLevelKey`, but the `kCG*WindowLevelKey` constants are KEYS for `CGWindowLevelForKey()`, not levels — the window sat at 5 instead of 3 (measured in the VM: `window level 5 -> 3`). And on the way out of fullscreen tao sets `NSNormalWindowLevel` unconditionally to undo its own borderless-fullscreen hack, without checking whether the window was pinned — so the pin is not lost, it is overwritten. Hence `float_window` (the real level, re-asserted once the window is realised) and `video_detached_pin_top` (called by the viewer after every toggle, the only side that knows one happened).

### Also

`NativeRtsp::register_window` is Windows-only now: only that sink parents a child window to a native handle, AppKit and GTK look a window up by its Tauri label. The unplug button is `isWindows || isMacOS`. **Linux keeps neither follow-up** — its GStreamer chain is still one linear branch and needs a tee plus a second widget, which is the Pi trip.

### Verified in the VM

`cargo check` clean on macOS (first try). Dual stream, z-order, detach, move, hover chrome, fullscreen, always-on-top — all confirmed by Marc.

Not confirmed there and worth a look on real hardware: **park and immediately recall**, where the dropped layer means black until the next keyframe. If that reads badly, the fix is a grace period (keep feeding for ~3 s, then drop), not a permanent cache.

The VM's low on-screen frame rate with a docked surface is **not** this change: profiled to CoreAnimation's software renderer in WindowServer (240–280 % while our process idles at 8–12 % and the sink reports 60 fps), reproduced by plain macOS window animations without Kite, and identical over VNC and AnyDesk. Details in the plan doc §8.6.
