### PR TITLE
ci: run the checks on maintenance branches and on PRs targeting them (1.0.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main, development]
+    branches: [master, main, development, 'release/**']
   pull_request:
-    branches: [master, main, development]
+    branches: [master, main, development, 'release/**']
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The CI triggers listed only `master` and `development`. `release/1.0.x` was cut from `v1.0.0` today for 1.0 patches, so a PR against it ran no checks even though the Contributing page asks for a green PR before review. Both triggers now include `release/**`.

Same change for `development` and `release/1.0.x`, one PR each, because a PR only runs the workflow its base branch carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)