### PR TITLE
fix(flightlog): discard sweeps every leftover temp session, recovery settles the pile in one launch

### DIFF
--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -475,7 +475,7 @@ fn connect_msp(
             .and_then(|p| p.parent().map(|p| p.join(".portable").exists()))
             .unwrap_or(false);
 
-        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "MSP", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), msp_raw_sink.clone()) {
+        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "MSP", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), state.active_temp_path.clone(), msp_raw_sink.clone()) {
             Ok(mut rec) => {
                 rec.start_continuous_log();
                 let handle = std::sync::Arc::new(std::sync::Mutex::new(rec));
@@ -601,7 +601,7 @@ fn connect_mavlink(
 
         // MAVLink records via .tlog; the MSP raw sink is unused here (kept empty).
         let msp_raw_sink: MspRawSink = std::sync::Arc::new(std::sync::Mutex::new(None));
-        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "MAVLink", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), msp_raw_sink) {
+        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "MAVLink", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), state.active_temp_path.clone(), msp_raw_sink) {
             Ok(mut rec) => {
                 rec.start_continuous_log();
                 let handle = std::sync::Arc::new(std::sync::Mutex::new(rec));
@@ -680,7 +680,7 @@ fn connect_passive_telemetry(
             .and_then(|p| p.parent().map(|p| p.join(".portable").exists()))
             .unwrap_or(false);
         let msp_raw_sink: MspRawSink = std::sync::Arc::new(std::sync::Mutex::new(None));
-        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "Telemetry", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), msp_raw_sink) {
+        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "Telemetry", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), state.active_temp_path.clone(), msp_raw_sink) {
             Ok(mut rec) => {
                 rec.start_continuous_log();
                 log::info!("Flight recorder initialized (passive telemetry)");

--- a/src-tauri/src/commands/flightlog.rs
+++ b/src-tauri/src/commands/flightlog.rs
@@ -1168,7 +1168,15 @@ pub fn flightlog_discard_pending_session(
         .map_err(|_| "Pending-session lock poisoned".to_string())?
         .take();
     if let Some(session) = session {
+        let dir = session.temp_path.parent().map(|p| p.to_path_buf());
         crate::flightlog::recorder::discard_pending_session(session);
+        // Discard means "no temp log left": sweep any straggler from an earlier crash as well.
+        if let Some(dir) = dir {
+            let swept = db::sweep_temp_sessions(&dir, &protected_temp_paths(&state));
+            if swept > 0 {
+                log::info!("Discard: swept {} leftover temp session(s)", swept);
+            }
+        }
     }
     Ok(())
 }
@@ -1221,34 +1229,79 @@ fn sessions_dir(custom: &str) -> std::path::PathBuf {
         .join("sessions")
 }
 
-/// Scan `<db_dir>/sessions/*.ktmp` for an orphan session left by a crash/close. Empty temp files
-/// (no telemetry) are deleted in passing; the newest non-empty one is returned for the recovery
-/// prompt. There should be at most one (the single-temp invariant); a straggler is simply offered
-/// on a later launch.
+/// Temp sessions that belong to a live workflow in this process — the one the connected recorder is
+/// writing, the pending (awaiting Save/Discard) one and the continue-on-reconnect one. The orphan
+/// scan and the discard sweeps must never touch these.
+fn protected_temp_paths(state: &crate::state::AppState) -> Vec<std::path::PathBuf> {
+    let mut keep = Vec::new();
+    if let Ok(slot) = state.active_temp_path.lock() {
+        keep.extend(slot.clone());
+    }
+    for handle in [&state.pending_session, &state.resume_pending] {
+        if let Ok(slot) = handle.lock() {
+            keep.extend(slot.as_ref().map(|s| s.temp_path.clone()));
+        }
+    }
+    keep
+}
+
+/// An empty temp session younger than this is not a leftover: a previous instance of the app may
+/// still be shutting down and filling it (Windows keeps the process alive for a few seconds after
+/// the window closes, and a second instance can already be up by then).
+const EMPTY_TEMP_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Scan `<db_dir>/sessions/*.ktmp` for an orphan session left by a crash/close. Sessions that are
+/// live in this process (recording / pending / continue-on-reconnect) are skipped; stale empty temp
+/// files (no telemetry) are deleted in passing; the newest non-empty one is returned for the
+/// recovery prompt. The frontend scans again after Save / Continue, and Discard sweeps every
+/// leftover, so a pile of stragglers is settled in one launch instead of resurfacing one per start.
 #[tauri::command]
-pub fn flightlog_scan_orphan_sessions(db_path: Option<String>) -> Result<Option<OrphanInfo>, String> {
+pub fn flightlog_scan_orphan_sessions(
+    db_path: Option<String>,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<Option<OrphanInfo>, String> {
     let dir = sessions_dir(&db_path.unwrap_or_default());
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
         Err(_) => return Ok(None), // no sessions dir yet → nothing to recover
     };
+    let keep = protected_temp_paths(&state);
+    let mut candidates = 0usize;
     let mut best: Option<OrphanInfo> = None;
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("ktmp") {
+        if path.extension().and_then(|e| e.to_str()) != Some("ktmp") || keep.contains(&path) {
             continue;
         }
+        candidates += 1;
         let conn = match db::open_temp_session(&path) {
             Ok(c) => c,
             Err(e) => {
-                log::warn!("Orphan scan: cannot open {}: {}", path.display(), e);
+                log::warn!("Orphan scan: cannot open {}: {} — left alone", path.display(), e);
                 continue;
             }
         };
-        let count = db::temp_session_row_count(&conn).unwrap_or(0);
+        // A read failure is not "empty": never delete what could not be inspected.
+        let count = match db::temp_session_row_count(&conn) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("Orphan scan: cannot read {}: {} — left alone", path.display(), e);
+                continue;
+            }
+        };
         if count == 0 {
             drop(conn);
-            db::remove_temp_session(&path); // empty → worthless
+            let age = entry.metadata().and_then(|m| m.modified()).ok().and_then(|t| t.elapsed().ok());
+            match age {
+                Some(a) if a < EMPTY_TEMP_GRACE => log::info!(
+                    "Orphan scan: {} is empty but only {}s old — left alone (another instance may still be writing it)",
+                    path.display(), a.as_secs(),
+                ),
+                _ => {
+                    log::info!("Orphan scan: removing empty temp session {}", path.display());
+                    db::remove_temp_session(&path);
+                }
+            }
             continue;
         }
         let meta = db::read_session_meta(&conn).ok().flatten();
@@ -1272,13 +1325,34 @@ pub fn flightlog_scan_orphan_sessions(db_path: Option<String>) -> Result<Option<
             _ => Some(info),
         };
     }
+    match &best {
+        Some(b) => log::info!(
+            "Orphan scan: {} candidate(s) in {}, offering {} ({} samples)",
+            candidates, dir.display(), b.temp_path, b.sample_count,
+        ),
+        None => log::debug!("Orphan scan: nothing to recover in {}", dir.display()),
+    }
     Ok(best)
 }
 
