### PR TITLE
fix(3d): constant per-frame cost for the live trail, no 2D work while 3D shows

### DIFF
--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -183,8 +183,16 @@
   function onZoomEnd() {
     const lat = followCurrent?.lat ?? 0;
     for (const mk of [uavMarker, playbackMarker]) mk?.setIcon(makeModelIcon(modelSizePx(lat)));
+    modelDrawnKey = ''; // new canvas → the cached "already drawn" state is stale
     applyFollowFrame();
   }
+
+  // The model is rasterised in software (uavTopDown.ts) — the one expensive step of a follow frame.
+  // It runs at the ATTITUDE DATA rate, not the display rate: the marker position and the map
+  // centre keep gliding every frame (cheap Leaflet calls), but the drawing only changes when the
+  // telemetry attitude changed, so the raster is skipped while the eased position catches up.
+  // Marc, 2026-09-08: no smoothing on the 2D model — a real update, a real redraw, nothing else.
+  let modelDrawnKey = '';
 
   const ARMING_FLAG_ARMED = 2;
   const MIN_TRAIL_DIST = 1; // meters — don't add trail point if moved less
@@ -1230,6 +1238,13 @@
   let activeColor = '#37a8db';
   let followRaf: number | null = null;
   let followLastT = 0;
+  // The 2D map stays mounted under the 3D view (the live track lives in its Leaflet layers). Its
+  // follow loop must NOT: every frame it software-rasterises the UAV model into the marker canvas
+  // and re-centres the hidden Leaflet map (tile requests included) — measured at 3–10 % of the main
+  // thread while 3D was on screen (Sony XQ-CT54, 2026-09-08). While 3D shows, targets are still
+  // recorded (turn rate, last position); the loop parks, and the switch back snaps to the newest
+  // target. The trail append is a separate path and keeps running — the track must never be lost.
+  let followParked = false;
   // True only while applyFollowFrame() drives a programmatic recenter. Leaflet fires `moveend`
   // SYNCHRONOUSLY inside setView, so saveMapState would otherwise persist the UAV-locked centre
   // 60×/s — writing the settings store from inside the render flush (→ effect_update_depth_exceeded)
@@ -1281,6 +1296,10 @@
     else if (turnArcShown && timeMs - turnArcLastActiveTs > TURN_HOLD_MS) turnArcShown = false;
 
     followTarget = { lat, lon, heading, pitch, roll, course, speed, turnRate: turnRateDegS };
