### PR TITLE
ci(docs): deploy "Dev" only from master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,9 @@
 #                    and moves "latest" onto it; older minors stay frozen on gh-pages as-is.
 #   docs-only fix  → lands on master (see contributing.md) and redeploys the current minor,
 #                    keeping the published release docs correct between releases.
+#   release branch → a workflow_dispatch on a release/x.y branch or tag redeploys THAT minor only.
+#                    "Dev" is always the master tip, so the Dev deploy is skipped on every other
+#                    ref (a dispatch there must not overwrite Dev with the patch line's docs).
 #
 # Local preview needs no CI: `mkdocs serve` (single version, see docs/requirements.txt) or
 # `mike serve` (the full versioned site from a local gh-pages branch).
@@ -67,6 +70,7 @@ jobs:
           # Release channel: the changelog hides "in development" sections (docs/hooks/changelog_channel.py).
           KITE_DOCS_CHANNEL: release
       - name: Deploy the development docs (Dev = master tip)
+        if: github.ref == 'refs/heads/master'
         run: mike deploy --push --title Dev dev
       - name: Point the site root at the latest release
         run: mike set-default --push latest


### PR DESCRIPTION
## Description

The docs workflow's `workflow_dispatch` on a release branch or tag is the documented way to redeploy a released minor's docs (on master the release deploy is skipped while `package.json` carries a pre-release suffix, so 1.0.x docs can only come from the release line). That dispatch also ran the **"Dev" deploy unconditionally**, so it would have overwritten the Dev version of the site with the 1.0.x tree. Dev is always the master tip: the step is now skipped on every ref other than `master`. Header comment updated to document the release-branch case.

Regression: introduced by the versioned-docs workflow (#86), never affected a user — the release-branch dispatch has not been used yet.

Forward-port to `development` / `master` with the next maintenance forward-port (the same line applies there; master additionally carries the pre-release guard from #122).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / Code health
- [ ] Documentation
- [x] Build / CI

## Checklist

- [x] `npm run check` passes (no code change)
- [x] `cargo check` passes (no code change)
- [x] No unrelated changes