-/// Recovery prompt → **Discard**: delete the orphan temp file; nothing reaches the main DB.
+/// Recovery prompt → **Discard**: delete the orphan temp file AND every other leftover in the
+/// sessions dir (live/pending/resume sessions excepted) — "discard" means no temp log remains,
+/// so a pile of stragglers cannot come back one per launch. Nothing reaches the main DB.
 #[tauri::command]
-pub fn flightlog_recover_discard(temp_path: String) -> Result<(), String> {
-    db::remove_temp_session(std::path::Path::new(&temp_path));
+pub fn flightlog_recover_discard(
+    temp_path: String,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<(), String> {
+    let path = std::path::PathBuf::from(&temp_path);
+    db::remove_temp_session(&path);
+    let swept = path
+        .parent()
+        .map(|dir| db::sweep_temp_sessions(dir, &protected_temp_paths(&state)))
+        .unwrap_or(0);
+    log::info!(
+        "Recovery: discarded {} and swept {} further leftover temp session(s)",
+        path.display(), swept,
+    );
     Ok(())
 }
 

--- a/src-tauri/src/flightlog/db.rs
+++ b/src-tauri/src/flightlog/db.rs
@@ -1135,6 +1135,29 @@ pub fn remove_temp_session(temp_path: &Path) {
     }
 }
 
+/// Delete every temp `.ktmp` session in `dir` except the ones in `keep` (the live, pending and
+/// continue-on-reconnect sessions). Enforces the single-temp invariant whenever the user discards:
+/// stragglers from earlier crashes must not resurface one per launch. Returns the number removed.
+pub fn sweep_temp_sessions(dir: &Path, keep: &[PathBuf]) -> usize {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("ktmp") || keep.contains(&path) {
+            continue;
+        }
+        log::info!("Sweeping leftover temp session {}", path.display());
+        remove_temp_session(&path);
+        if !path.exists() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
 /// List flight summaries ordered by start_time DESC.
 pub fn list_flights(conn: &Connection) -> SqlResult<Vec<FlightSummary>> {
     let mut stmt = conn.prepare(
@@ -2914,5 +2937,27 @@ mod tests {
 
         assert_eq!(blackbox_count, 1);
         assert_eq!(file_count, 1);
+    }
+
+    #[test]
+    fn sweep_temp_sessions_keeps_protected_and_removes_the_rest() {
+        let dir = std::env::temp_dir().join(format!("kite-sweep-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let live = dir.join("active_live.ktmp");
+        let old_a = dir.join("active_old_a.ktmp");
+        let old_b = dir.join("active_old_b.ktmp");
+        for p in [&live, &old_a, &old_b] {
+            drop(open_temp_session(p).unwrap());
+        }
+        std::fs::write(dir.join("notes.txt"), b"unrelated").unwrap();
+
+        let removed = sweep_temp_sessions(&dir, std::slice::from_ref(&live));
+
+        assert_eq!(removed, 2);
+        assert!(live.exists(), "the protected live session must survive the sweep");
+        assert!(!old_a.exists() && !old_b.exists(), "stragglers must be gone");
+        assert!(dir.join("notes.txt").exists(), "only .ktmp files are touched");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/flightlog/recorder.rs
+++ b/src-tauri/src/flightlog/recorder.rs
@@ -77,6 +77,10 @@ pub struct PendingSession {
 /// Shared, connection-independent slot for the one pending session (see `state::AppState`).
 pub type PendingSessionHandle = Arc<Mutex<Option<PendingSession>>>;
 
+/// Path of the temp `.ktmp` the recorder is writing right now, mirrored into app-state so the
+/// recovery scan and the discard sweeps never touch a live session (`None` while not recording).
+pub type ActiveTempPathHandle = Arc<Mutex<Option<PathBuf>>>;
+
 /// Commit a pending session into the main DB: insert the finalized flight, copy the temp
 /// `telemetry_records`, remove the temp file, and spawn weather/geocode enrichment. Returns the new
 /// flight id. Shared by the Save command and the recorder's grace-lapsed re-arm path.
@@ -378,6 +382,8 @@ pub struct FlightRecorder {
     /// A recovered session the user chose to continue on reconnect (ADR-042), consulted once on the
     /// first polled status of this connection (armed → resume; disarmed → finalize).
     resume: PendingSessionHandle,
+    /// Mirror of the active session's temp path for the command layer (see `ActiveTempPathHandle`).
+    active_path: ActiveTempPathHandle,
     /// Whether the first polled status has been seen on this connection (the trustworthy point to
     /// evaluate the continue-on-reconnect decision — past any handshake residual flags).
     first_status_seen: bool,
@@ -398,6 +404,7 @@ impl FlightRecorder {
         app_handle: AppHandle,
         pending: PendingSessionHandle,
         resume: PendingSessionHandle,
+        active_path: ActiveTempPathHandle,
         msp_raw_sink: MspRawSink,
     ) -> Result<Self, String> {
         let db_path = db::resolve_db_path(&settings.db_path, portable);
@@ -425,8 +432,17 @@ impl FlightRecorder {
             app_handle,
             pending,
             resume,
+            active_path,
             first_status_seen: false,
         })
+    }
+
+    /// Publish (or clear) the active session's temp path for the command layer.
+    fn publish_active_path(&self) {
+        let path = self.active_flight.as_ref().and_then(|f| f.temp_path.clone());
+        if let Ok(mut slot) = self.active_path.lock() {
+            *slot = path;
+        }
     }
 
     /// Update the protocol label (recorded in the flight metadata). Passive telemetry detects its
@@ -732,6 +748,7 @@ impl FlightRecorder {
             last_lon: None,
             start_mah: p.start_mah,
         });
+        self.publish_active_path();
         if let Err(e) = self.app_handle.emit("flight-recording-resumed", ()) {
             log::warn!("Failed to emit flight-recording-resumed: {}", e);
         }
@@ -820,6 +837,7 @@ impl FlightRecorder {
             last_lon: None,
             start_mah: self.snapshot.mah_drawn,
         });
+        self.publish_active_path();
 
         log::info!("Flight recording started (db={})", self.settings.db_enabled);
 
@@ -838,6 +856,7 @@ impl FlightRecorder {
     /// lifecycle event they then emit.
     fn take_active_as_pending(&mut self) -> Option<(PendingSession, i64)> {
         let mut flight = self.active_flight.take()?;
+        self.publish_active_path();
         let end_time = Utc::now();
         let duration = flight.start_instant.elapsed().as_secs() as i64;
         let last_timestamp_ms = flight.start_instant.elapsed().as_millis() as i64;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 use crate::aero::AeroCache;
-use crate::flightlog::recorder::PendingSessionHandle;
+use crate::flightlog::recorder::{ActiveTempPathHandle, PendingSessionHandle};
 use crate::mavlink_proto::MavlinkHandle;
 use crate::msp::FcInfo;
 use crate::passive_telemetry::PassiveHandle;
@@ -53,6 +53,9 @@ pub struct AppState {
     /// recorder consults it on its first polled status: armed → resume the same `.ktmp`; disarmed →
     /// finalize it into `pending_session` + the End-Flight dialog.
     pub resume_pending: PendingSessionHandle,
+    /// Temp `.ktmp` the connected recorder is writing right now (`None` while not recording). The
+    /// orphan scan and the discard sweeps leave it alone — it is a live session, not a leftover.
+    pub active_temp_path: ActiveTempPathHandle,
 }
 
 impl AppState {
@@ -70,6 +73,7 @@ impl AppState {
             aero: Mutex::new(None),
             pending_session: Arc::new(Mutex::new(None)),
             resume_pending: Arc::new(Mutex::new(None)),
+            active_temp_path: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2389,20 +2389,26 @@
     }
   }
 
-  // Startup recovery (ADR-042): if a crash/close left an orphan temp session, prompt for it.
+  // Startup recovery (ADR-042): if a crash/close left an orphan temp session, prompt for it. A pile
+  // of stragglers is settled in this one launch: Discard sweeps them all in the backend, and after
+  // Save / Continue the scan runs again (the handled session is excluded by then) until nothing is
+  // left — no more "one prompt per start" for the same pile. Bounded so a failing action cannot spin.
   async function runStartupRecovery(): Promise<void> {
     try {
-      const orphan = await scanOrphanSessions(flightLogDbPath);
-      if (!orphan) return;
-      const choice = await recoveryPrompt.show(orphan);
-      if (choice === 'discard') {
-        await recoverDiscard(orphan.temp_path);
-      } else if (choice === 'save') {
-        await recoverSaveIncomplete(orphan.temp_path, flightLogDbPath);
-        void loadLogbook();
-      } else if (choice === 'continue') {
-        await recoverContinue(orphan.temp_path, flightLogDbPath);
-        awaitingResumeReconnect = true; // resolved by the next connection's first poll
+      for (let round = 0; round < 10; round++) {
+        const orphan = await scanOrphanSessions(flightLogDbPath);
+        if (!orphan) return;
+        const choice = await recoveryPrompt.show(orphan);
+        if (choice === 'discard') {
+          await recoverDiscard(orphan.temp_path); // drops every leftover, not just this one
+          return;
+        } else if (choice === 'save') {
+          await recoverSaveIncomplete(orphan.temp_path, flightLogDbPath);
+          void loadLogbook();
+        } else if (choice === 'continue') {
+          await recoverContinue(orphan.temp_path, flightLogDbPath);
+          awaitingResumeReconnect = true; // resolved by the next connection's first poll
+        }
       }
     } catch (e) {
       console.warn('[recovery] startup recovery failed', e);


### PR DESCRIPTION
## Problem

The startup recovery scan offered only the **newest** orphan `.ktmp` per launch, and Discard removed just that one. A pile of leftover temp sessions therefore came back as "Incomplete recording found" **once per start** until the pile was exhausted — Marc saw it six launches in a row on the Sony (1.1-dev) and it is the same code in 1.0.

How a pile forms: the app is killed mid-recording without a disconnect — dev rebuilds (`npm run tauri dev` restarting the process), a backgrounded Android process killed by the OS, or the Windows case where the closed instance lingers a few seconds while a new one is already up. With continuous logging on, nobody ever clicks Discard/Continue on those, so they accumulate.

## Fix

- **Discard means no temp log remains.** The recovery prompt's Discard, the disconnect dialog's Discard and the End-Flight Discard all sweep the sessions dir afterwards. Sessions that are live in this process (recording / pending / continue-on-reconnect) are protected.
- The recorder mirrors its active temp path into app-state (`AppState::active_temp_path`) so neither the scan nor a sweep can touch a recording in progress — this also covers a surviving process whose webview reloads and re-runs the startup scan.
- The scan skips protected sessions, **runs again after Save / Continue** until nothing is left (bounded to 10 rounds), treats a read failure as "leave it alone" instead of "empty → delete", and leaves empty files younger than 60 s alone (the lingering-previous-instance case seen in today's Windows log: `os error 32` on a file the old process still had open).
- INFO log lines for the scan result, each recovery action and every sweep, so the Diagnostics log shows what happened next time.
- Unit test for the sweep helper (keeps the protected file, removes the rest, ignores non-`.ktmp` files).

Affects: v1.0.0 and earlier

## Verification

- `cargo check`, `cargo test --no-run`, `cargo test sweep_temp_sessions` (green), `npm run check` 0 errors.
- Manual (Marc, Windows dev build): staged three fake orphans with 40/120/75 samples → one prompt, one Discard → log shows `Recovery: discarded … and swept 2 further leftover temp session(s)`, sessions dir empty, next start clean.

Forward-port to `development` follows after merge (same as #140).