+    if (mapViewMode === '3d') {
+      followParked = true;
+      return;
+    }
     if (!followCurrent) {
       followCurrent = { ...followTarget };
       applyFollowFrame();
@@ -1297,6 +1316,7 @@
 
   function followLoop(t: number) {
     if (!followTarget || !followCurrent) { followRaf = null; return; }
+    if (mapViewMode === '3d') { followRaf = null; followParked = true; return; }
     const dt = followLastT ? Math.min(120, t - followLastT) : 16;
     followLastT = t;
     const k = 1 - Math.exp(-dt / FOLLOW_TAU_MS); // framerate-normalized ease
@@ -1324,12 +1344,26 @@
 
   /** Apply the eased frame: move + redraw the active marker always, recenter (+rotate) the map
    *  only while following. */
+  /** 3D → 2D: resume from the newest target without gliding in from a minutes-old position. */
+  $effect(() => {
+    if (mapViewMode !== '2d' || !followParked) return;
+    followParked = false;
+    if (!followTarget) return;
+    followCurrent = { ...followTarget };
+    applyFollowFrame();
+  });
+
   function applyFollowFrame() {
     if (!map || !followCurrent) return;
     const ll: L.LatLngExpression = [followCurrent.lat, followCurrent.lon];
     if (activeFollowMarker) {
       activeFollowMarker.setLatLng(ll);
-      drawModel(activeFollowMarker, followCurrent.heading, followCurrent.pitch, followCurrent.roll, activeColor);
+      const t = followTarget ?? followCurrent;
+      const key = `${t.heading}|${t.pitch}|${t.roll}|${activeColor}|${activeFollowMarker === uavMarker}`;
+      if (key !== modelDrawnKey) {
+        modelDrawnKey = key;
+        drawModel(activeFollowMarker, t.heading, t.pitch, t.roll, activeColor);
+      }
     }
     redrawDirLines();
     // Don't fight an in-progress zoom animation (would snap mid-zoom).

--- a/src/lib/components/Map3D.svelte
+++ b/src/lib/components/Map3D.svelte
@@ -303,6 +303,14 @@
   let pendingTrailPos: Cesium.Cartesian3 | undefined;
   let pendingTrailColor = '';
   const MIN_TRAIL_DIST_3D = 1; // meters
+  /** Points per dynamic run before it is baked into a static segment. The growing run is a
+   *  CallbackProperty polyline, and Cesium rebuilds THAT geometry on every render — so its cost
+   *  is per frame × points. Unbounded, a long flight paid for its whole track every frame
+   *  (profiled on a Sony XQ-CT54, 2026-09-08: the polyline rebuild doubled in four minutes of
+   *  flight and the 3D view fell to ~15 fps). Baking every few hundred points keeps the
+   *  per-frame work constant; the static segments are batched by Cesium and cost nothing after
+   *  their one-off build. 256 points × 5 m spacing ≈ 1.3 km per segment. */
+  const TRAIL_CHUNK_POINTS = 256;
   // Pre-arm trail: a thin plain black, ground-clamped line of GPS movement while DISARMED (monitoring
   // only). Cleared on arm; the colored flight trail takes over.
   let preArmTrailEntity: Cesium.Entity | undefined;
@@ -3006,7 +3014,8 @@
     return new Cesium.ColorMaterialProperty(Cesium.Color.fromCssColorString(color).withAlpha(fpvAlpha(0.7)));
   }
 
-  /** Bake the current growing run into a static polyline (called on a colour change). */
+  /** Bake the current growing run into a static polyline (on a colour change, and every
+   *  TRAIL_CHUNK_POINTS — see there). */
   function finalizeActiveSegment() {
     if (!viewer || activeTrailPositions.length < 2) return;
     const seg = viewer.entities.add({
@@ -3015,6 +3024,7 @@
         width: 2,
         material: trailMaterial(trailCurrentColor3D),
         clampToGround: false,
+        arcType: Cesium.ArcType.NONE,
       },
     });
     trailSegments3D.push({ entity: seg, color: trailCurrentColor3D });
@@ -3054,6 +3064,13 @@
     trailCurrentColor3D = color;
     activeTrailPositions.push(pos);
 
+    // Bound the dynamic run: bake it and continue from its last point (same colour) — the same
+    // hand-over the colour change above does, so the line stays continuous.
+    if (activeTrailPositions.length >= TRAIL_CHUNK_POINTS) {
+      finalizeActiveSegment();
+      activeTrailPositions = [activeTrailPositions[activeTrailPositions.length - 1]];
+    }
+
     if (!activeTrailEntity) {
       activeTrailEntity = viewer.entities.add({
         polyline: {
@@ -3061,6 +3078,11 @@
           width: 2,
           material: trailMaterial(color),
           clampToGround: false,
+          // Straight segments between points that are metres apart. The default (GEODESIC)
+          // subdivides every segment into great-circle arcs — for the dynamic run that meant
+          // re-arcing the whole track on every render (PolylinePipeline.generateCartesianArc was
+          // the top growing frame in the profile), for nothing visible at this spacing.
+          arcType: Cesium.ArcType.NONE,
         },
       });
     }


### PR DESCRIPTION
## What this is

A general performance fix for the 3D view with a live link, **backported** from 1.1 development to the 1.0 maintenance line. The problem exists on every platform and in every 1.0 build: the per-frame cost of the 3D scene grows with the length of the flight, and the hidden 2D map keeps doing work while 3D is on screen. It became obvious during the 1.1 Android work because a phone has no headroom to hide it — 1.0 has no Android build, but the same work drags on weak desktop systems (iGPU laptops, the Pi), which is why it goes to 1.0 as well.

## Root causes and fixes

1. **Live trail re-tessellated every render.** The growing run of the trail is a `CallbackProperty` polyline, and with the default `GEODESIC` arc type Cesium re-subdivides the whole track on every frame — cost proportional to flight length, on every render. Now `ArcType.NONE` (points are metres apart) and the run is baked into a static segment every 256 points, reusing the hand-over the flight-mode colour change already does. Per-frame cost is constant from then on.
2. **Hidden 2D map kept working.** The 2D map stays mounted under the 3D view so its Leaflet layers keep the live track. Its follow loop kept rasterising the UAV model in software and re-centring the hidden map on every animation frame. The loop now parks while 3D shows and snaps to the newest target on the way back. The trail append is a separate path and is untouched — the track is never lost.
3. **2D model raster at data rate.** The marker position and the map centre keep gliding per frame; the model is only redrawn when the telemetry heading/pitch/roll actually changed.

## Measurement

Profiled on the WebView renderer main thread (the bottleneck; the GPU sat at 30–45 %), same simulator (`tools/ltm_sim.py`, 10 Hz, 24 m/s), same steps, chase camera, sampled at 2 / 5 / 8 minutes of trail — share of the main thread:

| Trail | Build | Entity update | Arc generation | 2D follow + raster |
|---|---|---|---|---|
| 2 min | baseline | 3.4 | 2.2 | 1.9 |
| 8 min | baseline | 13.1 | 9.5 | 1.9 |
| 2 min | fix | 2.1 | 0.0 | 0.0 |
| 8 min | fix | 2.1 | 0.0 | 0.0 |

The baseline's trail work was still climbing at minute 8; on a 26-minute flight it dominated the frame. Verified by hand: 3D smooth and responsive with a live link, High-Res 3D included; only tile/terrain loads still hitch during camera pans.

Affects: v1.0.0 and earlier
