### PR TITLE
docs(site): release banner, collapsible sidebar sections with indented pages (1.0)

### DIFF
--- a/docs/user/assets/branding/extra.css
+++ b/docs/user/assets/branding/extra.css
@@ -12,3 +12,28 @@
   --md-accent-fg-color:         #f5a623;
   --md-accent-fg-color--transparent: rgba(245, 166, 35, 0.1);
 }
+
+/* ── Sidebar navigation ─────────────────────────────────────────────────────────────────
+   Sections are collapsible (no navigation.sections); the JS in assets/nav.js keeps the first one
+   ("Getting started") open. Section labels read as headers, their pages are indented under a
+   thin guide line. Desktop sidebar only — the mobile drawer keeps Material's slide-in layout. */
+@media screen and (min-width: 76.25em) {
+  .md-nav--primary > .md-nav__list > .md-nav__item--nested > .md-nav__link {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--md-default-fg-color);
+    margin-top: 0.9em;
+  }
+  .md-nav--primary > .md-nav__list > .md-nav__item--nested > .md-nav__link:hover {
+    color: var(--md-accent-fg-color);
+  }
+  .md-nav--primary .md-nav__item--nested > .md-nav > .md-nav__list {
+    margin-left: 0.35rem;
+    padding-left: 0.85rem;
+    border-left: 1px solid var(--md-default-fg-color--lightest);
+  }
+  /* Nested sections (e.g. Guides → Logbook) stay at page size, just bold. */
+  .md-nav--primary .md-nav__item--nested .md-nav__item--nested > .md-nav__link {
+    font-weight: 700;
+  }
+}

--- a/docs/user/assets/nav.js
+++ b/docs/user/assets/nav.js
@@ -1,0 +1,12 @@
+// Sidebar: keep the first navigation section ("Getting started") expanded. Material has no
+// per-section default, so this checks the section's toggle after every page load — including
+// navigation.instant loads, which replace the sidebar (document$ fires for each).
+document$.subscribe(function () {
+  var toggle = document.querySelector(
+    ".md-nav--primary > .md-nav__list > .md-nav__item--nested > .md-nav__toggle"
+  );
+  if (toggle && !toggle.checked) {
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,6 @@ theme:
         name: Switch to dark mode
   features:
     - announce.dismiss
-    - navigation.sections
     - navigation.top
     - navigation.instant
     - navigation.tracking
@@ -58,6 +57,9 @@ hooks:
 
 extra_css:
   - assets/branding/extra.css
+
+extra_javascript:
+  - assets/nav.js # keeps the "Getting started" section expanded (see the file)
 
 extra:
   # Header version dropdown (Material's native mike support): reads the versions.json that mike

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 
-<!-- Public-beta announcement bar (dismissible via the announce.dismiss feature). -->
+<!-- Announcement bar. announce.dismiss (mkdocs.yml) hides it once the reader clicks the X and
+     remembers that in localStorage, keyed by a hash of this text — so it stays hidden across visits
+     and versions until the text changes. Change the text = show it once more to everyone. -->
 {% block announce %}
-  Kite Ground Control is in <strong>public beta</strong> — your
+  <strong>Kite Ground Control 1.0 is released.</strong> Your
   <a href="https://github.com/b14ckyy/Kite-GC/issues">feedback &amp; bug reports</a> are very welcome.
 {% endblock %}
 


### PR DESCRIPTION
Cherry-pick of a91d156 (master) onto the maintenance branch so the published **1.0 / latest** docs pick up the site changes. The "1.0" version is deployed from this branch via `workflow_dispatch` (master is `1.1.0-dev` and only deploys "Dev"), so the change has to land here to reach the released docs.

**What changes on the site**

- Header banner: "Kite Ground Control 1.0 is released" with the feedback link, replacing the public-beta text. Dismissing it is remembered per browser (`announce.dismiss` stores the banner's content hash in `localStorage`; a changed banner text shows it again).
- Left navigation: top-level sections are collapsible, "Getting started" is kept open (`docs/user/assets/nav.js`), section labels are larger and bolder, pages are indented under a rule so headers and entries are distinguishable.

No app code touched. `mkdocs build --strict` passes on this branch.

**After merge:** run the `docs` workflow via *Run workflow* on `release/1.0.x` to redeploy the 1.0 version (Dev is skipped for non-master refs by #144).
