### PR TITLE
Linux: the second surface and the detached video window

### DIFF
--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -39,7 +39,7 @@ below. The release you are reading the docs for is expanded; click an older vers
     ??? info "Video in two places at once — and on a screen of its own"
         With Kite's own RTSP client the picture now runs in the **Video widget and a large surface at
         the same time** — the floating window or the fullscreen swap — the way the other sources
-        always did. One decode feeds both. [#129]
+        always did. One decode feeds both — on Windows, macOS and Linux. [#129] · [#132] · [#133]
 
         **And it can leave the app.** Hover the floating window and a **broken-chain button** appears
         in its top-left corner: the frame moves out into its own window, **always on top**, framed
@@ -128,7 +128,7 @@ below. The release you are reading the docs for is expanded; click an older vers
       client, Windows and macOS. [#130] · [#132]
     - **The video shows in two places at once** — with Kite's own RTSP client the picture now runs
       in the Video widget **and** the floating window (or the fullscreen swap) at the same time,
-      as it always did with the other sources. One decode feeds both. [#129] · [#132]
+      as it always did with the other sources. One decode feeds both. [#129] · [#132] · [#133]
     - **Desktop video window with a park button** — Start slides the window in, the camera button
       beside it parks and recalls it while the source runs; glass bezel, resize corner, no ✕. The
       Video panel replaces its preview with a status block (state, resolution, fps, codec, bitrate). [#127]
@@ -197,3 +197,4 @@ below. The release you are reading the docs for is expanded; click an older vers
 [#129]: https://github.com/b14ckyy/Kite-GC/pull/129
 [#130]: https://github.com/b14ckyy/Kite-GC/pull/130
 [#132]: https://github.com/b14ckyy/Kite-GC/pull/132
+[#133]: https://github.com/b14ckyy/Kite-GC/pull/133

--- a/docs/user/guides/video.md
+++ b/docs/user/guides/video.md
@@ -274,9 +274,11 @@ cannot fix from its side on that classic path:
   advanced capture path around that layer entirely), but a camera the system itself can't open cleanly
   is out of reach.
 - **The detached video window is not available on Linux.** The video layer Kite draws the picture
-  on lives in the main window there, so a second window has nowhere to put it — and for the same
-  reason Linux shows the picture on one surface at a time, not two. Windows and macOS do both. All
-  the in-app surfaces (widget, floating window, full-screen swap) work everywhere.
+  on lives in the main window there, so a second window has nowhere to put it. Showing the picture
+  in **two places at once** does work on Linux; the second place is converted on the processor
+  rather than the graphics chip (two hardware-accelerated video surfaces cannot share one pipeline),
+  which on a desktop costs a few percent of one core for a widget-sized tile. All the in-app
+  surfaces (widget, floating window, full-screen swap) work everywhere.
 
 None of this means Linux is unusable — with the **Native RTSP client** it is a first-class platform
 for network video, and a well-equipped desktop distribution generally plays the classic path fine

--- a/docs/user/guides/video.md
+++ b/docs/user/guides/video.md
@@ -136,9 +136,9 @@ The same feed can appear in several places at once (they all share one stream):
   It **can't host the map** (double-click does nothing there), and where it stands — including
   fullscreen — is remembered: quit while detached and it comes back detached, on the same screen. If
   that screen is gone, it opens at a default size on Kite's own screen.
-  Requires the **Native RTSP client**, on **Windows and macOS** — see the
-  [platform notes](#platform-notes-what-to-expect-per-operating-system); on Linux the button is
-  simply absent.
+  Requires the **Native RTSP client** — on **Windows**, **macOS** and **Linux**; the
+  [platform notes](#platform-notes-what-to-expect-per-operating-system) say what a Wayland desktop
+  does differently.
 
 ![The floating video window and the video widget](../assets/guides/video/video_floating_widget.png)
 /// caption
@@ -219,6 +219,8 @@ not hold 50 fps. MJPEG sources are passed through untouched, as always. The clie
 distribution's GStreamer plugins (the **.deb** installs them automatically; elsewhere:
 `gstreamer1.0-plugins-base`, `…-good`, `…-bad`, `gstreamer1.0-gtk3` and `gstreamer1.0-libav`, or your
 distro's equivalents) — if one is missing, Kite reports which GStreamer element it could not find.
+Showing the picture in **two places at once** and the **detached video window** both work on this
+route; the notes below say what each of them costs.
 
 !!! note "Raspberry Pi 5 and HEVC"
     Encoders that pad the picture height to their block size — NVENC at 720p codes 736 rows, every
@@ -273,12 +275,16 @@ cannot fix from its side on that classic path:
   Kite works around the worst cases (it caps the automatic resolution and frame rate, and routes the
   advanced capture path around that layer entirely), but a camera the system itself can't open cleanly
   is out of reach.
-- **The detached video window is not available on Linux.** The video layer Kite draws the picture
-  on lives in the main window there, so a second window has nowhere to put it. Showing the picture
-  in **two places at once** does work on Linux; the second place is converted on the processor
-  rather than the graphics chip (two hardware-accelerated video surfaces cannot share one pipeline),
-  which on a desktop costs a few percent of one core for a widget-sized tile. All the in-app
-  surfaces (widget, floating window, full-screen swap) work everywhere.
+- **The detached video window works, but it cannot stay on top of everything on Wayland.** Current
+  desktops that run on Wayland — GNOME's default — do not let an application put its own window
+  above other applications, so the detached window takes its turn in the normal stacking order
+  there. Put it on a second monitor or beside Kite and it stays where you want it. The window also
+  decodes the picture for itself (a window cannot borrow another window's hardware video surface),
+  so it costs a second hardware decode of the same stream.
+- **The picture in two places at once costs a conversion.** The second place is drawn by the
+  processor rather than the graphics chip (two hardware-accelerated surfaces cannot share one
+  pipeline), which on a desktop costs a few percent of one core for a widget-sized tile. All the
+  in-app surfaces (widget, floating window, full-screen swap) work everywhere.
 
 None of this means Linux is unusable — with the **Native RTSP client** it is a first-class platform
 for network video, and a well-equipped desktop distribution generally plays the classic path fine

--- a/src-tauri/src/commands/video.rs
+++ b/src-tauri/src/commands/video.rs
@@ -490,9 +490,13 @@ pub fn video_detached_open(
         // it has no handle for, and a still window publishes nothing again until it moves.
         #[cfg(target_os = "windows")]
         match win.hwnd() {
-            Ok(handle) => app
-                .state::<crate::video::rtsp_native::NativeRtsp>()
-                .register_window(DETACHED_LABEL, handle.0 as isize),
+            Ok(handle) => {
+                app.state::<crate::video::rtsp_native::NativeRtsp>()
+                    .register_window(DETACHED_LABEL, handle.0 as isize);
+                // The same handle carries the aspect lock (`video_detached_aspect`): it holds the
+                // shape from inside the OS resize loop, where the page cannot reach.
+                crate::video::win_aspect::install(handle.0 as isize);
+            }
             Err(e) => log::warn!("[video] detached window has no native handle ({e}) — no picture there"),
         }
         // Linux: the detached window needs a video layer tree of its own. A GStreamer sink's widget
@@ -593,8 +597,36 @@ pub fn video_detached_chrome(zones: DetachedChrome) {
     let _ = zones;
 }
 
-/// The page's layout, as [`video_detached_chrome`] takes it.
+/// Hold the detached window to the picture's shape while the user drags its corner. The page can
+/// only put the size right AFTER a drag — inside the OS's resize loop every correction it makes is
+/// overwritten by the next mouse move, which is what made the frame snap into shape when the
+/// pointer stopped. Each platform enforces it where its resize actually happens: a `WM_SIZING`
+/// subclass on Windows, GTK's geometry hints on Linux, AppKit's content aspect ratio on macOS.
+///
+/// `aspect` is the picture's width/height and `ring` the page's chrome around it in physical px;
+/// `aspect <= 0` releases the window, which is what fullscreen wants.
+#[tauri::command]
+pub fn video_detached_aspect(app: AppHandle, aspect: f64, ring: f64) {
+    #[cfg(target_os = "windows")]
+    {
+        let _ = &app;
+        crate::video::win_aspect::set_shape(aspect, ring);
+    }
+    #[cfg(target_os = "linux")]
+    crate::video::linux_drag::set_aspect(&app, DETACHED_LABEL, aspect, ring);
+    #[cfg(target_os = "macos")]
+    {
+        let _ = &app;
+        crate::video::apple_host::set_aspect(DETACHED_LABEL.to_string(), aspect, ring);
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+    let _ = (app, aspect, ring);
+}
+
+/// The page's layout, as [`video_detached_chrome`] takes it. Only Linux reads the rects — the other
+/// platforms take their window gestures from the page itself and never need to know.
 #[derive(serde::Deserialize)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub struct DetachedChrome {
     /// Dragging the picture moves the window (false while fullscreen).
     pub drag: bool,

--- a/src-tauri/src/commands/video.rs
+++ b/src-tauri/src/commands/video.rs
@@ -495,6 +495,11 @@ pub fn video_detached_open(
                 .register_window(DETACHED_LABEL, handle.0 as isize),
             Err(e) => log::warn!("[video] detached window has no native handle ({e}) — no picture there"),
         }
+        // Linux: the detached window needs a video layer tree of its own. A GStreamer sink's widget
+        // cannot move between windows, so that window gets its own host — and its own pipeline in
+        // `linux_sink`, fed the same access units from the one RTSP connection.
+        #[cfg(target_os = "linux")]
+        crate::video::linux_host::install_for(&app, DETACHED_LABEL);
         let app_handle = app.clone();
         win.on_window_event(move |event| {
             if matches!(event, tauri::WindowEvent::Destroyed) {
@@ -554,9 +559,19 @@ pub fn video_detached_close(app: AppHandle) -> Result<(), String> {
     {
         use tauri::Manager;
 
+        // Surfaces first, window second. On Linux that window owns a GStreamer pipeline rendering
+        // into a widget INSIDE it, and withdrawing the surfaces is what stops that pipeline. The
+        // last frames may still be in flight when the window goes — a stopping pipeline's
+        // complaints are swallowed rather than ending the stream (see `linux_sink`'s bus loop).
+        app.state::<crate::video::rtsp_native::NativeRtsp>()
+            .forget_window(DETACHED_LABEL);
         if let Some(win) = app.get_webview_window(DETACHED_LABEL) {
             win.destroy().map_err(|e| e.to_string())?;
         }
+        // Belt and braces: whatever route the pipeline took down, this window's video layer must
+        // not outlive it (`linux_host` explains what an inherited one does to the next window).
+        #[cfg(target_os = "linux")]
+        crate::video::linux_host::uninstall(DETACHED_LABEL);
         Ok(())
     }
     #[cfg(not(desktop))]
@@ -564,4 +579,27 @@ pub fn video_detached_close(app: AppHandle) -> Result<(), String> {
         let _ = app;
         Ok(())
     }
+}
+
+/// What the detached window's page handles itself: the rects of its overlay buttons (while they
+/// are on screen) and of its resize corner, in CSS px, plus whether dragging the picture may move
+/// the window at all. Linux reads them from the GTK press handler — see `video::linux_drag`, which
+/// also explains why the move cannot go through `startDragging()` there. A no-op elsewhere.
+#[tauri::command]
+pub fn video_detached_chrome(zones: DetachedChrome) {
+    #[cfg(target_os = "linux")]
+    crate::video::linux_drag::set_zones(zones.drag, zones.grip, zones.chrome);
+    #[cfg(not(target_os = "linux"))]
+    let _ = zones;
+}
+
+/// The page's layout, as [`video_detached_chrome`] takes it.
+#[derive(serde::Deserialize)]
+pub struct DetachedChrome {
+    /// Dragging the picture moves the window (false while fullscreen).
+    pub drag: bool,
+    /// The resize corner, `[x, y, w, h]`.
+    pub grip: Option<[f64; 4]>,
+    /// Rects the page wants the press for.
+    pub chrome: Vec<[f64; 4]>,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,7 +97,7 @@ use commands::video::{
     video_rtsp_native_sink_surfaces, video_rtsp_native_stats,
     video_linux_hole_spike,
     video_rtsp_native_sink_buffer, video_rtsp_native_sink_orient,
-    video_detached_open, video_detached_close, video_detached_pin_top,
+    video_detached_open, video_detached_close, video_detached_pin_top, video_detached_chrome,
 };
 use video::{MediaMtx, MjpegServer};
 use commands::logging::{set_log_level, get_log_path, log_session_settings, log_frontend};
@@ -780,6 +780,7 @@ pub fn run() {
             video_detached_open,
             video_detached_close,
             video_detached_pin_top,
+            video_detached_chrome,
             radar_configure,
             radar_set_center,
             radar_set_node_pos,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,7 +97,7 @@ use commands::video::{
     video_rtsp_native_sink_surfaces, video_rtsp_native_stats,
     video_linux_hole_spike,
     video_rtsp_native_sink_buffer, video_rtsp_native_sink_orient,
-    video_detached_open, video_detached_close, video_detached_pin_top, video_detached_chrome,
+    video_detached_open, video_detached_close, video_detached_pin_top, video_detached_chrome, video_detached_aspect,
 };
 use video::{MediaMtx, MjpegServer};
 use commands::logging::{set_log_level, get_log_path, log_session_settings, log_frontend};
@@ -781,6 +781,7 @@ pub fn run() {
             video_detached_close,
             video_detached_pin_top,
             video_detached_chrome,
+            video_detached_aspect,
             radar_configure,
             radar_set_center,
             radar_set_node_pos,

--- a/src-tauri/src/video/apple_host.rs
+++ b/src-tauri/src/video/apple_host.rs
@@ -276,6 +276,35 @@ pub fn float_window(label: String) {
     });
 }
 
+/// Hold `label`'s window to the picture's shape while the user resizes it. AppKit enforces a
+/// content aspect ratio inside its own resize loop, which is the only place it can be enforced
+/// without fighting the drag.
+///
+/// The ratio is the WINDOW's, not the picture's: the page's chrome (`ring`, physical px) is a fixed
+/// border around the picture, so it shifts the ratio slightly, and by more the smaller the window
+/// is. It is therefore worked out from the window's size at the time — the page re-sends the shape
+/// whenever a resize settles, so the ratio it is held to is always the one it currently has. What
+/// remains is a pixel or two at the far end of a long drag, which the page's own snap takes care
+/// of. `aspect <= 0` releases the window (fullscreen).
+pub fn set_aspect(label: String, aspect: f64, ring: f64) {
+    on_main(move |_| {
+        let Some(app) = APP.get() else { return };
+        let Some(window) = app.get_webview_window(&label) else { return };
+        let Ok(ptr) = window.ns_window() else { return };
+        // SAFETY: tauri hands out the live NSWindow of this window.
+        let Some(ns_window) = (unsafe { Retained::retain(ptr.cast::<NSWindow>()) }) else { return };
+        if aspect <= 0.0 {
+            ns_window.setContentAspectRatio(CGSize::new(0.0, 0.0));
+            return;
+        }
+        let size = ns_window.contentView().map(|v| v.frame().size).unwrap_or(CGSize::new(0.0, 0.0));
+        let scale = ns_window.backingScaleFactor().max(1.0);
+        let border = ring / scale; // the ring arrives in physical px, AppKit works in points
+        let picture = (size.width - border).max(160.0);
+        ns_window.setContentAspectRatio(CGSize::new(picture + border, picture / aspect + border));
+    });
+}
+
 /// Stack the containers the way the DOM stacks their surfaces. `keys` arrives highest-priority
 /// FIRST (`main` > `floating` > `widget`), and DOM stacking is the reverse of that — the widget dock
 /// paints over the floating window, which paints over the fullscreen swap. So the list is walked

--- a/src-tauri/src/video/linux_drag.rs
+++ b/src-tauri/src/video/linux_drag.rs
@@ -23,6 +23,7 @@ use std::sync::Mutex;
 use gtk::gdk;
 use gtk::glib;
 use gtk::prelude::*;
+use tauri::{AppHandle, Manager};
 
 /// What the page handles itself, and where the resize corner is (CSS px, `[x, y, w, h]`).
 #[derive(Clone, Default)]
@@ -40,6 +41,42 @@ pub fn set_zones(drag: bool, grip: Option<[f64; 4]>, chrome: Vec<[f64; 4]>) {
     if let Ok(mut z) = ZONES.lock() {
         *z = Zones { drag, grip, chrome };
     }
+}
+
+/// Hold the window to the picture's shape while it is resized. GTK constrains the size it accepts
+/// from the compositor, so this works inside the drag rather than after it — the page's own snap
+/// (`DetachedVideoFrame`) stays the authority for the exact size and has nothing left to do while
+/// this holds. `ring` is the page's chrome in physical px; `aspect <= 0` releases the window
+/// (fullscreen, where a constraint would fight the screen's own size).
+pub fn set_aspect(app: &AppHandle, label: &str, aspect: f64, ring: f64) {
+    // The window is looked up ON the GTK thread: GTK objects are not `Send`, so only the handle and
+    // the label may cross (the same shape `linux_host::install_for` uses).
+    let app = app.clone();
+    let label = label.to_string();
+    glib::MainContext::default().invoke(move || {
+        let Some(window) = app.get_webview_window(&label) else { return };
+        let Ok(gtk_window) = window.gtk_window() else { return };
+        if aspect <= 0.0 {
+            gtk_window.set_geometry_hints(None::<&gtk::Widget>, None, gdk::WindowHints::empty());
+            return;
+        }
+        let border = (ring / f64::from(gtk_window.scale_factor().max(1))).round() as i32;
+        let geometry = gdk::Geometry::new(
+            -1, -1, -1, -1, // no size limits of our own: tauri set the minimum
+            border,
+            border,
+            -1,
+            -1,
+            aspect,
+            aspect,
+            gdk::Gravity::NorthWest,
+        );
+        gtk_window.set_geometry_hints(
+            None::<&gtk::Widget>,
+            Some(&geometry),
+            gdk::WindowHints::ASPECT | gdk::WindowHints::BASE_SIZE,
+        );
+    });
 }
 
 fn hit(r: &[f64; 4], x: f64, y: f64) -> bool {

--- a/src-tauri/src/video/linux_drag.rs
+++ b/src-tauri/src/video/linux_drag.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+//! Move and resize the detached video window from the GTK button-press handler (Linux).
+//!
+//! Tauri's `startDragging()` / `startResizeDragging()` reach GTK through the IPC: by the time
+//! `begin_move_drag` runs, the press is long over and no event is current. Under GNOME/Wayland the
+//! compositor then honours the request only every SECOND press — measured on Debian 13
+//! (2026-09-08): the page logged a `pointerdown` for every attempt and the command returned `Ok`
+//! every time, and the window still moved on every other one. The resize the same window gets from
+//! tauri-runtime-wry's undecorated-border handler never failed once, and that one runs INSIDE the
+//! button-press event. So this does too.
+//!
+//! The handler cannot ask the page what sits under the pointer, so the page says so in advance:
+//! [`set_zones`] takes the rects of its own corner chrome (buttons stay with the page — those
+//! presses are passed through) and of the resize grip, in CSS px, refreshed whenever they move.
+//! Everything else is the drag surface.
+//!
+//! Only the detached window gets this. The main window is decorated and drags by its title bar.
+
+use std::sync::Mutex;
+
+use gtk::gdk;
+use gtk::glib;
+use gtk::prelude::*;
+
+/// What the page handles itself, and where the resize corner is (CSS px, `[x, y, w, h]`).
+#[derive(Clone, Default)]
+struct Zones {
+    /// Dragging the picture moves the window — off while fullscreen.
+    drag: bool,
+    grip: Option<[f64; 4]>,
+    chrome: Vec<[f64; 4]>,
+}
+
+static ZONES: Mutex<Zones> = Mutex::new(Zones { drag: false, grip: None, chrome: Vec::new() });
+
+/// The page's current layout. Called on every change (fullscreen, chrome appearing, resize).
+pub fn set_zones(drag: bool, grip: Option<[f64; 4]>, chrome: Vec<[f64; 4]>) {
+    if let Ok(mut z) = ZONES.lock() {
+        *z = Zones { drag, grip, chrome };
+    }
+}
+
+fn hit(r: &[f64; 4], x: f64, y: f64) -> bool {
+    x >= r[0] && x < r[0] + r[2] && y >= r[1] && y < r[1] + r[3]
+}
+
+/// Take over left-button presses on `webview`. GTK runs handlers in connection order, so
+/// tauri-runtime-wry's border-resize handler — connected when the window was created — still gets
+/// the outer few pixels first; this sees everything inside them.
+pub fn install(window: &gtk::Window, webview: &gtk::Widget) {
+    let win = window.clone();
+    webview.connect_button_press_event(move |webview, ev| {
+        if ev.button() != 1 || ev.event_type() != gdk::EventType::ButtonPress {
+            return glib::Propagation::Proceed;
+        }
+        let Ok(zones) = ZONES.lock() else { return glib::Propagation::Proceed };
+        if !zones.drag {
+            return glib::Propagation::Proceed;
+        }
+        let (x, y) = ev.position();
+        // The outermost few pixels are the window's own resize border: tauri-runtime-wry hit-tests
+        // them in a handler connected before this one (its inset, `BORDERLESS_RESIZE_INSET`,
+        // scaled). It starts the edge resize and lets the press through, so anything done here
+        // would take that gesture over — leave the rim alone.
+        let border = f64::from(5 * webview.scale_factor());
+        let (w, h) = (f64::from(webview.allocated_width()), f64::from(webview.allocated_height()));
+        if x < border || y < border || x > w - border || y > h - border {
+            return glib::Propagation::Proceed;
+        }
+        // The page's own controls: it gets the press, we do nothing.
+        if zones.chrome.iter().any(|r| hit(r, x, y)) {
+            return glib::Propagation::Proceed;
+        }
+        let grip = zones.grip.filter(|r| hit(r, x, y));
+        drop(zones);
+        let (rx, ry) = ev.root();
+        let (rx, ry) = (rx as i32, ry as i32);
+        match grip {
+            // One corner, both axes — the page snaps the aspect back when the drag settles.
+            Some(_) => win.begin_resize_drag(gdk::WindowEdge::NorthEast, 1, rx, ry, ev.time()),
+            None => win.begin_move_drag(1, rx, ry, ev.time()),
+        }
+        // The press belongs to the window gesture now; letting WebKit have it as well would leave
+        // the page thinking a button is held down for as long as the compositor owns the pointer.
+        glib::Propagation::Stop
+    });
+}

--- a/src-tauri/src/video/linux_host.rs
+++ b/src-tauri/src/video/linux_host.rs
@@ -12,6 +12,12 @@
 //! GdkWindow and a GL context, and re-parenting it between clips (let alone between windows) is
 //! exactly the kind of surgery that costs the display, as `GL_DISPLAYS` in `linux_sink` documents.
 //!
+//! And there is one such tree PER WINDOW, keyed by its Tauri label: the main window, and the
+//! detached video window when it is open. That is also why the detached window gets a pipeline of
+//! its own in `linux_sink` rather than a branch of the main one — a widget cannot move between
+//! windows any more than between clips, and two `gtkglsink`s inside ONE pipeline cannot share the
+//! single GL context a pipeline distributes (they can across two pipelines).
+//!
 //! Widget tree, built once at startup by re-hosting the WebView that tao/wry packed into
 //! the window's default vbox:
 //!
@@ -37,6 +43,7 @@
 //! rects) and is mapped to GTK's logical px through the window's integer scale factor.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 
 use gtk::glib;
 use gtk::prelude::*;
@@ -76,7 +83,8 @@ struct Host {
 }
 
 thread_local! {
-    static HOST: RefCell<Option<Host>> = const { RefCell::new(None) };
+    /// One tree per window label (`main`, and `video` while the detached window is open).
+    static HOSTS: RefCell<HashMap<String, Host>> = RefCell::new(HashMap::new());
 }
 
 /// The clip paints the letterbox: everything in the hole that the video doesn't cover
@@ -87,16 +95,23 @@ const CSS: &str = ".kite-video-clip, .kite-video-base { background-color: #000; 
 /// from Tauri's setup (the WebView exists by then). Failure leaves the window as it was and
 /// only costs the native sink route.
 pub fn install(app: &AppHandle) {
+    install_for(app, "main");
+}
+
+/// Same for another window — the detached video window, once it exists. Idempotent: a label that
+/// already has a tree is left alone.
+pub fn install_for(app: &AppHandle, label: &str) {
     let handle = app.clone();
+    let label = label.to_string();
     glib::MainContext::default().invoke(move || {
-        if let Err(e) = install_from_app(&handle) {
-            log::warn!("[video] linux host: {e} — the native decode sink is unavailable");
+        if let Err(e) = install_from_app(&handle, &label) {
+            log::warn!("[video] linux host: {label}: {e} — the native decode sink is unavailable there");
         }
     });
 }
 
-fn install_from_app(app: &AppHandle) -> Result<(), String> {
-    let window = app.get_webview_window("main").ok_or("no main window")?;
+fn install_from_app(app: &AppHandle, label: &str) -> Result<(), String> {
+    let window = app.get_webview_window(label).ok_or("no such window")?;
     let gtk_window = window.gtk_window().map_err(|e| format!("gtk window: {e}"))?;
     let vbox = window.default_vbox().map_err(|e| format!("default vbox: {e}"))?;
     let children = vbox.children();
@@ -104,17 +119,51 @@ fn install_from_app(app: &AppHandle) -> Result<(), String> {
         let names: Vec<String> = children.iter().map(|c| c.type_().name().to_string()).collect();
         return Err(format!("no WebKitWebView in the default vbox (children: {names:?})"));
     };
-    install_tree(gtk_window.upcast_ref(), &vbox, Some(&webview))
+    let gtk_window: &gtk::Window = gtk_window.upcast_ref();
+
+    // A tree may still be on file for this label from a window that is GONE — the detached video
+    // window's, whenever its pipeline was not torn down through the path that calls `uninstall`
+    // (the stream stopping while it was open, say). Keeping it would park the NEW window's video
+    // widget in the dead one's clip layer: `gtkglsink` finds no toplevel above it and opens a
+    // window of its own ("Gtk+ GL renderer"), the app's own frame stays transparent, and closing
+    // that stray window pulls the widget out from under the running pipeline — which kills the
+    // stream (Marc, 2026-09-08). Same window → nothing to do; a different one → start over.
+    let known = HOSTS.with(|h| {
+        h.borrow().get(label).map(|host| host.window.as_ptr() == gtk_window.as_ptr())
+    });
+    match known {
+        Some(true) => return Ok(()),
+        Some(false) => {
+            log::info!("[video] linux host: {label}: the window changed — rebuilding the video layer");
+            HOSTS.with(|h| {
+                if let Some(mut host) = h.borrow_mut().remove(label) {
+                    for slot in 0..host.outs.len() {
+                        detach_widget(&mut host, slot);
+                    }
+                }
+            });
+        }
+        None => {}
+    }
+
+    install_tree_for(label, gtk_window, &vbox, Some(&webview))?;
+    // The detached window is undecorated: its move and resize gestures have to come from the press
+    // handler, not from the IPC (see `linux_drag`).
+    if label != "main" {
+        crate::video::linux_drag::install(gtk_window, &webview);
+    }
+    Ok(())
 }
 
 /// Build the layer tree under `window` (main thread). `webview` is re-hosted as the
 /// overlay child; `None` (tests) leaves the overlay with just the video layer.
-pub(crate) fn install_tree(
+pub(crate) fn install_tree_for(
+    label: &str,
     window: &gtk::Window,
     vbox: &gtk::Box,
     webview: Option<&gtk::Widget>,
 ) -> Result<(), String> {
-    if HOST.with(|h| h.borrow().is_some()) {
+    if HOSTS.with(|h| h.borrow().contains_key(label)) {
         return Ok(());
     }
     let provider = gtk::CssProvider::new();
@@ -162,25 +211,44 @@ pub(crate) fn install_tree(
     overlay.show_all();
 
     log::info!(
-        "[video] linux host: video layer installed, {SLOTS} slots (scale factor {})",
+        "[video] linux host: video layer installed in window {label}, {SLOTS} slots (scale factor {})",
         window.scale_factor()
     );
-    HOST.with(|h| {
-        *h.borrow_mut() = Some(Host {
-            window: window.clone(),
-            base,
-            outs,
-        })
+    HOSTS.with(|h| {
+        h.borrow_mut().insert(
+            label.to_string(),
+            Host {
+                window: window.clone(),
+                base,
+                outs,
+            },
+        )
     });
     Ok(())
 }
 
+/// Forget a window's tree — its window is going away (the detached video window closed). The
+/// widgets are removed first so the sink's pipeline can drop them safely.
+pub fn uninstall(label: &str) {
+    let label = label.to_string();
+    glib::MainContext::default().invoke(move || {
+        HOSTS.with(|h| {
+            if let Some(mut host) = h.borrow_mut().remove(&label) {
+                for slot in 0..host.outs.len() {
+                    detach_widget(&mut host, slot);
+                }
+            }
+        });
+    });
+}
+
 /// Run `f` against the host on the GTK main loop. Silently nothing without a host
 /// (install failed / not called — the MJPEG route needs none of this).
-fn on_main(f: impl FnOnce(&mut Host) + Send + 'static) {
+fn on_main(label: &str, f: impl FnOnce(&mut Host) + Send + 'static) {
+    let label = label.to_string();
     glib::MainContext::default().invoke(move || {
-        HOST.with(|h| {
-            if let Some(host) = h.borrow_mut().as_mut() {
+        HOSTS.with(|h| {
+            if let Some(host) = h.borrow_mut().get_mut(&label) {
                 f(host);
             }
         });
@@ -213,8 +281,8 @@ fn layout(host: &Host, slot: usize) {
 
 /// On-screen rect of one slot (PHYSICAL px, window client coords): FULL box `x/y/w/h` for the
 /// video's aspect-fit layout, VISIBLE box `cx/cy/cw/ch` for the clip.
-pub fn set_rect(slot: usize, rect: [i32; 8]) {
-    on_main(move |host| {
+pub fn set_rect(label: &str, slot: usize, rect: [i32; 8]) {
+    on_main(label, move |host| {
         if let Some(out) = host.outs.get_mut(slot) {
             out.rect = rect;
         }
@@ -224,8 +292,8 @@ pub fn set_rect(slot: usize, rect: [i32; 8]) {
 
 /// Give a slot to a surface, or park it because no surface wants it right now. Parking is not
 /// hiding — see [`PARK_POS`] for why that distinction is what keeps the pipeline alive.
-pub fn set_visible(slot: usize, visible: bool) {
-    on_main(move |host| {
+pub fn set_visible(label: &str, slot: usize, visible: bool) {
+    on_main(label, move |host| {
         if let Some(out) = host.outs.get_mut(slot) {
             out.parked = !visible;
             out.clip.set_visible(true);
@@ -239,8 +307,8 @@ pub fn set_visible(slot: usize, visible: bool) {
 /// paints over the floating window — so raising them in that order leaves the LAST one, the widget,
 /// on top. Only matters where two surfaces overlap; the clips have their own GdkWindows, so this is
 /// a stacking change, not a re-parent.
-pub fn restack(order: Vec<usize>) {
-    on_main(move |host| {
+pub fn restack(label: &str, order: Vec<usize>) {
+    on_main(label, move |host| {
         for slot in order {
             if let Some(out) = host.outs.get(slot) {
                 if let Some(win) = out.clip.window() {
@@ -257,11 +325,12 @@ pub fn restack(order: Vec<usize>) {
 /// The returned receiver yields once, `true` when the widget is placed — a sink that
 /// needs its widget realized before it starts (GL context) waits on it.
 pub fn attach(
+    label: &str,
     slot: usize,
     make: impl FnOnce() -> Option<gtk::Widget> + Send + 'static,
 ) -> std::sync::mpsc::Receiver<bool> {
     let (tx, rx) = std::sync::mpsc::channel();
-    on_main(move |host| {
+    on_main(label, move |host| {
         detach_widget(host, slot);
         let Some(w) = make() else {
             let _ = tx.send(false);
@@ -283,18 +352,26 @@ pub fn attach(
 
 /// Remove every video widget and hide every layer. The receiver yields once the main loop did
 /// it — a sink tears its pipeline down only after that (see linux_sink's Drop).
-pub fn detach() -> std::sync::mpsc::Receiver<()> {
+pub fn detach(label: &str) -> std::sync::mpsc::Receiver<()> {
     let (tx, rx) = std::sync::mpsc::channel();
-    on_main(move |host| {
-        for slot in 0..host.outs.len() {
-            detach_widget(host, slot);
-            if let Some(out) = host.outs.get_mut(slot) {
-                out.parked = true;
-                // Really hidden this time: the pipeline is going away, there is nothing left that
-                // could need a realized widget.
-                out.clip.hide();
+    let label = label.to_string();
+    // Not through `on_main`: the answer has to come even when the tree is already gone (a window
+    // that closed hands its layer back before its pipeline is torn down), or the caller sits out
+    // the full timeout for nothing.
+    glib::MainContext::default().invoke(move || {
+        HOSTS.with(|h| {
+            if let Some(host) = h.borrow_mut().get_mut(&label) {
+                for slot in 0..host.outs.len() {
+                    detach_widget(host, slot);
+                    if let Some(out) = host.outs.get_mut(slot) {
+                        out.parked = true;
+                        // Really hidden this time: the pipeline is going away, there is nothing
+                        // left that could need a realized widget.
+                        out.clip.hide();
+                    }
+                }
             }
-        }
+        });
         let _ = tx.send(());
     });
     rx
@@ -313,10 +390,10 @@ fn detach_widget(host: &mut Host, slot: usize) {
 #[cfg(debug_assertions)]
 pub fn spike(on: bool) {
     if !on {
-        let _ = detach();
+        let _ = detach("main");
         return;
     }
-    let _ = attach(0, || {
+    let _ = attach("main", 0, || {
         let area = gtk::DrawingArea::new();
         area.connect_draw(|w, cr| {
             let (aw, ah) = (w.allocated_width() as f64, w.allocated_height() as f64);

--- a/src-tauri/src/video/linux_host.rs
+++ b/src-tauri/src/video/linux_host.rs
@@ -5,6 +5,13 @@
 //! counterpart of the Android `NativeVideo` view host: a video widget BELOW the transparent
 //! WebKitWebView, in the same GtkWindow, visible wherever the DOM cut its hole.
 //!
+//! Since VIDEO_MULTISINK_WINDOW.md §4.2 there are [`SLOTS`] of them — the video widget and the
+//! floating window at the same time. A slot is a fixed seat: it owns one clip layer and holds one
+//! pipeline branch's widget for the sink's whole life. The sink decides which SURFACE a slot shows;
+//! the widget itself never moves. That is deliberate — a `gtkglsink` widget carries a realized
+//! GdkWindow and a GL context, and re-parenting it between clips (let alone between windows) is
+//! exactly the kind of surgery that costs the display, as `GL_DISPLAYS` in `linux_sink` documents.
+//!
 //! Widget tree, built once at startup by re-hosting the WebView that tao/wry packed into
 //! the window's default vbox:
 //!
@@ -12,8 +19,8 @@
 //!                         transparent)
 //!                         overlay child: WebKitWebView (fills; alpha-0 background from the
 //!                         `transparent` window flag in tauri.linux.conf.json) }
-//!   base → clip GtkLayout (own GdkWindow: clips children, paints black) at the VISIBLE box
-//!   clip → the video widget at the FULL box, offset so it lands in window coordinates
+//!   base → clip GtkLayout per slot (own GdkWindow: clips children, paints black) at its VISIBLE box
+//!   clip → that slot's video widget at the FULL box, offset so it lands in window coordinates
 //!
 //! The WebView sits exactly two levels below the window, as tao/wry built it —
 //! tauri-runtime-wry's undecorated-resize handler relies on that (see `install_tree`).
@@ -35,15 +42,37 @@ use gtk::glib;
 use gtk::prelude::*;
 use tauri::{AppHandle, Manager};
 
-/// Main-thread state; `None` until the tree was installed.
-struct Host {
-    window: gtk::Window,
-    base: gtk::Layout,
+/// On-screen surfaces this host can show at once (VIDEO_MULTISINK_WINDOW.md D1: the widget tile
+/// plus one large surface). One clip layer and one pipeline branch each, both built up front —
+/// the maximum is known, so nothing is added to a running pipeline.
+pub const SLOTS: usize = 2;
+
+/// One seat: its clip layer, the widget the sink parked in it, and the last rect it was given.
+struct Out {
     clip: gtk::Layout,
     video: Option<gtk::Widget>,
     /// Last rect pushed (physical px: x, y, w, h, cx, cy, cw, ch) — re-applied when a
     /// widget is attached after the rect arrived.
     rect: [i32; 8],
+    /// No surface wants this slot: it is parked (see [`PARK_POS`]) rather than hidden.
+    parked: bool,
+}
+
+/// Where an idle slot's clip goes: one logical pixel, off the base layout's top-left corner, so it
+/// is clipped away instead of drawn.
+///
+/// It must NOT be hidden. A hidden GtkLayout is not mapped, its child is never realized, and an
+/// unrealized `gtkglsink` widget has no GtkGLArea and therefore no GL context — `glupload` then has
+/// nothing to negotiate against and the whole pipeline dies with `not-negotiated (-4)` at the
+/// appsrc, before the first frame. Cost of parking instead: one 1×1 GL area that renders nothing,
+/// because that slot's valve drops every buffer upstream of it.
+const PARK_POS: i32 = -8;
+
+/// Main-thread state; `None` until the tree was installed.
+struct Host {
+    window: gtk::Window,
+    base: gtk::Layout,
+    outs: Vec<Out>,
 }
 
 thread_local! {
@@ -102,12 +131,16 @@ pub(crate) fn install_tree(
     // Black under the whole hole: letterbox bars outside the clip layer must not show the
     // window theme colour.
     base.style_context().add_class("kite-video-base");
-    let clip = gtk::Layout::new(None::<&gtk::Adjustment>, None::<&gtk::Adjustment>);
-    clip.style_context().add_class("kite-video-clip");
-    clip.set_size_request(1, 1);
-    // Stays hidden until a rect and a visible=true arrive from the surface router.
-    clip.set_no_show_all(true);
-    base.put(&clip, 0, 0);
+    let mut outs = Vec::with_capacity(SLOTS);
+    for _ in 0..SLOTS {
+        let clip = gtk::Layout::new(None::<&gtk::Adjustment>, None::<&gtk::Adjustment>);
+        clip.style_context().add_class("kite-video-clip");
+        clip.set_size_request(1, 1);
+        // Stays hidden until a rect and a visible=true arrive from the surface router.
+        clip.set_no_show_all(true);
+        base.put(&clip, PARK_POS, PARK_POS);
+        outs.push(Out { clip, video: None, rect: [0, 0, 1, 1, 0, 0, 1, 1], parked: true });
+    }
 
     // New tree: window → overlay { main: vbox → base ; overlay: webview }. The vbox stays
     // (tao's `default_vbox` keeps pointing at a live, hosted box) but moves under the
@@ -129,16 +162,14 @@ pub(crate) fn install_tree(
     overlay.show_all();
 
     log::info!(
-        "[video] linux host: video layer installed (scale factor {})",
+        "[video] linux host: video layer installed, {SLOTS} slots (scale factor {})",
         window.scale_factor()
     );
     HOST.with(|h| {
         *h.borrow_mut() = Some(Host {
             window: window.clone(),
             base,
-            clip,
-            video: None,
-            rect: [0, 0, 1, 1, 0, 0, 1, 1],
+            outs,
         })
     });
     Ok(())
@@ -156,73 +187,123 @@ fn on_main(f: impl FnOnce(&mut Host) + Send + 'static) {
     });
 }
 
-/// Apply `host.rect` to the clip and the video widget (physical → logical px).
-fn layout(host: &Host) {
+/// Apply one slot's rect to its clip and video widget (physical → logical px). A parked slot goes
+/// to its corner at 1×1 instead — visible, so its widget stays realized (see [`PARK_POS`]).
+fn layout(host: &Host, slot: usize) {
     let s = host.window.scale_factor().max(1) as f64;
     let l = |v: i32| (v as f64 / s).round() as i32;
-    let [x, y, w, h, cx, cy, cw, ch] = host.rect;
-    host.base.move_(&host.clip, l(cx), l(cy));
-    host.clip.set_size_request(l(cw).max(1), l(ch).max(1));
-    if let Some(v) = &host.video {
-        host.clip.move_(v, l(x - cx), l(y - cy));
+    let Some(out) = host.outs.get(slot) else { return };
+    if out.parked {
+        host.base.move_(&out.clip, PARK_POS, PARK_POS);
+        out.clip.set_size_request(1, 1);
+        if let Some(v) = &out.video {
+            out.clip.move_(v, 0, 0);
+            v.set_size_request(1, 1);
+        }
+        return;
+    }
+    let [x, y, w, h, cx, cy, cw, ch] = out.rect;
+    host.base.move_(&out.clip, l(cx), l(cy));
+    out.clip.set_size_request(l(cw).max(1), l(ch).max(1));
+    if let Some(v) = &out.video {
+        out.clip.move_(v, l(x - cx), l(y - cy));
         v.set_size_request(l(w).max(1), l(h).max(1));
     }
 }
 
-/// On-screen rect (PHYSICAL px, window client coords): FULL box `x/y/w/h` for the video's
-/// aspect-fit layout, VISIBLE box `cx/cy/cw/ch` for the clip.
-#[allow(clippy::too_many_arguments)]
-pub fn set_rect(x: i32, y: i32, w: i32, h: i32, cx: i32, cy: i32, cw: i32, ch: i32) {
+/// On-screen rect of one slot (PHYSICAL px, window client coords): FULL box `x/y/w/h` for the
+/// video's aspect-fit layout, VISIBLE box `cx/cy/cw/ch` for the clip.
+pub fn set_rect(slot: usize, rect: [i32; 8]) {
     on_main(move |host| {
-        host.rect = [x, y, w, h, cx, cy, cw, ch];
-        layout(host);
+        if let Some(out) = host.outs.get_mut(slot) {
+            out.rect = rect;
+        }
+        layout(host, slot);
     });
 }
 
-/// Show/hide the layer (no DOM surface wants it right now).
-pub fn set_visible(visible: bool) {
-    on_main(move |host| host.clip.set_visible(visible));
+/// Give a slot to a surface, or park it because no surface wants it right now. Parking is not
+/// hiding — see [`PARK_POS`] for why that distinction is what keeps the pipeline alive.
+pub fn set_visible(slot: usize, visible: bool) {
+    on_main(move |host| {
+        if let Some(out) = host.outs.get_mut(slot) {
+            out.parked = !visible;
+            out.clip.set_visible(true);
+        }
+        layout(host, slot);
+    });
 }
 
-/// Put a video widget into the layer, replacing any previous one. `make` runs on the GTK
+/// Stack the clips the way the DOM stacks their surfaces. `order` arrives highest-priority FIRST
+/// (`main` > `floating` > `widget`) and DOM stacking is the reverse of that — the widget dock
+/// paints over the floating window — so raising them in that order leaves the LAST one, the widget,
+/// on top. Only matters where two surfaces overlap; the clips have their own GdkWindows, so this is
+/// a stacking change, not a re-parent.
+pub fn restack(order: Vec<usize>) {
+    on_main(move |host| {
+        for slot in order {
+            if let Some(out) = host.outs.get(slot) {
+                if let Some(win) = out.clip.window() {
+                    win.raise();
+                }
+            }
+        }
+    });
+}
+
+/// Put a video widget into a slot, replacing any previous one. `make` runs on the GTK
 /// main thread — GTK objects don't cross threads, so the caller builds the widget there
 /// (e.g. reads a gtksink's `widget` property). `None` from `make` leaves the layer empty.
 /// The returned receiver yields once, `true` when the widget is placed — a sink that
 /// needs its widget realized before it starts (GL context) waits on it.
 pub fn attach(
+    slot: usize,
     make: impl FnOnce() -> Option<gtk::Widget> + Send + 'static,
 ) -> std::sync::mpsc::Receiver<bool> {
     let (tx, rx) = std::sync::mpsc::channel();
     on_main(move |host| {
-        detach_widget(host);
+        detach_widget(host, slot);
         let Some(w) = make() else {
             let _ = tx.send(false);
             return;
         };
-        host.clip.put(&w, 0, 0);
+        let Some(out) = host.outs.get_mut(slot) else {
+            let _ = tx.send(false);
+            return;
+        };
+        out.clip.set_visible(true);
+        out.clip.put(&w, 0, 0);
         w.show();
-        host.video = Some(w);
-        layout(host);
+        out.video = Some(w);
+        layout(host, slot);
         let _ = tx.send(true);
     });
     rx
 }
 
-/// Remove the video widget and hide the layer. The receiver yields once the main loop did
+/// Remove every video widget and hide every layer. The receiver yields once the main loop did
 /// it — a sink tears its pipeline down only after that (see linux_sink's Drop).
 pub fn detach() -> std::sync::mpsc::Receiver<()> {
     let (tx, rx) = std::sync::mpsc::channel();
     on_main(move |host| {
-        detach_widget(host);
-        host.clip.hide();
+        for slot in 0..host.outs.len() {
+            detach_widget(host, slot);
+            if let Some(out) = host.outs.get_mut(slot) {
+                out.parked = true;
+                // Really hidden this time: the pipeline is going away, there is nothing left that
+                // could need a realized widget.
+                out.clip.hide();
+            }
+        }
         let _ = tx.send(());
     });
     rx
 }
 
-fn detach_widget(host: &mut Host) {
-    if let Some(w) = host.video.take() {
-        host.clip.remove(&w);
+fn detach_widget(host: &mut Host, slot: usize) {
+    let Some(out) = host.outs.get_mut(slot) else { return };
+    if let Some(w) = out.video.take() {
+        out.clip.remove(&w);
     }
 }
 
@@ -235,7 +316,7 @@ pub fn spike(on: bool) {
         let _ = detach();
         return;
     }
-    let _ = attach(|| {
+    let _ = attach(0, || {
         let area = gtk::DrawingArea::new();
         area.connect_draw(|w, cr| {
             let (aw, ah) = (w.allocated_width() as f64, w.allocated_height() as f64);

--- a/src-tauri/src/video/linux_sink.rs
+++ b/src-tauri/src/video/linux_sink.rs
@@ -5,13 +5,31 @@
 //! `win_sink` (Media Foundation) and `android_sink` (MediaCodec). H.264/HEVC access units
 //! from the RTSP client go into
 //!
-//!   appsrc → h264parse/h265parse → decodebin3 → tee
-//!                                                  ├→ queue → valve → [leg] → gtkglsink   (slot 0)
-//!                                                  └→ queue → valve → [leg] → gtkglsink   (slot 1)
-//!   leg = glupload → glcolorconvert → glvideoflip
+//!   appsrc → h264parse/h265parse → decodebin3 → glupload → glcolorconvert → tee
+//!                            ├→ queue → valve → glvideoflip → gtkglsink                  (slot 0)
+//!                            └→ queue → valve → glvideoflip → gldownload → videoconvert → gtksink
+//!
+//! The tee sits BEHIND the GL upload on purpose. In front of it, one GL branch and one CPU branch
+//! have to agree on a buffer type, and the only thing both accept is system memory — the VA decoder
+//! then stops handing out DMABuf and every frame is copied through RAM and uploaded again. Measured
+//! on the Debian 13 laptop: the decoder's caps were plain `video/x-raw`/NV12, the video engine idled
+//! at 16 % while Render/3D sat at 80 % and the memory bus moved 8.8 GB/s (2026-09-08). Behind the
+//! upload the decoder keeps its zero-copy path, the tee shares GL buffers, and only the SECOND
+//! branch pays a readback — and only while it actually has a surface, because its valve drops
+//! everything otherwise.
 //!
 //! and each gtkglsink's GtkGLArea widget is what `linux_host` places below the WebView, one per
 //! slot (VIDEO_MULTISINK_WINDOW.md §4.2 — the video widget and the floating window at once).
+//!
+//! One such pipeline PER WINDOW. The main window's has both branches; the detached video window
+//! gets a pipeline of its own, fed the same access units from the same RTSP connection — never a
+//! second network stream, which over an LTE or Wi-Fi link to the aircraft would be the opposite of
+//! an improvement. It is a second DECODE (the macOS sink's D9 trade, for the same reason: a
+//! `gtkglsink` widget cannot move between windows, and two of them inside ONE pipeline cannot share
+//! the single GL context a pipeline distributes — across two pipelines they can, so the detached
+//! window keeps hardware-accelerated rendering instead of falling back to the CPU leg).
+//! Docked surfaces stay on ONE decode with a tee, deliberately: the Pi 5 decodes H.264 in software,
+//! where a second decode would cost far more than the CPU convert of the small second surface.
 //!
 //! BOTH branches are built up front and stay for the sink's life: the maximum is known (two), and
 //! adding a branch to a running pipeline means pad blocking and re-negotiation, which on the Pi's
@@ -122,12 +140,14 @@ struct Pacing {
 }
 
 pub struct LinuxVideoSink {
-    pipeline: gst::Pipeline,
-    appsrc: gst_app::AppSrc,
-    branches: Vec<Branch>,
+    /// One per window; `main` is built at start and lives as long as the sink, the detached video
+    /// window's comes and goes with its surfaces.
+    pipes: Mutex<Vec<Pipe>>,
+    /// What every new pipeline is built from.
+    codec: VideoCodec,
+    gl: bool,
     shared: Arc<Shared>,
     pacing: Mutex<Pacing>,
-    bus_thread: Option<JoinHandle<()>>,
     /// Conformance window stripped from this stream's SPS (module docs), if any.
     window: Option<Window>,
     geom: Mutex<Geom>,
@@ -143,9 +163,6 @@ pub fn hevc_decoder_is_stateless() -> bool {
 /// Last rect and orientation from the frontend — re-laid out when either changes.
 #[derive(Default)]
 struct Geom {
-    /// Per slot: the surface it currently serves and the rect that surface last published.
-    /// `None` = the slot is idle (its valve drops, its clip is hidden).
-    slots: Vec<Option<Slot>>,
     mirror: bool,
     rotate180: bool,
 }
@@ -158,6 +175,23 @@ struct Slot {
     key: String,
     /// The surface's own rect (physical px), before the conformance-window correction.
     rect: [i32; 8],
+}
+
+/// One window's pipeline: its own decode, its own branches, its own bus thread.
+struct Pipe {
+    /// Tauri window label whose host tree this pipeline renders into.
+    label: String,
+    pipeline: gst::Pipeline,
+    appsrc: gst_app::AppSrc,
+    branches: Vec<Branch>,
+    bus_thread: Option<JoinHandle<()>>,
+    /// Ends THIS pipeline's bus loop. The sink-wide `Shared::stopping` only ever ends all of them
+    /// at once, so a single window's teardown had nothing to stop its bus thread with and hung in
+    /// `join()` forever — with the sink mutex held, which then swallowed the next stop, the next
+    /// start ("Starting" for good) and the dock-back (Marc, 2026-09-08).
+    stopping: Arc<AtomicBool>,
+    /// Per slot: the surface it currently serves. `None` = idle (valve dropping, clip parked).
+    slots: Vec<Option<Slot>>,
 }
 
 /// One pipeline branch and the elements that belong only to it.
@@ -197,18 +231,37 @@ impl LinuxVideoSink {
             }
             _ => {}
         }
-        match Self::build(codec, gl, window) {
-            Ok(sink) => Ok(sink),
+        let shared = Arc::new(Shared::default());
+        let (main, gl) = match build_pipe("main", linux_host::SLOTS, codec, gl, &shared) {
+            Ok(p) => (p, gl),
             Err(e) if gl => {
                 log::warn!("[video] linux sink: GL sink unavailable ({e}) — using the cairo sink");
                 GL_UNAVAILABLE.store(true, Ordering::Relaxed);
-                Self::build(codec, false, window)
+                (build_pipe("main", linux_host::SLOTS, codec, false, &shared)?, false)
             }
-            Err(e) => Err(e),
-        }
+            Err(e) => return Err(e),
+        };
+        Ok(Self {
+            pipes: Mutex::new(vec![main]),
+            codec,
+            gl,
+            shared,
+            pacing: Mutex::new(Pacing::default()),
+            window,
+            geom: Mutex::new(Geom { mirror: false, rotate180: false }),
+        })
     }
+}
 
-    fn build(codec: VideoCodec, gl: bool, window: Option<Window>) -> Result<Self, String> {
+/// Build one window's pipeline with `slots` branches and start it. `label` names the host tree its
+/// widgets go into — the main window's, or the detached video window's.
+fn build_pipe(
+    label: &str,
+    slots: usize,
+    codec: VideoCodec,
+    gl: bool,
+    shared: &Arc<Shared>,
+) -> Result<Pipe, String> {
         let (parser, caps) = match codec {
             VideoCodec::H265 => ("h265parse", "video/x-h265,stream-format=byte-stream,alignment=au"),
             _ => ("h264parse", "video/x-h264,stream-format=byte-stream,alignment=au"),
@@ -250,17 +303,35 @@ impl LinuxVideoSink {
             });
         }
 
-        // One decode feeds every branch: the tee sits right behind decodebin3.
+        // One decode feeds every branch, and the split happens AFTER the upload (module docs): the
+        // decoder keeps whatever zero-copy memory it prefers, and the tee shares the uploaded
+        // frames.
         let tee = make("tee")?;
+        // ONLY the upload goes in front of the tee. The colour convert stays in the branches: in
+        // front, it would have to produce a format BOTH branches accept, which lands on RGBA — 3.7 MB
+        // per 720p frame against 1.4 MB as NV12, 221 MB/s of graphics memory instead of 83 at 60 fps.
+        // That surcharge eats exactly the headroom the window compositing needs, and the picture
+        // loses frames as the window grows (Marc, Debian 13, 2026-09-08). Behind the tee, branch 0
+        // is byte for byte the chain that shipped.
+        let head: Vec<gst::Element> = if gl { vec![make("glupload")?] } else { Vec::new() };
         pipeline
-            .add_many([appsrc.upcast_ref::<gst::Element>(), &parse, &decode, &tee])
+            .add_many([appsrc.upcast_ref::<gst::Element>(), &parse, &decode])
             .map_err(|e| format!("add: {e}"))?;
+        pipeline.add_many(head.iter()).map_err(|e| format!("add: {e}"))?;
+        pipeline.add(&tee).map_err(|e| format!("add: {e}"))?;
         gst::Element::link_many([appsrc.upcast_ref::<gst::Element>(), &parse, &decode])
             .map_err(|e| format!("link: {e}"))?;
+        gst::Element::link_many(head.iter()).map_err(|e| format!("link: {e}"))?;
+        // Cairo has no head at all — there the decoder's system memory IS the common denominator,
+        // so the tee sits right behind it.
+        match head.last() {
+            Some(last) => last.link(&tee).map_err(|e| format!("link head->tee: {e}"))?,
+            None => {}
+        }
         // decodebin3's source pad appears once the decoder negotiated: link it then.
-        let tee_in = tee.clone();
+        let head_in = head.first().cloned().unwrap_or_else(|| tee.clone());
         decode.connect_pad_added(move |_, pad| {
-            let Some(sinkpad) = tee_in.static_pad("sink") else { return };
+            let Some(sinkpad) = head_in.static_pad("sink") else { return };
             if sinkpad.is_linked() {
                 return;
             }
@@ -269,15 +340,22 @@ impl LinuxVideoSink {
             }
         });
 
-        let mut branches = Vec::with_capacity(linux_host::SLOTS);
-        for slot in 0..linux_host::SLOTS {
+        let mut branches = Vec::with_capacity(slots);
+        for slot in 0..slots {
             // A queue per branch so a slow one cannot stall the tee — and with it the other
             // branch. Leaky downstream: a branch that falls behind drops its own OLD frames
             // instead of building latency for everyone.
             let queue = make("queue")?;
-            queue.set_property("max-size-buffers", 3u32);
+            // Measured in TIME, not in buffers, and generously: in paced mode (`set_buffer` > 0) the
+            // sink holds every frame until its timestamp, so the cushion's worth of frames waits
+            // here. A three-buffer bucket threw the rest away — 60 fps in, ~10 fps on screen, while
+            // the counter in front of it still read 60 (Marc, 2026-09-08). One second covers every
+            // depth the stepper offers with room to spare; leaky only ever trips on a real overrun,
+            // and then it drops this branch's OLDEST frames rather than stalling the tee and with it
+            // the other branch.
+            queue.set_property("max-size-buffers", 0u32);
             queue.set_property("max-size-bytes", 0u32);
-            queue.set_property("max-size-time", 0u64);
+            queue.set_property("max-size-time", 1_000_000_000u64);
             queue.set_property_from_str("leaky", "downstream");
             // Idle slots drop here, before the colour convert and the render. `forward-sticky-events`
             // is not optional: the default `drop-all` swallows the CAPS event too, downstream never
@@ -288,25 +366,27 @@ impl LinuxVideoSink {
             valve.set_property_from_str("drop-mode", "forward-sticky-events");
             valve.set_property("drop", true);
 
-            // The post-decode leg: GL (zero-copy import where the decoder offers DMABuf) or cairo.
-            //
-            // ONLY THE FIRST branch gets GL. Two `gtkglsink`s in one pipeline each bring their own
-            // GtkGLArea and therefore their own GL context, while the pipeline distributes a single
-            // one — the second branch's `glupload` then has nothing it can negotiate against and the
-            // stream dies with `not-negotiated (-4)` at the appsrc, before a frame is shown. Proven
-            // by elimination on Debian 13 (2026-09-08): the same pipeline with BOTH branches on
-            // cairo runs clean through the sink's own start/stop test, and one GL branch alone runs
-            // in the app. So the second surface is converted on the CPU. It is the cheaper half of
-            // the deal anyway: the decode is shared (the tee sits behind the decoder), and the
-            // router hands slot 0 — the GL one — to the HIGHEST-priority surface, which is the big
-            // one; the second is normally the small widget tile.
-            let gl = gl && slot == 0;
-            let (leg, flip, sink) = if gl {
-                let upload = make("glupload")?;
+            // The branch itself. Only the FIRST one renders through GL: two `gtkglsink`s in one
+            // pipeline each bring their own GtkGLArea and therefore their own GL context, while a
+            // pipeline distributes a single one — the second then has nothing to negotiate against
+            // and the stream dies with `not-negotiated (-4)` at the appsrc, before a frame is shown
+            // (proven by elimination on Debian 13, 2026-09-08). The second branch therefore reads
+            // the frame back and renders on the CPU. It pays that only while it HAS a surface: its
+            // valve drops everything otherwise. Slot 0 goes to the highest-priority — largest —
+            // surface, so the readback serves the small widget tile.
+            let (leg, flip, sink) = if gl && slot == 0 {
                 let convert = make("glcolorconvert")?;
                 let flip = make("glvideoflip")?;
                 let sink = make("gtkglsink")?;
-                (vec![upload, convert, flip.clone(), sink.clone()], flip, sink)
+                (vec![convert, flip.clone(), sink.clone()], flip, sink)
+            } else if gl {
+                let convert = make("glcolorconvert")?;
+                let flip = make("glvideoflip")?;
+                let download = make("gldownload")?;
+                let to_cpu = make("videoconvert")?;
+                to_cpu.set_property("n-threads", 0u32);
+                let sink = make("gtksink")?;
+                (vec![convert, flip.clone(), download, to_cpu, sink.clone()], flip, sink)
             } else {
                 let convert = make("videoconvert")?;
                 // All cores: single-threaded the Pi 5 converts a cropped 720p60 HEVC at 45 fps,
@@ -335,7 +415,7 @@ impl LinuxVideoSink {
 
             // The widget must exist (and be realized, for GL) before the sink starts.
             let widget_sink = sink.clone();
-            let placed = linux_host::attach(slot, move || {
+            let placed = linux_host::attach(label, slot, move || {
                 Some(widget_sink.property::<gtk::Widget>("widget"))
             });
             match placed.recv_timeout(ATTACH_TIMEOUT) {
@@ -346,12 +426,15 @@ impl LinuxVideoSink {
             branches.push(Branch { valve, flip, sink });
         }
 
-        let shared = Arc::new(Shared::default());
         // Counted at the TEE's input, not at a sink: it is one number for the stream (as on the
         // other platforms), and a probe on one branch would read zero whenever that slot is the
         // idle one. The caps event carries the DISPLAY size — decoders report the cropped picture
         // there, the coded size stays in the meta.
-        if let Some(pad) = tee.static_pad("sink") {
+        //
+        // Only the MAIN pipeline counts. Every window decodes the same stream, so letting the
+        // detached window's pipeline add to the same counter reported 120 fps for a 60 fps source
+        // (Marc, 2026-09-08) — the panel shows the stream's rate, not the sum of the renders.
+        if let (Some(pad), true) = (tee.static_pad("sink"), label == "main") {
             let s = shared.clone();
             pad.add_probe(gst::PadProbeType::BUFFER, move |_, _| {
                 s.presented.fetch_add(1, Ordering::Relaxed);
@@ -367,7 +450,14 @@ impl LinuxVideoSink {
                             if w > 0 && h > 0 {
                                 s.width.store(w as u32, Ordering::Relaxed);
                                 s.height.store(h as u32, Ordering::Relaxed);
-                                log::info!("[video] linux sink: output {w}x{h} ({})", st.name());
+                                // The FULL caps, not just the structure name: the memory feature is
+                                // the whole story of whether the decoder hands its frames over
+                                // without a copy (`memory:DMABuf` / `memory:VAMemory`) or through
+                                // system RAM.
+                                log::info!(
+                                    "[video] linux sink: output {w}x{h} {}",
+                                    c.caps().to_string()
+                                );
                             }
                         }
                     }
@@ -377,41 +467,56 @@ impl LinuxVideoSink {
         }
 
         let bus = pipeline.bus().ok_or("no pipeline bus")?;
+        let stopping = Arc::new(AtomicBool::new(false));
         let bus_thread = {
-            let shared = shared.clone();
-            Some(std::thread::spawn(move || bus_loop(&bus, &shared)))
+            let shared = Arc::clone(shared);
+            let stopping = Arc::clone(&stopping);
+            Some(std::thread::spawn(move || bus_loop(&bus, &shared, &stopping)))
         };
 
         if let Err(e) = pipeline.set_state(gst::State::Playing) {
             let _ = pipeline.set_state(gst::State::Null);
-            shared.stopping.store(true, Ordering::SeqCst);
+            stopping.store(true, Ordering::SeqCst);
             if let Some(t) = bus_thread {
                 let _ = t.join();
             }
-            let _ = linux_host::detach().recv_timeout(ATTACH_TIMEOUT);
+            let _ = linux_host::detach(label).recv_timeout(ATTACH_TIMEOUT);
             let detail = shared.error.lock().unwrap().clone().unwrap_or_default();
             return Err(format!("pipeline start failed ({e}) {detail}"));
         }
         log::info!(
-            "[video] linux sink: {} pipeline up ({})",
+            "[video] linux sink: {} pipeline up in window {label} ({}, {slots} slot(s))",
             if matches!(codec, VideoCodec::H265) { "HEVC" } else { "H.264" },
             if gl { "GL" } else { "cairo" }
         );
-        Ok(Self {
+        Ok(Pipe {
+            label: label.to_string(),
             pipeline,
             appsrc,
             branches,
-            shared,
-            pacing: Mutex::new(Pacing::default()),
             bus_thread,
-            window,
-            geom: Mutex::new(Geom {
-                slots: vec![None; linux_host::SLOTS],
-                mirror: false,
-                rotate180: false,
-            }),
+            stopping,
+            slots: vec![None; slots],
         })
+}
+
+/// Stop one window's pipeline and give its widgets back, in the order the GL widget needs (see the
+/// sink's `Drop`).
+fn teardown_pipe(mut pipe: Pipe, shared: &Shared) {
+    // Before anything else: the bus loop is the one thread that must be told, and `join()` below
+    // waits for it.
+    pipe.stopping.store(true, Ordering::SeqCst);
+    let _ = pipe.appsrc.end_of_stream();
+    let _ = pipe.pipeline.set_state(gst::State::Null);
+    if let Some(t) = pipe.bus_thread.take() {
+        let _ = t.join();
     }
+    let _ = linux_host::detach(&pipe.label).recv_timeout(ATTACH_TIMEOUT);
+    let _ = shared;
+    log::info!("[video] linux sink: pipeline for window {} stopped", pipe.label);
+}
+
+impl LinuxVideoSink {
 
     /// Queue one access unit (Annex-B) with its unwrapped 90 kHz timestamp.
     pub fn push(&self, au: Vec<u8>, ts90k: u64) {
@@ -425,8 +530,12 @@ impl LinuxVideoSink {
         if let Some(b) = buffer.get_mut() {
             b.set_pts(gst::ClockTime::from_nseconds(pts));
         }
-        // Err = flushing/stopped: the stream is ending anyway.
-        let _ = self.appsrc.push_buffer(buffer);
+        // Every window's pipeline gets the SAME access unit from the one RTSP connection — the
+        // split is at the decoder, never at the network. Err = flushing/stopped: that pipeline is
+        // ending anyway.
+        for pipe in self.pipes.lock().unwrap().iter() {
+            let _ = pipe.appsrc.push_buffer(buffer.clone());
+        }
     }
 
     /// Media time → running-time PTS. Anchored at the first frame so the picture starts
@@ -467,8 +576,13 @@ impl LinuxVideoSink {
         }
     }
 
+    /// The MAIN pipeline's running time. With a second window open there are two clocks, but the
+    /// pacing cushion is one number for the stream and the difference between two pipelines started
+    /// seconds apart is far below the cushion itself.
     fn running_time(&self) -> u64 {
-        match (self.pipeline.clock(), self.pipeline.base_time()) {
+        let pipes = self.pipes.lock().unwrap();
+        let Some(pipe) = pipes.first() else { return 0 };
+        match (pipe.pipeline.clock(), pipe.pipeline.base_time()) {
             (Some(clock), Some(base)) => clock.time().map(|t| t.saturating_sub(base).nseconds()).unwrap_or(0),
             _ => 0,
         }
@@ -479,77 +593,113 @@ impl LinuxVideoSink {
         self.shared.error.lock().unwrap().clone()
     }
 
-    /// The surfaces to present into (VIDEO_MULTISINK_WINDOW.md §4.1), highest priority first and
-    /// capped at [`linux_host::SLOTS`]. A surface keeps the slot it already had — its branch owns a
-    /// realized GL widget, so moving a picture between slots would mean moving that widget, which
-    /// is precisely what must not happen (see `linux_host`). Slots nobody claims are idled: valve
-    /// dropping, clip hidden.
+    /// The surfaces to present into (VIDEO_MULTISINK_WINDOW.md §4.1), highest priority first.
     ///
-    /// Only the MAIN window's surfaces are servable: the GTK host layer lives there, so a surface
-    /// published by the detached video window has nowhere to go here and must not be drawn into the
-    /// main window instead. A second host — a second window's own overlay tree — is the follow-up.
+    /// Grouped BY WINDOW: each window has its own pipeline (the main one, and the detached video
+    /// window's while it is open), and within a window the surfaces are capped at
+    /// [`linux_host::SLOTS`] and assigned to seats. A surface keeps the seat it already had — its
+    /// branch owns a realized GL widget, and moving a picture between seats would mean moving that
+    /// widget, which is precisely what must not happen (see `linux_host`). Seats nobody claims are
+    /// idled: valve dropping, clip parked.
+    ///
+    /// A window that appears gets a pipeline built for it; one whose surfaces are all gone has its
+    /// pipeline torn down, so a closed detached window costs nothing.
     pub fn set_surfaces(&self, surfaces: &[SinkSurface]) {
-        let want: Vec<&SinkSurface> = surfaces
-            .iter()
-            .filter(|s| s.window == "main")
-            .take(linux_host::SLOTS)
-            .collect();
-
-        let mut g = self.geom.lock().unwrap();
-        // Keep every surface that still wants a slot where it is, then fill the freed slots with
-        // the newcomers in priority order.
-        for slot in g.slots.iter_mut() {
-            if let Some(cur) = slot {
-                if !want.iter().any(|s| s.key == cur.key) {
-                    *slot = None;
-                }
+        // Which windows want something, in first-seen (priority) order.
+        let mut windows: Vec<&str> = Vec::new();
+        for s in surfaces {
+            if !windows.iter().any(|w| *w == s.window) {
+                windows.push(&s.window);
             }
         }
-        for s in &want {
-            let rect = [s.full.0, s.full.1, s.full.2, s.full.3, s.clip.0, s.clip.1, s.clip.2, s.clip.3];
-            if let Some(cur) = g.slots.iter_mut().flatten().find(|c| c.key == s.key) {
-                cur.rect = rect;
+
+        let mut pipes = self.pipes.lock().unwrap();
+        // Gone: every pipeline except the main one whose window asks for nothing any more.
+        let mut i = 0;
+        while i < pipes.len() {
+            if pipes[i].label != "main" && !windows.iter().any(|w| *w == pipes[i].label) {
+                let pipe = pipes.remove(i);
+                let shared = Arc::clone(&self.shared);
+                // The window's video layer goes back NOW, from this thread: `uninstall` only posts
+                // to the GTK loop, so it lands there before anything a pipeline built later can
+                // queue — the layer can never be pulled out from under a NEW window of the same
+                // name. What is left is GStreamer work that waits for that same loop, so it must
+                // not run here: this is called with the sink's lock held, and on the GTK thread
+                // itself whenever a Tauri command drives it. Off it goes.
+                linux_host::uninstall(&pipe.label);
+                std::thread::spawn(move || teardown_pipe(pipe, &shared));
+            } else {
+                i += 1;
+            }
+        }
+        // New: a window with surfaces and no pipeline yet. ONE slot — a second window shows one
+        // picture, and two `gtkglsink`s in one pipeline cannot share its single GL context.
+        for w in &windows {
+            if pipes.iter().any(|p| p.label == *w) {
                 continue;
             }
-            let Some(free) = g.slots.iter_mut().find(|c| c.is_none()) else { continue };
-            *free = Some(Slot { key: s.key.clone(), rect });
+            match build_pipe(w, 1, self.codec, self.gl, &self.shared) {
+                Ok(p) => pipes.push(p),
+                Err(e) => log::warn!("[video] linux sink: no pipeline for window {w}: {e}"),
+            }
         }
-        // Which slot each surface ended up in, in the published (priority) order — the host stacks
-        // the clips by it, because two surfaces may overlap.
-        let order: Vec<usize> = want
-            .iter()
-            .filter_map(|s| g.slots.iter().position(|c| c.as_ref().is_some_and(|c| c.key == s.key)))
-            .collect();
-        let live: Vec<bool> = g.slots.iter().map(|c| c.is_some()).collect();
-        drop(g);
 
-        for (slot, on) in live.iter().enumerate() {
-            if let Some(b) = self.branches.get(slot) {
-                b.valve.set_property("drop", !on);
+        for pipe in pipes.iter_mut() {
+            let want: Vec<&SinkSurface> = surfaces
+                .iter()
+                .filter(|s| s.window == pipe.label)
+                .take(pipe.slots.len())
+                .collect();
+            // Keep every surface that still wants a seat where it is, then fill the freed seats
+            // with the newcomers in priority order.
+            for seat in pipe.slots.iter_mut() {
+                if let Some(cur) = seat {
+                    if !want.iter().any(|s| s.key == cur.key) {
+                        *seat = None;
+                    }
+                }
             }
-            if *on {
-                self.apply_rect(slot);
+            for s in &want {
+                let rect = [s.full.0, s.full.1, s.full.2, s.full.3, s.clip.0, s.clip.1, s.clip.2, s.clip.3];
+                if let Some(cur) = pipe.slots.iter_mut().flatten().find(|c| c.key == s.key) {
+                    cur.rect = rect;
+                    continue;
+                }
+                let Some(free) = pipe.slots.iter_mut().find(|c| c.is_none()) else { continue };
+                *free = Some(Slot { key: s.key.clone(), rect });
             }
-            linux_host::set_visible(slot, *on);
-        }
-        if !order.is_empty() {
-            linux_host::restack(order);
+            // Which seat each surface ended up in, in the published (priority) order — the host
+            // stacks the clips by it, because two surfaces may overlap.
+            let order: Vec<usize> = want
+                .iter()
+                .filter_map(|s| pipe.slots.iter().position(|c| c.as_ref().is_some_and(|c| c.key == s.key)))
+                .collect();
+
+            for slot in 0..pipe.slots.len() {
+                let live = pipe.slots[slot].clone();
+                if let Some(b) = pipe.branches.get(slot) {
+                    b.valve.set_property("drop", live.is_none());
+                }
+                if let Some(seat) = live {
+                    linux_host::set_rect(&pipe.label, slot, self.host_rect(seat.rect));
+                }
+                linux_host::set_visible(&pipe.label, slot, pipe.slots[slot].is_some());
+            }
+            if !order.is_empty() {
+                linux_host::restack(&pipe.label, order);
+            }
         }
     }
 
-    /// Lay one slot's widget out. With a stripped window the DISPLAY picture is aspect-fitted into
-    /// the full box and the widget grown to the CODED picture around it, so the padding rows
-    /// fall outside the visible box; the visible box is also clipped to the fitted picture
-    /// (a letterboxed box would otherwise show the padding in its bars).
-    fn apply_rect(&self, slot: usize) {
+    /// Turn a surface's rect into the one the host lays the widget out with. With a stripped
+    /// conformance window the DISPLAY picture is aspect-fitted into the full box and the widget
+    /// grown to the CODED picture around it, so the padding rows fall outside the visible box; the
+    /// visible box is also clipped to the fitted picture (a letterboxed box would otherwise show
+    /// the padding in its bars). Without a window it is the surface's own rect.
+    fn host_rect(&self, rect: [i32; 8]) -> [i32; 8] {
+        let [x, y, w, h, cx, cy, cw, ch] = rect;
+        let Some(win) = self.window else { return rect };
         let g = self.geom.lock().unwrap();
-        let Some(Some([x, y, w, h, cx, cy, cw, ch])) = g.slots.get(slot).map(|c| c.as_ref().map(|c| c.rect)) else {
-            return;
-        };
-        let Some(win) = self.window else {
-            linux_host::set_rect(slot, [x, y, w, h, cx, cy, cw, ch]);
-            return;
-        };
         let (dw, dh) = (win.display_w().max(1) as f64, win.display_h().max(1) as f64);
         let scale = (w as f64 / dw).min(h as f64 / dh);
         let (fw, fh) = (dw * scale, dh * scale);
@@ -561,19 +711,28 @@ impl LinuxVideoSink {
         let (vx, vy) = ((cx as f64).max(fx), (cy as f64).max(fy));
         let (vx2, vy2) = (((cx + cw) as f64).min(fx + fw), ((cy + ch) as f64).min(fy + fh));
         let r = |v: f64| v.round() as i32;
-        linux_host::set_rect(
-            slot,
-            [
-                r(fx - left * scale),
-                r(fy - top * scale),
-                r(win.coded_w as f64 * scale),
-                r(win.coded_h as f64 * scale),
-                r(vx),
-                r(vy),
-                r((vx2 - vx).max(1.0)),
-                r((vy2 - vy).max(1.0)),
-            ],
-        );
+        [
+            r(fx - left * scale),
+            r(fy - top * scale),
+            r(win.coded_w as f64 * scale),
+            r(win.coded_h as f64 * scale),
+            r(vx),
+            r(vy),
+            r((vx2 - vx).max(1.0)),
+            r((vy2 - vy).max(1.0)),
+        ]
+    }
+
+    /// Re-apply every live seat's rect — after an orientation change, which moves the padding.
+    fn relayout(&self) {
+        let pipes = self.pipes.lock().unwrap();
+        for pipe in pipes.iter() {
+            for (slot, seat) in pipe.slots.iter().enumerate() {
+                if let Some(seat) = seat {
+                    linux_host::set_rect(&pipe.label, slot, self.host_rect(seat.rect));
+                }
+            }
+        }
     }
 
     /// Smoothing-buffer depth in frames (0 = render on decode, the latency-first default).
@@ -581,8 +740,10 @@ impl LinuxVideoSink {
         let frames = frames.min(3);
         let before = self.shared.buffer_frames.swap(frames, Ordering::Relaxed);
         if (before == 0) != (frames == 0) {
-            for b in &self.branches {
-                b.sink.set_property("sync", frames > 0);
+            for pipe in self.pipes.lock().unwrap().iter() {
+                for b in &pipe.branches {
+                    b.sink.set_property("sync", frames > 0);
+                }
             }
         }
     }
@@ -595,25 +756,21 @@ impl LinuxVideoSink {
             (false, true) => "180",
             (true, true) => "vert", // mirror + 180° = vertical flip
         };
-        // Per branch: the flip element belongs to one leg, so every leg needs telling.
-        for b in &self.branches {
-            b.flip.set_property_from_str("video-direction", direction);
+        // Per branch: the flip element belongs to one leg, so every leg of every pipeline needs
+        // telling.
+        for pipe in self.pipes.lock().unwrap().iter() {
+            for b in &pipe.branches {
+                b.flip.set_property_from_str("video-direction", direction);
+            }
         }
-        let live: Vec<usize> = {
+        {
             let mut g = self.geom.lock().unwrap();
             g.mirror = mirror;
             g.rotate180 = rotate180;
-            g.slots
-                .iter()
-                .enumerate()
-                .filter_map(|(i, c)| c.is_some().then_some(i))
-                .collect()
-        };
-        // A flip moves the conformance-window padding, so every live slot is laid out again.
+        }
+        // A flip moves the conformance-window padding, so every live seat is laid out again.
         if self.window.is_some() {
-            for slot in live {
-                self.apply_rect(slot);
-            }
+            self.relayout();
         }
     }
 
@@ -642,21 +799,30 @@ impl Drop for LinuxVideoSink {
     /// blocked main thread, and the main loop must be free when it happens.
     fn drop(&mut self) {
         self.shared.stopping.store(true, Ordering::SeqCst);
-        let _ = self.appsrc.end_of_stream();
-        let _ = self.pipeline.set_state(gst::State::Null);
-        if let Some(t) = self.bus_thread.take() {
-            let _ = t.join();
+        // Inline, unlike the single-window teardown above: the sink is going away as a whole, so
+        // nothing can build a pipeline behind our back, and the caller (a stream stop, a restart)
+        // must not find half a sink still holding GL widgets.
+        let pipes: Vec<Pipe> = self.pipes.lock().unwrap().drain(..).collect();
+        for pipe in pipes {
+            let label = pipe.label.clone();
+            teardown_pipe(pipe, &self.shared);
+            // A window of its own (the detached one) hands its video layer back with the pipeline
+            // that fed it. Leaving it on file would make the NEXT window under that label inherit a
+            // tree belonging to a destroyed one — see the rebuild check in `linux_host`. The main
+            // window keeps its layer: it outlives every stream and is only ever installed once.
+            if label != "main" {
+                linux_host::uninstall(&label);
+            }
+            // The pipeline drops at the end of this iteration — step (3).
         }
-        let _ = linux_host::detach().recv_timeout(ATTACH_TIMEOUT);
-        // `self.pipeline` drops after this body — step (3).
     }
 }
 
 /// Pipeline errors → the sink's error slot (the stream ends on it and the frontend
 /// reconnects with a fresh sink); warnings go to the log only.
-fn bus_loop(bus: &gst::Bus, shared: &Shared) {
+fn bus_loop(bus: &gst::Bus, shared: &Shared, stopping: &AtomicBool) {
     use gst::MessageView;
-    while !shared.stopping.load(Ordering::SeqCst) {
+    while !shared.stopping.load(Ordering::SeqCst) && !stopping.load(Ordering::SeqCst) {
         let Some(msg) = bus.timed_pop_filtered(
             gst::ClockTime::from_mseconds(200),
             &[gst::MessageType::Error, gst::MessageType::Warning, gst::MessageType::HaveContext],
@@ -675,7 +841,15 @@ fn bus_loop(bus: &gst::Bus, shared: &Shared) {
             }
             MessageView::Error(e) => {
                 let debug = e.debug().map(|d| d.to_string()).unwrap_or_default();
-                shared.fail(format!("{src}: {} ({debug})", e.error()));
+                // A pipeline on its way out takes its window's widgets with it, and whatever it
+                // shouts on the way ("Output widget was destroyed") is expected — it must not end
+                // the STREAM, which is what happened when the detached window closed while its
+                // last frames were still in flight (Marc, 2026-09-08).
+                if stopping.load(Ordering::SeqCst) {
+                    log::debug!("[video] linux sink: {src} while stopping: {}", e.error());
+                } else {
+                    shared.fail(format!("{src}: {} ({debug})", e.error()));
+                }
             }
             MessageView::Warning(w) => {
                 log::debug!("[video] linux sink: {src}: {}", w.error());
@@ -730,7 +904,7 @@ mod tests {
         let vbox = gtk::Box::new(gtk::Orientation::Vertical, 0);
         window.add(&vbox);
         window.show_all();
-        linux_host::install_tree(&window, &vbox, None).expect("host tree");
+        linux_host::install_tree_for("main", &window, &vbox, None).expect("host tree");
 
         let done = Arc::new(AtomicBool::new(false));
         let worker = {
@@ -824,7 +998,7 @@ mod tests {
         }
         vbox.pack_start(&webview, true, true, 0);
         window.show_all();
-        linux_host::install_tree(&window, &vbox, Some(webview.upcast_ref())).expect("host tree");
+        linux_host::install_tree_for("main", &window, &vbox, Some(webview.upcast_ref())).expect("host tree");
 
         let done = Arc::new(AtomicBool::new(false));
         let worker = {

--- a/src-tauri/src/video/linux_sink.rs
+++ b/src-tauri/src/video/linux_sink.rs
@@ -5,10 +5,19 @@
 //! `win_sink` (Media Foundation) and `android_sink` (MediaCodec). H.264/HEVC access units
 //! from the RTSP client go into
 //!
-//!   appsrc → h264parse/h265parse → decodebin3 → glupload → glcolorconvert → glvideoflip
-//!   → gtkglsink
+//!   appsrc → h264parse/h265parse → decodebin3 → tee
+//!                                                  ├→ queue → valve → [leg] → gtkglsink   (slot 0)
+//!                                                  └→ queue → valve → [leg] → gtkglsink   (slot 1)
+//!   leg = glupload → glcolorconvert → glvideoflip
 //!
-//! and the gtkglsink's GtkGLArea widget is what `linux_host` places below the WebView.
+//! and each gtkglsink's GtkGLArea widget is what `linux_host` places below the WebView, one per
+//! slot (VIDEO_MULTISINK_WINDOW.md §4.2 — the video widget and the floating window at once).
+//!
+//! BOTH branches are built up front and stay for the sink's life: the maximum is known (two), and
+//! adding a branch to a running pipeline means pad blocking and re-negotiation, which on the Pi's
+//! stateless decoder is exactly the kind of interruption it cannot conceal. An unused branch is
+//! idled by its `valve`, which drops buffers before the colour convert and the render — the decode
+//! is upstream of the tee, so a second surface costs a convert and a render, never a second decode.
 //! decodebin3 picks the decoder the machine has — VA-API (`vah264dec`/`vah265dec`, Intel/
 //! AMD), V4L2 (Pi 4 H264 stateful, Pi 5 HEVC stateless `v4l2slh265dec`) or software
 //! (`avdec_*`) — and the GL leg imports DMABuf output without a copy where the decoder
@@ -115,8 +124,7 @@ struct Pacing {
 pub struct LinuxVideoSink {
     pipeline: gst::Pipeline,
     appsrc: gst_app::AppSrc,
-    flip: gst::Element,
-    sink: gst::Element,
+    branches: Vec<Branch>,
     shared: Arc<Shared>,
     pacing: Mutex<Pacing>,
     bus_thread: Option<JoinHandle<()>>,
@@ -135,9 +143,30 @@ pub fn hevc_decoder_is_stateless() -> bool {
 /// Last rect and orientation from the frontend — re-laid out when either changes.
 #[derive(Default)]
 struct Geom {
-    rect: Option<[i32; 8]>,
+    /// Per slot: the surface it currently serves and the rect that surface last published.
+    /// `None` = the slot is idle (its valve drops, its clip is hidden).
+    slots: Vec<Option<Slot>>,
     mirror: bool,
     rotate180: bool,
+}
+
+/// What a slot is showing right now.
+#[derive(Clone)]
+struct Slot {
+    /// The surface's `window/id` — kept so a surface keeps its slot across pushes and its
+    /// widget never has to move.
+    key: String,
+    /// The surface's own rect (physical px), before the conformance-window correction.
+    rect: [i32; 8],
+}
+
+/// One pipeline branch and the elements that belong only to it.
+struct Branch {
+    /// Drops everything while this slot is idle — cheaper than blocking, and it cannot stall
+    /// the tee (which would stall the OTHER branch with it).
+    valve: gst::Element,
+    flip: gst::Element,
+    sink: gst::Element,
 }
 
 impl LinuxVideoSink {
@@ -221,41 +250,17 @@ impl LinuxVideoSink {
             });
         }
 
-        // The post-decode leg: GL (zero-copy import where the decoder offers DMABuf) or cairo.
-        let (chain, flip, sink) = if gl {
-            let upload = make("glupload")?;
-            let convert = make("glcolorconvert")?;
-            let flip = make("glvideoflip")?;
-            let sink = make("gtkglsink")?;
-            (vec![upload, convert, flip.clone(), sink.clone()], flip, sink)
-        } else {
-            let convert = make("videoconvert")?;
-            // All cores: single-threaded the Pi 5 converts a cropped 720p60 HEVC at 45 fps,
-            // with threads 57 (then the decoder's own copy is the limit).
-            convert.set_property("n-threads", 0u32);
-            let flip = make("videoflip")?;
-            let sink = make("gtksink")?;
-            (vec![convert, flip.clone(), sink.clone()], flip, sink)
-        };
-        // Latency first: render on decode. `set_buffer` flips this for the paced depths.
-        sink.set_property("sync", false);
-        // Paced mode only (no effect while unsynced): see the two constants above.
-        sink.set_property("max-lateness", LATE_TOLERANCE_NS);
-        sink.set_property("qos", false);
-
+        // One decode feeds every branch: the tee sits right behind decodebin3.
+        let tee = make("tee")?;
         pipeline
-            .add_many([appsrc.upcast_ref::<gst::Element>(), &parse, &decode])
-            .map_err(|e| format!("add: {e}"))?;
-        pipeline
-            .add_many(chain.iter())
+            .add_many([appsrc.upcast_ref::<gst::Element>(), &parse, &decode, &tee])
             .map_err(|e| format!("add: {e}"))?;
         gst::Element::link_many([appsrc.upcast_ref::<gst::Element>(), &parse, &decode])
             .map_err(|e| format!("link: {e}"))?;
-        gst::Element::link_many(chain.iter()).map_err(|e| format!("link: {e}"))?;
         // decodebin3's source pad appears once the decoder negotiated: link it then.
-        let first = chain[0].clone();
+        let tee_in = tee.clone();
         decode.connect_pad_added(move |_, pad| {
-            let Some(sinkpad) = first.static_pad("sink") else { return };
+            let Some(sinkpad) = tee_in.static_pad("sink") else { return };
             if sinkpad.is_linked() {
                 return;
             }
@@ -264,11 +269,89 @@ impl LinuxVideoSink {
             }
         });
 
+        let mut branches = Vec::with_capacity(linux_host::SLOTS);
+        for slot in 0..linux_host::SLOTS {
+            // A queue per branch so a slow one cannot stall the tee — and with it the other
+            // branch. Leaky downstream: a branch that falls behind drops its own OLD frames
+            // instead of building latency for everyone.
+            let queue = make("queue")?;
+            queue.set_property("max-size-buffers", 3u32);
+            queue.set_property("max-size-bytes", 0u32);
+            queue.set_property("max-size-time", 0u64);
+            queue.set_property_from_str("leaky", "downstream");
+            // Idle slots drop here, before the colour convert and the render. `forward-sticky-events`
+            // is not optional: the default `drop-all` swallows the CAPS event too, downstream never
+            // negotiates, and the failed caps event travels back up as `not-negotiated (-4)` at the
+            // appsrc — the whole stream dies before the first frame (Marc, Debian 13, 2026-09-08).
+            // The property is only settable in NULL/READY, hence here and not at first use.
+            let valve = make("valve")?;
+            valve.set_property_from_str("drop-mode", "forward-sticky-events");
+            valve.set_property("drop", true);
+
+            // The post-decode leg: GL (zero-copy import where the decoder offers DMABuf) or cairo.
+            //
+            // ONLY THE FIRST branch gets GL. Two `gtkglsink`s in one pipeline each bring their own
+            // GtkGLArea and therefore their own GL context, while the pipeline distributes a single
+            // one — the second branch's `glupload` then has nothing it can negotiate against and the
+            // stream dies with `not-negotiated (-4)` at the appsrc, before a frame is shown. Proven
+            // by elimination on Debian 13 (2026-09-08): the same pipeline with BOTH branches on
+            // cairo runs clean through the sink's own start/stop test, and one GL branch alone runs
+            // in the app. So the second surface is converted on the CPU. It is the cheaper half of
+            // the deal anyway: the decode is shared (the tee sits behind the decoder), and the
+            // router hands slot 0 — the GL one — to the HIGHEST-priority surface, which is the big
+            // one; the second is normally the small widget tile.
+            let gl = gl && slot == 0;
+            let (leg, flip, sink) = if gl {
+                let upload = make("glupload")?;
+                let convert = make("glcolorconvert")?;
+                let flip = make("glvideoflip")?;
+                let sink = make("gtkglsink")?;
+                (vec![upload, convert, flip.clone(), sink.clone()], flip, sink)
+            } else {
+                let convert = make("videoconvert")?;
+                // All cores: single-threaded the Pi 5 converts a cropped 720p60 HEVC at 45 fps,
+                // with threads 57 (then the decoder's own copy is the limit).
+                convert.set_property("n-threads", 0u32);
+                let flip = make("videoflip")?;
+                let sink = make("gtksink")?;
+                (vec![convert, flip.clone(), sink.clone()], flip, sink)
+            };
+            // Latency first: render on decode. `set_buffer` flips this for the paced depths.
+            sink.set_property("sync", false);
+            // A sink that receives nothing must not hold the pipeline in preroll: an idle branch's
+            // valve drops every buffer, and with the default async behaviour the PLAYING transition
+            // then never completes — the LIVE branch shows its one preroll frame and freezes
+            // (Marc, 2026-09-08).
+            sink.set_property("async", false);
+            // Paced mode only (no effect while unsynced): see the two constants above.
+            sink.set_property("max-lateness", LATE_TOLERANCE_NS);
+            sink.set_property("qos", false);
+
+            let mut chain = vec![queue.clone(), valve.clone()];
+            chain.extend(leg);
+            pipeline.add_many(chain.iter()).map_err(|e| format!("add: {e}"))?;
+            gst::Element::link_many(chain.iter()).map_err(|e| format!("link: {e}"))?;
+            tee.link(&queue).map_err(|e| format!("link tee->queue: {e}"))?;
+
+            // The widget must exist (and be realized, for GL) before the sink starts.
+            let widget_sink = sink.clone();
+            let placed = linux_host::attach(slot, move || {
+                Some(widget_sink.property::<gtk::Widget>("widget"))
+            });
+            match placed.recv_timeout(ATTACH_TIMEOUT) {
+                Ok(true) => {}
+                Ok(false) => return Err("the host has no place for the video widget".to_string()),
+                Err(_) => return Err("the video host did not answer (not installed?)".to_string()),
+            }
+            branches.push(Branch { valve, flip, sink });
+        }
+
         let shared = Arc::new(Shared::default());
-        // Frames reaching the sink = presented (the sink renders every buffer at depth 0 and
-        // the on-time ones when paced); the caps event carries the DISPLAY size — decoders
-        // report the cropped picture there, the coded size stays in the meta.
-        if let Some(pad) = sink.static_pad("sink") {
+        // Counted at the TEE's input, not at a sink: it is one number for the stream (as on the
+        // other platforms), and a probe on one branch would read zero whenever that slot is the
+        // idle one. The caps event carries the DISPLAY size — decoders report the cropped picture
+        // there, the coded size stays in the meta.
+        if let Some(pad) = tee.static_pad("sink") {
             let s = shared.clone();
             pad.add_probe(gst::PadProbeType::BUFFER, move |_, _| {
                 s.presented.fetch_add(1, Ordering::Relaxed);
@@ -291,15 +374,6 @@ impl LinuxVideoSink {
                 }
                 gst::PadProbeReturn::Ok
             });
-        }
-
-        // The widget must exist (and be realized, for GL) before the sink starts.
-        let widget_sink = sink.clone();
-        let placed = linux_host::attach(move || Some(widget_sink.property::<gtk::Widget>("widget")));
-        match placed.recv_timeout(ATTACH_TIMEOUT) {
-            Ok(true) => {}
-            Ok(false) => return Err("the host has no place for the video widget".to_string()),
-            Err(_) => return Err("the video host did not answer (not installed?)".to_string()),
         }
 
         let bus = pipeline.bus().ok_or("no pipeline bus")?;
@@ -326,13 +400,16 @@ impl LinuxVideoSink {
         Ok(Self {
             pipeline,
             appsrc,
-            flip,
-            sink,
+            branches,
             shared,
             pacing: Mutex::new(Pacing::default()),
             bus_thread,
             window,
-            geom: Mutex::new(Geom::default()),
+            geom: Mutex::new(Geom {
+                slots: vec![None; linux_host::SLOTS],
+                mirror: false,
+                rotate180: false,
+            }),
         })
     }
 
@@ -402,40 +479,75 @@ impl LinuxVideoSink {
         self.shared.error.lock().unwrap().clone()
     }
 
-    /// The surfaces to present into (VIDEO_MULTISINK_WINDOW.md §4.1). This platform drives ONE
-    /// output for now, so the first entry wins — the router publishes them highest-priority first —
-    /// and an empty list hides the layer. Two outputs here are the follow-up (§4.2).
+    /// The surfaces to present into (VIDEO_MULTISINK_WINDOW.md §4.1), highest priority first and
+    /// capped at [`linux_host::SLOTS`]. A surface keeps the slot it already had — its branch owns a
+    /// realized GL widget, so moving a picture between slots would mean moving that widget, which
+    /// is precisely what must not happen (see `linux_host`). Slots nobody claims are idled: valve
+    /// dropping, clip hidden.
     ///
     /// Only the MAIN window's surfaces are servable: the GTK host layer lives there, so a surface
     /// published by the detached video window has nowhere to go here and must not be drawn into the
-    /// main window instead (a second host is the same follow-up).
+    /// main window instead. A second host — a second window's own overlay tree — is the follow-up.
     pub fn set_surfaces(&self, surfaces: &[SinkSurface]) {
-        match surfaces.iter().find(|s| s.window == "main") {
-            Some(s) => {
-                self.set_rect(s.full.0, s.full.1, s.full.2, s.full.3, s.clip.0, s.clip.1, s.clip.2, s.clip.3);
-                self.set_visible(true);
+        let want: Vec<&SinkSurface> = surfaces
+            .iter()
+            .filter(|s| s.window == "main")
+            .take(linux_host::SLOTS)
+            .collect();
+
+        let mut g = self.geom.lock().unwrap();
+        // Keep every surface that still wants a slot where it is, then fill the freed slots with
+        // the newcomers in priority order.
+        for slot in g.slots.iter_mut() {
+            if let Some(cur) = slot {
+                if !want.iter().any(|s| s.key == cur.key) {
+                    *slot = None;
+                }
             }
-            None => self.set_visible(false),
+        }
+        for s in &want {
+            let rect = [s.full.0, s.full.1, s.full.2, s.full.3, s.clip.0, s.clip.1, s.clip.2, s.clip.3];
+            if let Some(cur) = g.slots.iter_mut().flatten().find(|c| c.key == s.key) {
+                cur.rect = rect;
+                continue;
+            }
+            let Some(free) = g.slots.iter_mut().find(|c| c.is_none()) else { continue };
+            *free = Some(Slot { key: s.key.clone(), rect });
+        }
+        // Which slot each surface ended up in, in the published (priority) order — the host stacks
+        // the clips by it, because two surfaces may overlap.
+        let order: Vec<usize> = want
+            .iter()
+            .filter_map(|s| g.slots.iter().position(|c| c.as_ref().is_some_and(|c| c.key == s.key)))
+            .collect();
+        let live: Vec<bool> = g.slots.iter().map(|c| c.is_some()).collect();
+        drop(g);
+
+        for (slot, on) in live.iter().enumerate() {
+            if let Some(b) = self.branches.get(slot) {
+                b.valve.set_property("drop", !on);
+            }
+            if *on {
+                self.apply_rect(slot);
+            }
+            linux_host::set_visible(slot, *on);
+        }
+        if !order.is_empty() {
+            linux_host::restack(order);
         }
     }
 
-    /// On-screen video rect (PHYSICAL px, window coords): FULL box + VISIBLE box — the
-    /// host lays the widget out in the full box and clips it at the visible edge.
-    #[allow(clippy::too_many_arguments)]
-    fn set_rect(&self, x: i32, y: i32, w: i32, h: i32, cx: i32, cy: i32, cw: i32, ch: i32) {
-        self.geom.lock().unwrap().rect = Some([x, y, w, h, cx, cy, cw, ch]);
-        self.apply_rect();
-    }
-
-    /// Lay the widget out. With a stripped window the DISPLAY picture is aspect-fitted into
+    /// Lay one slot's widget out. With a stripped window the DISPLAY picture is aspect-fitted into
     /// the full box and the widget grown to the CODED picture around it, so the padding rows
     /// fall outside the visible box; the visible box is also clipped to the fitted picture
     /// (a letterboxed box would otherwise show the padding in its bars).
-    fn apply_rect(&self) {
+    fn apply_rect(&self, slot: usize) {
         let g = self.geom.lock().unwrap();
-        let Some([x, y, w, h, cx, cy, cw, ch]) = g.rect else { return };
+        let Some(Some([x, y, w, h, cx, cy, cw, ch])) = g.slots.get(slot).map(|c| c.as_ref().map(|c| c.rect)) else {
+            return;
+        };
         let Some(win) = self.window else {
-            linux_host::set_rect(x, y, w, h, cx, cy, cw, ch);
+            linux_host::set_rect(slot, [x, y, w, h, cx, cy, cw, ch]);
             return;
         };
         let (dw, dh) = (win.display_w().max(1) as f64, win.display_h().max(1) as f64);
@@ -450,19 +562,18 @@ impl LinuxVideoSink {
         let (vx2, vy2) = (((cx + cw) as f64).min(fx + fw), ((cy + ch) as f64).min(fy + fh));
         let r = |v: f64| v.round() as i32;
         linux_host::set_rect(
-            r(fx - left * scale),
-            r(fy - top * scale),
-            r(win.coded_w as f64 * scale),
-            r(win.coded_h as f64 * scale),
-            r(vx),
-            r(vy),
-            r((vx2 - vx).max(1.0)),
-            r((vy2 - vy).max(1.0)),
+            slot,
+            [
+                r(fx - left * scale),
+                r(fy - top * scale),
+                r(win.coded_w as f64 * scale),
+                r(win.coded_h as f64 * scale),
+                r(vx),
+                r(vy),
+                r((vx2 - vx).max(1.0)),
+                r((vy2 - vy).max(1.0)),
+            ],
         );
-    }
-
-    fn set_visible(&self, visible: bool) {
-        linux_host::set_visible(visible);
     }
 
     /// Smoothing-buffer depth in frames (0 = render on decode, the latency-first default).
@@ -470,7 +581,9 @@ impl LinuxVideoSink {
         let frames = frames.min(3);
         let before = self.shared.buffer_frames.swap(frames, Ordering::Relaxed);
         if (before == 0) != (frames == 0) {
-            self.sink.set_property("sync", frames > 0);
+            for b in &self.branches {
+                b.sink.set_property("sync", frames > 0);
+            }
         }
     }
 
@@ -482,14 +595,25 @@ impl LinuxVideoSink {
             (false, true) => "180",
             (true, true) => "vert", // mirror + 180° = vertical flip
         };
-        self.flip.set_property_from_str("video-direction", direction);
-        {
+        // Per branch: the flip element belongs to one leg, so every leg needs telling.
+        for b in &self.branches {
+            b.flip.set_property_from_str("video-direction", direction);
+        }
+        let live: Vec<usize> = {
             let mut g = self.geom.lock().unwrap();
             g.mirror = mirror;
             g.rotate180 = rotate180;
-        }
+            g.slots
+                .iter()
+                .enumerate()
+                .filter_map(|(i, c)| c.is_some().then_some(i))
+                .collect()
+        };
+        // A flip moves the conformance-window padding, so every live slot is laid out again.
         if self.window.is_some() {
-            self.apply_rect();
+            for slot in live {
+                self.apply_rect(slot);
+            }
         }
     }
 

--- a/src-tauri/src/video/mod.rs
+++ b/src-tauri/src/video/mod.rs
@@ -21,6 +21,9 @@ pub mod rtsp_native;
 pub mod surface;
 /// Windows H264/HEVC decode + render sink for the hole-punch surface (MOBILE_RTSP.md P2.1).
 #[cfg(target_os = "windows")]
+pub mod win_aspect;
+
+#[cfg(target_os = "windows")]
 pub mod win_sink;
 /// Android H264/HEVC MediaCodec sink for the same hole-punch surface (MOBILE_RTSP.md P2.2).
 #[cfg(target_os = "android")]

--- a/src-tauri/src/video/mod.rs
+++ b/src-tauri/src/video/mod.rs
@@ -27,6 +27,9 @@ pub mod win_sink;
 pub mod android_sink;
 /// Linux GTK host for the hole-punch surface below the WebKitWebView (MOBILE_RTSP.md P2.3).
 #[cfg(target_os = "linux")]
+pub mod linux_drag;
+
+#[cfg(target_os = "linux")]
 pub mod linux_host;
 /// Linux GStreamer H264/HEVC sink into that host (MOBILE_RTSP.md P2.3).
 #[cfg(target_os = "linux")]

--- a/src-tauri/src/video/win_aspect.rs
+++ b/src-tauri/src/video/win_aspect.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+
+//! Aspect-locked interactive resize for the detached video window (Windows).
+//!
+//! The page alone can only correct the window AFTER a drag: inside the OS's modal resize loop every
+//! `setSize` is overwritten by the next mouse move, which is why the frame used to snap into shape
+//! the moment the pointer stopped. Windows asks the window itself instead — `WM_SIZING` carries the
+//! rectangle the user is dragging out, and whatever the window writes back is what the drag shows.
+//! So the window is subclassed and the rectangle is bent there, live.
+//!
+//! The page still snaps when the drag settles (`DetachedVideoFrame`): that stays the authority for
+//! the exact size, and with this in place it has nothing left to correct.
+
+use std::sync::atomic::{AtomicIsize, Ordering};
+use std::sync::Mutex;
+
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM};
+use windows::Win32::UI::WindowsAndMessaging::{
+    CallWindowProcW, DefWindowProcW, SetWindowLongPtrW, GWLP_WNDPROC, WMSZ_BOTTOM, WMSZ_BOTTOMLEFT,
+    WMSZ_LEFT, WMSZ_RIGHT, WMSZ_TOP, WMSZ_TOPLEFT, WMSZ_TOPRIGHT, WM_SIZING,
+};
+
+/// The picture's width/height and the chrome around it (physical px, the same on both axes).
+/// Aspect `0` = no lock, which is also the state while the window is fullscreen.
+static SHAPE: Mutex<(f64, f64)> = Mutex::new((0.0, 0.0));
+/// The window procedure this one replaced. `0` until a window is subclassed.
+static PREV: AtomicIsize = AtomicIsize::new(0);
+
+/// Smallest picture the lock will produce — below the window's own minimum size, so the minimum is
+/// still the one Tauri set.
+const MIN_PICTURE: f64 = 80.0;
+
+/// Take over the window's messages. Called once per detached window, right after it was created.
+pub fn install(hwnd: isize) {
+    let prev = unsafe { SetWindowLongPtrW(HWND(hwnd as *mut _), GWLP_WNDPROC, wndproc as *const () as usize as isize) };
+    // A window created before this one is gone by now; only the live handle's procedure is chained.
+    PREV.store(prev, Ordering::SeqCst);
+}
+
+/// The shape to hold. `aspect <= 0` releases the window (fullscreen).
+pub fn set_shape(aspect: f64, ring: f64) {
+    if let Ok(mut s) = SHAPE.lock() {
+        *s = (aspect, ring);
+    }
+}
+
+unsafe extern "system" fn wndproc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    let prev = PREV.load(Ordering::SeqCst);
+    let result = if prev == 0 {
+        DefWindowProcW(hwnd, msg, wparam, lparam)
+    } else {
+        // SAFETY: `prev` is the procedure Windows handed back when this one was installed.
+        let prev: unsafe extern "system" fn(HWND, u32, WPARAM, LPARAM) -> LRESULT =
+            std::mem::transmute(prev);
+        CallWindowProcW(Some(prev), hwnd, msg, wparam, lparam)
+    };
+    if msg != WM_SIZING || lparam.0 == 0 {
+        return result;
+    }
+    let (aspect, ring) = SHAPE.lock().map(|s| *s).unwrap_or((0.0, 0.0));
+    if aspect <= 0.0 {
+        return result;
+    }
+    // The rectangle the drag is proposing, in screen px — bent in place. The chain ran first, so
+    // whatever tao wants to say about the size is said before this.
+    let rect = &mut *(lparam.0 as *mut RECT);
+    let edge = wparam.0 as u32;
+    let w = f64::from(rect.right - rect.left) - ring;
+    let h = f64::from(rect.bottom - rect.top) - ring;
+    // The side being dragged leads. A corner drags both, and then the one that reaches further
+    // wins — the same rule the page applies when it snaps.
+    let picture = match edge {
+        WMSZ_TOP | WMSZ_BOTTOM => h * aspect,
+        WMSZ_LEFT | WMSZ_RIGHT => w,
+        _ => w.max(h * aspect),
+    }
+    .max(MIN_PICTURE);
+    let width = (picture + ring).round() as i32;
+    let height = (picture / aspect + ring).round() as i32;
+    // Grow away from the corner the drag is NOT holding.
+    match edge {
+        WMSZ_LEFT | WMSZ_TOPLEFT | WMSZ_BOTTOMLEFT => rect.left = rect.right - width,
+        _ => rect.right = rect.left + width,
+    }
+    match edge {
+        WMSZ_TOP | WMSZ_TOPLEFT | WMSZ_TOPRIGHT => rect.top = rect.bottom - height,
+        _ => rect.bottom = rect.top + height,
+    }
+    LRESULT(1)
+}

--- a/src/lib/components/video/DetachedVideoFrame.svelte
+++ b/src/lib/components/video/DetachedVideoFrame.svelte
@@ -57,6 +57,10 @@
   let fullscreen = $state(false);
   /** The windowed box (physical px) — kept across a fullscreen trip, which must not be saved as it. */
   let box = $state<{ x: number; y: number; w: number; h: number } | null>(null);
+  /** The overlay controls and the resize corner — their rects go to the backend (`pushZones`). */
+  let closeEl = $state<HTMLElement | undefined>(undefined);
+  let fsEl = $state<HTMLElement | undefined>(undefined);
+  let gripEl = $state<HTMLElement | undefined>(undefined);
 
   const live = $derived(feed.status === 'live' && feed.nativeSink);
   const armed = $derived($activeNativeSurfaces.has('floating'));
@@ -71,6 +75,24 @@
   let snapTimer = 0;
   let reportTimer = 0;
 
+  /** Overlay chrome visible? Driven by pointer activity, not by CSS `:hover`: WebKitGTK does not
+   *  reliably deliver a leave event when the pointer leaves the window, so the buttons stayed on
+   *  screen for good (Marc, Linux, 2026-09-08). Movement shows them, [`CHROME_IDLE_MS`] of quiet or
+   *  losing focus hides them again — the way a video player behaves anyway. */
+  let chrome = $state(false);
+  let chromeTimer = 0;
+  const CHROME_IDLE_MS = 1800;
+
+  function wakeChrome(): void {
+    chrome = true;
+    clearTimeout(chromeTimer);
+    chromeTimer = window.setTimeout(() => (chrome = false), CHROME_IDLE_MS);
+  }
+  function sleepChrome(): void {
+    clearTimeout(chromeTimer);
+    chrome = false;
+  }
+
   // A saved box carries the aspect of whatever stream was running when it was saved, and the default
   // box ignores the ring — so the frame is fitted to the picture once the stream's aspect is known,
   // and again whenever it changes (a different source, a resolution switch).
@@ -79,6 +101,12 @@
     if (!aspect || fullscreen) return;
     clearTimeout(snapTimer);
     snapTimer = window.setTimeout(() => void snapAspect(), SNAP_IDLE_MS);
+  });
+
+  // Whenever the page's own hit areas change — the chrome coming and going, fullscreen swallowing
+  // them — the backend needs the new rects. A resize moves them too: see `onGeometryChanged`.
+  $effect(() => {
+    pushZones();
   });
 
   onMount(() => {
@@ -99,9 +127,14 @@
       .catch(() => {});
     void win.onResized(onGeometryChanged).then((u) => offs.push(u));
     void win.onMoved(onGeometryChanged).then((u) => offs.push(u));
+    // Focus gone = pointer gone, as far as the chrome is concerned.
+    void win.onFocusChanged(({ payload }) => {
+      if (!payload) sleepChrome();
+    }).then((u) => offs.push(u));
     return () => {
       clearTimeout(snapTimer);
       clearTimeout(reportTimer);
+      clearTimeout(chromeTimer);
       for (const u of offs) u();
       stopNativeSurfaceRouter();
       document.documentElement.classList.remove('detached-video');
@@ -109,6 +142,7 @@
   });
 
   function onGeometryChanged(): void {
+    pushZones();
     clearTimeout(snapTimer);
     clearTimeout(reportTimer);
     snapTimer = window.setTimeout(() => void snapAspect(), SNAP_IDLE_MS);
@@ -140,16 +174,25 @@
     try {
       const size = await win.innerSize();
       const ring = 2 * RING_PX * (await win.scaleFactor());
-      const target = Math.round((size.width - ring) / feed.aspect + ring);
-      if (Math.abs(target - size.height) > 2) {
-        await win.setSize(new PhysicalSize(size.width, Math.max(120, target)));
+      // BOTH axes drive the result — the grip is a corner, so a diagonal pull has to land where
+      // the pointer is. Always deriving the height from the width made the corner feel one-axis:
+      // pulling it down grew the window and the snap pulled it straight back (Marc, 2026-09-08).
+      // The picture keeps whichever side reaches FURTHER, so either direction leads and the other
+      // follows — and no memory of where the drag began is needed.
+      const pic = Math.max(size.width - ring, (size.height - ring) * feed.aspect);
+      const next = { w: Math.round(pic + ring), h: Math.round(pic / feed.aspect + ring) };
+      if (Math.abs(next.w - size.width) > 2 || Math.abs(next.h - size.height) > 2) {
+        await win.setSize(new PhysicalSize(Math.max(200, next.w), Math.max(120, next.h)));
       }
     } catch {
       /* the window is going away */
     }
   }
 
+  // Windows and macOS take their window gestures from here. On Linux these never fire: the GTK
+  // press handler has already claimed the press (see `pushZones` and video::linux_drag).
   function onBodyPointerDown(e: PointerEvent): void {
+    wakeChrome();
     if (e.button !== 0 || fullscreen) return;
     void win.startDragging();
   }
@@ -157,6 +200,28 @@
   function onGripPointerDown(e: PointerEvent): void {
     e.stopPropagation();
     void win.startResizeDragging('NorthEast');
+  }
+
+  /** Tell the backend which parts of the window the PAGE handles: its overlay buttons while they
+   *  are on screen, and the resize corner. Linux starts the move and the resize from the GTK press
+   *  handler — the only place the compositor accepts them from — and that handler cannot hit-test
+   *  the DOM, so it is told beforehand. A no-op on Windows and macOS. */
+  function pushZones(): void {
+    const rect = (el: HTMLElement | undefined): [number, number, number, number] | null => {
+      if (!el) return null;
+      const b = el.getBoundingClientRect();
+      return [b.x, b.y, b.width, b.height];
+    };
+    const held: [number, number, number, number][] = [];
+    if (chrome) {
+      for (const el of [closeEl, fsEl]) {
+        const r = rect(el);
+        if (r) held.push(r);
+      }
+    }
+    void invoke('video_detached_chrome', {
+      zones: { drag: !fullscreen, grip: rect(gripEl), chrome: held },
+    }).catch(() => {});
   }
 
   async function toggleFullscreen(): Promise<void> {
@@ -171,6 +236,18 @@
     if (box) void emitTo('main', 'video-detached-geometry', { ...box, fullscreen: next }).catch(() => {});
   }
 
+  /// Ask the app to take the picture back rather than closing this window ourselves. The main
+  /// window stops this window's video first and destroys it afterwards — the other way round the
+  /// renderer loses its widget mid-frame and the whole stream dies with it (Linux, 2026-09-08).
+  async function dockBack(): Promise<void> {
+    // Withdraw this window's surfaces FIRST, from here: the backend then stops this window's own
+    // pipeline while its widgets are still alive, on this command's worker thread — nothing in the
+    // main app waits for it. Only then ask to be taken back.
+    stopNativeSurfaceRouter();
+    await invoke('video_rtsp_native_sink_surfaces', { surfaces: [] }).catch(() => {});
+    void emitTo('main', 'video-detached-dock', {}).catch(() => void win.close());
+  }
+
   function onKey(e: KeyboardEvent): void {
     if (e.key === 'Escape' && fullscreen) void toggleFullscreen();
   }
@@ -178,7 +255,15 @@
 
 <svelte:window onkeydown={onKey} />
 
-<div class="dv-root" class:fs={fullscreen}>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="dv-root"
+  class:fs={fullscreen}
+  class:chrome
+  onpointermove={wakeChrome}
+  onpointerenter={wakeChrome}
+  onpointerleave={sleepChrome}
+>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="dv-body"
@@ -205,9 +290,10 @@
 
     <!-- Hover chrome (D5): invisible until the pointer is over the frame. -->
     <button
+      bind:this={closeEl}
       class="dv-btn dv-close"
       onpointerdown={(e) => e.stopPropagation()}
-      onclick={() => void win.close()}
+      onclick={() => void dockBack()}
       title={$t('video.detachedClose')}
       aria-label={$t('video.detachedClose')}
     >
@@ -219,6 +305,7 @@
       </svg>
     </button>
     <button
+      bind:this={fsEl}
       class="dv-btn dv-fs"
       onpointerdown={(e) => e.stopPropagation()}
       onclick={() => void toggleFullscreen()}
@@ -239,7 +326,12 @@
 
   {#if !fullscreen}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="dv-grip" onpointerdown={onGripPointerDown} title={$t('video.resizeWindow')}></div>
+    <div
+      bind:this={gripEl}
+      class="dv-grip"
+      onpointerdown={onGripPointerDown}
+      title={$t('video.resizeWindow')}
+    ></div>
   {/if}
 </div>
 
@@ -339,7 +431,7 @@
     transition: opacity 0.15s ease, background 0.2s;
     pointer-events: none;
   }
-  .dv-root:hover .dv-btn {
+  .dv-root.chrome .dv-btn {
     opacity: 1;
     pointer-events: auto;
   }
@@ -373,22 +465,35 @@
     bottom: 8px;
   }
 
-  /* Resize corner — the same L the in-app frame draws in its bezel, a shade lighter than the ring. */
+  /* Resize corner. The hit area is far bigger than the L it draws, and it sits INSIDE the window's
+     own few-pixel resize border: that border is a ONE-AXIS edge resize, handled natively before the
+     page ever sees the press, so a corner drawn on top of it grabbed a single axis whenever the
+     pointer missed the very corner pixel (Marc, 2026-09-08). The easy 44 px square is ours now,
+     both axes at once, and only the outer rim belongs to the window. */
   .dv-grip {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 44px;
+    height: 44px;
+    cursor: nesw-resize;
+    touch-action: none;
+  }
+  /* The visible L — the same corner the in-app floating frame draws (`.fw-grip`), a shade lighter
+     than the ring — in that square's own corner. */
+  .dv-grip::after {
+    content: '';
     position: absolute;
     top: 0;
     right: 0;
     width: 26px;
     height: 26px;
     box-sizing: border-box;
-    background: transparent;
     border-top: 4px solid #5e5e5e;
     border-right: 4px solid #5e5e5e;
     border-top-right-radius: 8px;
-    cursor: nesw-resize;
-    touch-action: none;
   }
-  .dv-grip:hover {
+  .dv-grip:hover::after {
     border-color: #727272;
   }
 </style>

--- a/src/lib/components/video/DetachedVideoFrame.svelte
+++ b/src/lib/components/video/DetachedVideoFrame.svelte
@@ -167,6 +167,27 @@
     void emitTo('main', 'video-detached-geometry', { ...box, fullscreen }).catch(() => {});
   }
 
+  /** Hand the backend the shape to hold while the user drags. The OS owns the resize loop, so a
+   *  live aspect lock can only live there (`video_detached_aspect`); this page keeps the last word
+   *  through [`snapAspect`], which now has next to nothing left to correct. Re-sent when the
+   *  stream's aspect changes, on the way in and out of fullscreen (0 releases the window), and
+   *  after every settle — the ring around the picture shifts the WINDOW's own ratio a little, and
+   *  by more the smaller it is. */
+  async function pushAspect(aspect: number): Promise<void> {
+    try {
+      const ring = 2 * RING_PX * (await win.scaleFactor());
+      await invoke('video_detached_aspect', { aspect, ring });
+    } catch {
+      /* the window is going away */
+    }
+  }
+
+  $effect(() => {
+    // Read both synchronously — an effect tracks nothing an await hides.
+    const aspect = fullscreen ? 0 : feed.aspect;
+    void pushAspect(aspect);
+  });
+
   /** Snap the height so the PICTURE (the box inside the ring) carries the stream's aspect exactly —
    *  the same inside-out sizing the in-app frame uses, so neither ever shows bars. */
   async function snapAspect(): Promise<void> {
@@ -184,6 +205,7 @@
       if (Math.abs(next.w - size.width) > 2 || Math.abs(next.h - size.height) > 2) {
         await win.setSize(new PhysicalSize(Math.max(200, next.w), Math.max(120, next.h)));
       }
+      void pushAspect(feed.aspect);
     } catch {
       /* the window is going away */
     }

--- a/src/lib/components/video/FloatingVideoWindow.svelte
+++ b/src/lib/components/video/FloatingVideoWindow.svelte
@@ -43,7 +43,7 @@
   } from '$lib/stores/video';
   import { canvasSink, mjpegSink } from '$lib/controllers/mjpegSink';
   import { detachVideo } from '$lib/controllers/detachedVideo';
-  import { isMacOS, isWindows } from '$lib/platform';
+  import { isMobile } from '$lib/platform';
   import { nativeSurface, activeNativeSurfaces } from '$lib/controllers/nativeVideo';
   import { doubleTap, mouseDoubleClick } from '$lib/helpers/doubleTap';
   import { beginFloatMove, startFloatMove, startFloatResize } from '$lib/helpers/floatWindowGestures';
@@ -68,9 +68,9 @@
   const live = $derived($videoState.status === 'live');
   /** The unplug button: take the picture out of the app into its own window (D3). Native decode
    *  sink only (D2) — the DOM paths render into THIS WebView and cannot be handed to another one.
-   *  Not on Linux: its GStreamer host still lives in the main window, so a second window has
-   *  nowhere to put the picture until it grows one (VIDEO_MULTISINK_WINDOW.md §4.2). */
-  const canDetach = $derived((isWindows || isMacOS) && live && $videoState.nativeSink);
+   *  Every desktop platform serves it now, each in its own way: a child window on Windows, a second
+   *  AppKit host on macOS, a second GStreamer pipeline on Linux. */
+  const canDetach = $derived(!isMobile && live && $videoState.nativeSink);
   /** Narrow derived, not a raw store read in the effect below (that would re-run it on every
    *  telemetry patch): detaching must skip the slide-out — see there. */
   const detached = $derived($videoState.undocked);
@@ -314,9 +314,9 @@
       </div>
     {/if}
 
-    <!-- Resize corner: the lighter top-right corner of the bezel (an L in the bezel itself; the hit
-         area extends over the picture's corner, transparent). Video mode only — with the map in the
-         frame its layer covers the chrome, so +page draws the same corner above the map. -->
+    <!-- Resize corner: the lighter L just inside the picture's top-right corner. Video mode only —
+         with the map in the frame its layer covers the chrome, so +page draws the same corner
+         above the map. -->
     {#if !mapHere}
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div class="fw-grip" onpointerdown={onGripPointerDown} title={$t('video.resizeWindow')}></div>
@@ -505,13 +505,14 @@
     padding: 0 10px;
   }
 
-  /* Resize corner — an L drawn IN the bezel (4 px = the bezel's border + padding), a shade lighter
-     than the glass, opaque, rounded with the frame's outer corner; the rest of the box is a
-     transparent, touch-sized hit area over the picture's corner. */
+  /* Resize corner — an L a shade lighter than the glass, set INSIDE the picture rather than drawn
+     into the bezel: it reads better there, and it is the same corner the detached window shows
+     (DetachedVideoFrame's `.dv-grip`). 7 px = the bezel's 4 px plus the 3 px inset both use. The
+     box is the hit area. */
   .fw-grip {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 7px;
+    right: 7px;
     width: 26px;
     height: 26px;
     z-index: 62;

--- a/src/lib/controllers/detachedVideo.ts
+++ b/src/lib/controllers/detachedVideo.ts
@@ -25,9 +25,11 @@
 //   main  → video : `video-detached-state`     { status, error, aspect, nativeSink, reconnect }
 //   video → main  : `video-detached-ready`     (mounted — send me the state)
 //                   `video-detached-geometry`  the box to remember (physical px)
-//                   `video-detached-closed`    emitted by the BACKEND on destroy (its own button,
-//                                              Alt+F4, or our close) — the picture docks back in
-//                                              unless we were the one closing it.
+//                   `video-detached-dock`      the viewer's dock button: take the picture back. The
+//                                              window is still ALIVE here — the reconciler closes it,
+//                                              which is what stops its video before the widgets die.
+//                   `video-detached-closed`    emitted by the BACKEND once the window is really gone
+//                                              (Alt+F4, or our own close).
 
 import { get } from 'svelte/store';
 import { invoke } from '@tauri-apps/api/core';
@@ -72,6 +74,7 @@ let lastPushed = '';
 export function startDetachedVideo(): void {
   if (unsubscribe) return;
   void listen(`video-detached-closed`, onClosed).then((u) => unlisteners.push(u));
+  void listen('video-detached-dock', onDockRequest).then((u) => unlisteners.push(u));
   void listen('video-detached-ready', () => pushState(get(videoState), true)).then((u) => unlisteners.push(u));
   void listen<DetachBox>('video-detached-geometry', (e) => setDetachBox(e.payload)).then((u) => unlisteners.push(u));
   unsubscribe = videoState.subscribe(reconcile);
@@ -144,6 +147,14 @@ async function closeWindow(): Promise<void> {
       reconcile(get(videoState));
     }, 2000);
   }
+}
+
+/** The viewer's dock button. The window is still there, so `windowOpen` stays true and the
+ *  reconciler does the closing — in the right order, which is the whole point (the window's own
+ *  video has to stop before GTK takes its widgets down). */
+function onDockRequest(): void {
+  setUndocked(false);
+  reconcile(get(videoState));
 }
 
 /** The window is gone. Ours → keep the wish (a restarted source detaches again); the user's → dock

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3369,12 +3369,12 @@
   {#if mapFloating && $videoState.status === 'live' && !phoneUi && $videoState.floating}
     <div class="miniframe-ctl" style={mapFrameStyle}>
       <button class="mf-corner mf-close" style="border-top-left-radius:{5 * uiScale}px;" onclick={() => setMapLocation('main')} title={$t('video.close')}>✕</button>
-      <!-- The window's resize corner, redrawn above the map at the OUTER frame's top-right corner
-           (this layer is unzoomed and sits at the inner box, hence the bezel/scale offsets). -->
+      <!-- The window's resize corner, redrawn above the map just inside the picture's top-right
+           corner (this layer is unzoomed and sits at the inner box, hence the scale offsets). -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="mf-corner mf-grip"
-        style="top:{-floatBezel * uiScale}px; right:{-floatBezel * uiScale}px; width:{26 * uiScale}px; height:{26 * uiScale}px; border-width:{floatBezel * uiScale}px; border-top-right-radius:{8 * uiScale}px;"
+        style="top:{3 * uiScale}px; right:{3 * uiScale}px; width:{26 * uiScale}px; height:{26 * uiScale}px; border-width:{floatBezel * uiScale}px; border-top-right-radius:{8 * uiScale}px;"
         onpointerdown={(e) => startFloatResize(e, { left: floatLeft, top: floatTop, width: floatW, height: floatH, vw: logicalW, vh: logicalH })}
         title={$t('video.resizeWindow')}
       ></div>


### PR DESCRIPTION
Closes the last two gaps D16 left in `active/VIDEO_MULTISINK_WINDOW.md`: Linux can now show the picture in two places at once **and** take it out into its own window. Verified by Marc on his Debian 13 laptop (GNOME/Wayland, VA-API, 720p60 HEVC).

## The second surface

The pipeline was one linear chain; it now has a `tee` behind `decodebin3` feeding two branches, both built up front — adding one to a running pipeline means re-negotiation, which the Pi's stateless decoder cannot conceal. An idle branch is stopped by its `valve` before the colour convert and the render, and the decode sits upstream of the tee, so a second surface in the same window never costs a second decode: **5–6 % of one core** for the widget-sized tile, released the moment it is hidden.

Only branch 0 renders through GL. Two `gtkglsink`s each bring their own GtkGLArea and therefore their own GL context, while a pipeline distributes a single one — the second has nothing to negotiate against and the stream dies with `not-negotiated (-4)` before the first frame. The second branch reads the frame back and draws on the CPU, and slot 0 always goes to the largest surface, so the readback serves the small tile. Two more traps on the way: `valve` in its default `drop-all` mode swallows the CAPS event as well (→ `forward-sticky-events`), and a sink that receives nothing holds the pipeline in preroll, freezing the live branch on its first frame (→ `async=false`).

## The detached window

One pipeline **per window**, one slot, fed the same access units from the one RTSP connection: a slot's widget cannot migrate between windows, and two GL sinks can share a context across two pipelines but not inside one. That means a second decode of the same stream — the trade macOS already makes per layer.

Its move and resize run in the **GTK button-press handler** (`video::linux_drag`), not through `startDragging()`. That reaches GTK from the IPC's idle callback with no event current, and GNOME/Wayland then honours a move only every second press — measured, with the page logging a `pointerdown` and the command an `Ok` for every attempt, while tauri's own in-event border resize never failed once. The page hands the handler its hit zones (overlay buttons while visible, resize corner) so it knows what to pass through; the outer 5 px rim stays tauri's.

## Fixes found in the runtime test

Three freezes were one bug: the bus watch thread could only be stopped **sink-wide**, so a single window's teardown hung in `join()` while holding the sink lock — a stream stop that logged nothing and left the popout frozen, the next start stuck at "Starting", and a frozen app on dock-back (the frozen process had its main thread in `futex_wait` instead of the GTK loop's poll). Each pipeline carries its own stop flag now, a pipeline on its way out logs its complaints instead of failing the stream, and a window's video layer is rebuilt when the window behind it changed — without that a reopened popout inherited the dead layer and GStreamer opened a bare "Gtk+ GL renderer" window of its own, which killed the stream when closed.

`Regression: introduced on this branch, never released.`

## Also in here — all platforms

- **The resize corner moved inside the window's own resize rim.** That rim is a one-axis edge resize handled natively, which is why the corner felt one-axis whenever the pointer missed its tip. It is a 44 px hit area now, and the aspect snap follows whichever axis was pulled further, so a corner drag always drives both. The in-app floating frame and its mini-frame copy over the map draw the same inset corner.
- **The window keeps the picture's shape while it is resized** (`video_detached_aspect`). It used to be free form and snapped into shape when the pointer stopped; the page cannot do better alone, because the OS owns the pointer during a drag and overwrites anything set inside that loop. So each platform is told the shape where its resize loop asks: a `WM_SIZING` subclass on Windows, GTK geometry hints on Linux, AppKit's `contentAspectRatio` on macOS. The settle snap stays the exact authority — with a pixel or two left to do, and the shape is re-sent after every settle because the fixed 5 px ring shifts the window's own ratio. Fullscreen releases the lock.

## Known limits

- **No always-on-top on Wayland** — the protocol gives a client no way to ask, and GNOME's default session is Wayland. The detached window takes its turn in the normal stacking order there; said plainly in the user docs.
- **In-window frame smoothness.** `ffplay` plays the same stream perfectly smoothly on the same machine through the same GL path; in Kite it is acceptable but not perfect, and worse the larger the window. Pacing, `sync` and the queue were verified sane, an X11 session changed nothing, and neither did the smoothing buffer — what is left is the compositing of the Kite window itself, not the pipeline. Unsolved, tracked in §9.6 of the plan.

## Checks

`npm run check` 0 errors · `cargo check` + `cargo test --no-run` clean on Windows and on the laptop, `cargo check` clean in the macOS VM.

Smoke-tested by Marc on **Linux** (drag, corner resize, dock/undock cycles, stream stop with the popout open, restart) and on **Windows** (the same plus the aspect lock). The Linux and macOS runs of the aspect lock are still to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
