### PR TITLE
fix: INAV HDOP field offset, Fly Here radius field, saved Telemetry protocol restore

### DIFF
--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -108,6 +108,22 @@ below. The release you are reading the docs for is expanded; click an older vers
       and after any packet loss the video pauses until the next keyframe instead of freezing the
       Pi's hardware decoder. Kernel-side report: raspberrypi/linux#7609. [#112]
 
+??? note "1.0.1 — patch release"
+
+    **Fixed**
+
+    - **HDOP on INAV showed the wrong figure.** The GPS tile read the position-error field instead
+      of HDOP, because the first field of INAV's GPS statistics message is 16 bits and Kite decoded
+      it as 32. The recorder stored the same two values one field out. [#PRNUM]
+    - **"Fly Here" opened with an empty radius field** on fixed wing, which reads as "no radius"
+      while the vehicle would in fact use its configured one. It now starts at the aircraft's own
+      loiter radius, and an explicit value from this session still wins. [#PRNUM]
+    - **The radius stepper was clipped** by the edge of the "Fly Here" popup, so its "+" button
+      could not be reached. [#PRNUM]
+    - **A saved Telemetry connection came back as MSP.** Restoring the last-used protocol mapped
+      everything that was not MAVLink onto MSP, so the passive Telemetry choice was silently
+      rewritten. [#PRNUM]
+
 ??? note "1.0.0 — Initial release"
 
     The first stable release of **Kite Ground Control**: a cross-platform ground station for

--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -114,15 +114,16 @@ below. The release you are reading the docs for is expanded; click an older vers
 
     - **HDOP on INAV showed the wrong figure.** The GPS tile read the position-error field instead
       of HDOP, because the first field of INAV's GPS statistics message is 16 bits and Kite decoded
-      it as 32. The recorder stored the same two values one field out. [#PRNUM]
+      it as 32. The recorder stored the same two values one field out. [#143]
     - **"Fly Here" opened with an empty radius field** on fixed wing, which reads as "no radius"
-      while the vehicle would in fact use its configured one. It now starts at the aircraft's own
-      loiter radius, and an explicit value from this session still wins. [#PRNUM]
+      while the vehicle would in fact use its configured one. The field now shows the aircraft's own
+      loiter radius. Leave it alone and the aircraft keeps using that setting, turn direction
+      included; type a value and yours wins. [#143]
     - **The radius stepper was clipped** by the edge of the "Fly Here" popup, so its "+" button
-      could not be reached. [#PRNUM]
+      could not be reached. [#143]
     - **A saved Telemetry connection came back as MSP.** Restoring the last-used protocol mapped
       everything that was not MAVLink onto MSP, so the passive Telemetry choice was silently
-      rewritten. [#PRNUM]
+      rewritten. [#143]
 
 ??? note "1.0.0 — Initial release"
 
@@ -152,3 +153,4 @@ below. The release you are reading the docs for is expanded; click an older vers
 [#105]: https://github.com/b14ckyy/Kite-GC/pull/105
 [#111]: https://github.com/b14ckyy/Kite-GC/pull/111
 [#112]: https://github.com/b14ckyy/Kite-GC/pull/112
+[#143]: https://github.com/b14ckyy/Kite-GC/pull/143

--- a/src-tauri/src/scheduler/telemetry.rs
+++ b/src-tauri/src/scheduler/telemetry.rs
@@ -606,7 +606,7 @@ fn decode_gps_statistics(payload: &[u8]) -> TelemetryPayload {
     // eph (16–17) / epv (18–19) ride along in the same message — captured for the recorder.
     let eph = if payload.len() >= 18 { Some(read_u16(payload, 16) as f64) } else { None };
     let epv = if payload.len() >= 20 { Some(read_u16(payload, 18) as f64) } else { None };
-    eprintln!("[GPS-STATS] hdop_raw={} hdop={:.2} eph={:?} epv={:?}", hdop_raw, hdop, eph, epv);
+    log::debug!("[GPS-STATS] hdop_raw={} hdop={:.2} eph={:?} epv={:?}", hdop_raw, hdop, eph, epv);
     TelemetryPayload::GpsStats(GpsStatsData { hdop, eph, epv })
 }
 

--- a/src-tauri/src/scheduler/telemetry.rs
+++ b/src-tauri/src/scheduler/telemetry.rs
@@ -593,15 +593,19 @@ fn decode_misc2(payload: &[u8]) -> TelemetryPayload {
     })
 }
 
-/// MSP_GPSSTATISTICS (166): [lastDt:u32, errors:u32, timeouts:u32, packetCount:u32,
-///                            hdop:u16, eph:u16, epv:u16]
+/// MSP_GPSSTATISTICS (166): [lastMessageDt:u16, errors:u32, timeouts:u32, packetCount:u32,
+///                            hdop:u16, eph:u16, epv:u16, hwVersion:u8]
 /// HDOP is a raw u16, scaled * 100 by INAV (e.g. 100 = HDOP 1.00).
+///
+/// `lastMessageDt` is a **u16**, not a u32 (INAV `src/main/fc/fc_msp.c`, unchanged from 7.0 to
+/// master, which only appends `hwVersion`). Reading it as 32 bits shifted every later field by two
+/// bytes, so `eph` was reported as the HDOP.
 fn decode_gps_statistics(payload: &[u8]) -> TelemetryPayload {
-    let hdop_raw = read_u16(payload, 16); // bytes 16–17
+    let hdop_raw = read_u16(payload, 14); // bytes 14–15
     let hdop = hdop_raw as f64 / 100.0;
-    // eph (18–19) / epv (20–21) ride along in the same message — captured for the recorder.
-    let eph = if payload.len() >= 20 { Some(read_u16(payload, 18) as f64) } else { None };
-    let epv = if payload.len() >= 22 { Some(read_u16(payload, 20) as f64) } else { None };
+    // eph (16–17) / epv (18–19) ride along in the same message — captured for the recorder.
+    let eph = if payload.len() >= 18 { Some(read_u16(payload, 16) as f64) } else { None };
+    let epv = if payload.len() >= 20 { Some(read_u16(payload, 18) as f64) } else { None };
     eprintln!("[GPS-STATS] hdop_raw={} hdop={:.2} eph={:?} epv={:?}", hdop_raw, hdop, eph, epv);
     TelemetryPayload::GpsStats(GpsStatsData { hdop, eph, epv })
 }

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -1185,7 +1185,10 @@
       },
     });
 
-    guidedPopup = L.popup({ maxWidth: 240, closeOnClick: false, className: "guided-popup-wrap" })
+    // 240 was too narrow for the two-field (alt + loiter radius) fixed-wing form: each
+    // NumberStepper is a fixed ~132 px (24 px button + 74 px input + padding + 24 px button), so the
+    // pair plus their gap needs ~274 px and the second field's "+" was clipped by the popup edge.
+    guidedPopup = L.popup({ maxWidth: 300, closeOnClick: false, className: "guided-popup-wrap" })
       .setLatLng(e.latlng)
       .setContent(el)
       .openOn(map);

--- a/src/lib/components/control/GuidedTargetForm.svelte
+++ b/src/lib/components/control/GuidedTargetForm.svelte
@@ -9,7 +9,7 @@
   // `guidedParams` store so the last values persist for the next click. See VEHICLE_CONTROL.md.
   import { t } from 'svelte-i18n';
   import NumberStepper from '$lib/components/NumberStepper.svelte';
-  import { guidedParams, type GuidedParams } from '$lib/controllers/vehicleControl';
+  import { guidedParams, fcLoiterRadius, type GuidedParams } from '$lib/controllers/vehicleControl';
 
   let {
     lat,
@@ -26,7 +26,11 @@
 
   let alt = $state($guidedParams.alt);
   let yaw = $state<number>($guidedParams.yaw ?? NaN);
-  let radius = $state<number>($guidedParams.loiterRadius ?? NaN);
+  // Seed the radius from the FC's own default (WP_LOITER_RAD / NAV_LOITER_RAD, already read into
+  // `fcLoiterRadius` for the loiter ring) when this session has no explicit value yet. The field used
+  // to open blank, which reads as "no radius" while the vehicle will in fact use its configured one:
+  // showing that number is both the honest default and the one the aircraft is about to fly.
+  let radius = $state<number>($guidedParams.loiterRadius ?? $fcLoiterRadius ?? NaN);
 
   function fly() {
     const p: GuidedParams = {
@@ -67,6 +71,9 @@
   .gtf-fields {
     display: flex;
     gap: 10px;
+    /* Wrap rather than overflow: the steppers are fixed-width, so if the popup is ever narrower
+       than the pair needs, the second field drops to its own line instead of being clipped. */
+    flex-wrap: wrap;
   }
   .gtf-fly {
     width: 100%;

--- a/src/lib/components/control/GuidedTargetForm.svelte
+++ b/src/lib/components/control/GuidedTargetForm.svelte
@@ -30,14 +30,27 @@
   // `fcLoiterRadius` for the loiter ring) when this session has no explicit value yet. The field used
   // to open blank, which reads as "no radius" while the vehicle will in fact use its configured one:
   // showing that number is both the honest default and the one the aircraft is about to fly.
+  //
+  // The seed is a *display* value only, never sent. `fcLoiterRadius` holds the magnitude, but on
+  // ArduPilot the sign of WP_LOITER_RAD is the turn direction: with param3 = 0, `set_guided_WP`
+  // takes radius and direction from the parameter, while a positive param3 plus param4 = NaN makes
+  // `handle_command_int_do_reposition` clear `loiter_ccw` and force clockwise. Echoing the seed back
+  // would therefore reverse the turn on an aircraft configured counter-clockwise. So while the field
+  // still shows the untouched seed we send null and let the FC use its own value, sign included.
+  const seeded = $guidedParams.loiterRadius == null && $fcLoiterRadius != null;
   let radius = $state<number>($guidedParams.loiterRadius ?? $fcLoiterRadius ?? NaN);
 
   function fly() {
+    // Untouched seed: send nothing, and do not persist it as this session's explicit value either,
+    // or it would stick across a reconnect to an aircraft with a different radius.
+    const untouched = seeded && radius === $fcLoiterRadius;
     const p: GuidedParams = {
       alt,
       speed: $guidedParams.speed,
       yaw: multirotor ? (Number.isNaN(yaw) ? null : yaw) : $guidedParams.yaw,
-      loiterRadius: multirotor ? $guidedParams.loiterRadius : (Number.isNaN(radius) ? null : radius),
+      loiterRadius: multirotor
+        ? $guidedParams.loiterRadius
+        : (untouched || Number.isNaN(radius) ? null : radius),
     };
     guidedParams.set(p);
     onfly(lat, lon, p);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -734,7 +734,13 @@
   const saved = get(settings);
   selectedPort = saved.lastPort;
   selectedBaud = saved.lastBaud;
-  selectedProtocol = (saved.lastProtocol === 'mavlink' ? 'mavlink' : 'msp') as ProtocolType;
+  // Honour any protocol we actually support. The old form mapped everything that was not 'mavlink'
+  // onto 'msp', which silently rewrote a stored 'telemetry' choice: a user who last connected in
+  // passive Telemetry mode came back to MSP selected. MSP stays the fallback for an unrecognised or
+  // missing value, so a fresh install is unchanged.
+  selectedProtocol = (saved.lastProtocol === 'mavlink' || saved.lastProtocol === 'telemetry'
+    ? saved.lastProtocol
+    : 'msp') as ProtocolType;
   // Restore the full last-used connection path so nothing has to be re-entered.
   if (saved.lastTransport === 'serial' || saved.lastTransport === 'tcp' || saved.lastTransport === 'udp' || saved.lastTransport === 'ble') {
     selectedTransport = saved.lastTransport;


### PR DESCRIPTION
## Description

The three fixes from #131 that you accepted, rebased onto `release/1.0.x` as one patch PR.

**Affects: v1.0.0 and earlier.** None of these are regressions; all three are in the released build.

1. **HDOP read the wrong field.** `MSP_GPSSTATISTICS` starts with `lastMessageDt`, which INAV packs
   as a `uint16` (`src/main/fc/fc_msp.c`). Decoding it as 32 bits shifted every later field by two
   bytes, so the GPS tile showed `eph` as the HDOP, and `eph`/`epv` were off by two in the recorder.
   As you confirmed, the layout has not moved since before 7.0 and master only appends `hwVersion`,
   so there is no version gating.
2. **Fly Here opened with a blank, clipped radius field** on fixed wing. It now seeds from the FC's
   own `WP_LOITER_RAD`, already read into `fcLoiterRadius` for the loiter ring, and an explicit
   value from the session still wins. The popup went from 240 px to 300 px, because each
   NumberStepper is a fixed ~132 px and the alt + radius pair needs ~274 px, so the radius "+" was
   cut off by the popup edge.
3. **A saved Telemetry protocol came back as MSP.** The restore mapped everything that was not
   `mavlink` onto `msp`, silently rewriting a stored `telemetry` choice. MSP stays the fallback for
   an unrecognised or missing value, so a fresh install is unchanged.

Nothing else from #131 is here: the default-protocol change is dropped, and the per-protocol port
re-default waits for a 1.1 PR against `development` as you asked.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / Code health
- [x] Documentation
- [ ] Build / CI

## Checklist

- [x] `npm run check` passes
- [x] `cargo check` (in `src-tauri`) passes
- [x] I have tested the changes locally (dev + relevant build)
- [x] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes

## Notes for reviewer

Per your note, fix 3 is reworked for this tree: `ConnectionControls.svelte` does not exist on 1.0.x,
so the restore lives in `+page.svelte`. The transport/port toggle in `Toolbar.svelte` is untouched
and MSP is still the default everywhere.

Verification: `cargo check` clean, `npm run check` 559 files 0 errors 0 warnings, and the HDOP fix
re-checked against a simulated FC sending the firmware layout (hdop 1.10, eph 1.50): the tile read
1.5 before and reads 1.1 now.

Three things for you to decide rather than me:

1. **Changelog placement.** I added a `1.0.1 — patch release` section with the four paragraphs
   worded as fixes, below the `1.1.0 — in development` block that is still present on this branch.
   That 1.1 block looks like a leftover from the tag cut; removing it felt like your call, not
   something to slip into a patch PR.
2. **The `[#PRNUM]` placeholders** in those changelog entries. Tell me this PR number is fine to
   use and I will amend them to it, or say if you would rather they carry no reference on a patch
   branch.
3. **A stray debug print in the released build**: `src-tauri/src/scheduler/telemetry.rs` has an
   `eprintln!("[GPS-STATS] …")` that fires on every GPS statistics message. I left it alone to keep
   this to the three approved fixes; happy to drop it here or in its own PR, whichever you prefer.
