### PR TITLE
Snapshot development → master (1.0.1 maintenance forward-port)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,9 @@
 #                    and moves "latest" onto it; older minors stay frozen on gh-pages as-is.
 #   docs-only fix  → lands on master (see contributing.md) and redeploys the current minor,
 #                    keeping the published release docs correct between releases.
+#   release branch → a workflow_dispatch on a release/x.y branch or tag redeploys THAT minor only.
+#                    "Dev" is always the master tip, so the Dev deploy is skipped on every other
+#                    ref (a dispatch there must not overwrite Dev with the patch line's docs).
 #
 # Local preview needs no CI: `mkdocs serve` (single version, see docs/requirements.txt) or
 # `mike serve` (the full versioned site from a local gh-pages branch).
@@ -67,6 +70,7 @@ jobs:
           # Release channel: the changelog hides "in development" sections (docs/hooks/changelog_channel.py).
           KITE_DOCS_CHANNEL: release
       - name: Deploy the development docs (Dev = master tip)
+        if: github.ref == 'refs/heads/master'
         run: mike deploy --push --title Dev dev
       - name: Point the site root at the latest release
         run: mike set-default --push latest

--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -108,6 +108,22 @@ below. The release you are reading the docs for is expanded; click an older vers
       and after any packet loss the video pauses until the next keyframe instead of freezing the
       Pi's hardware decoder. Kernel-side report: raspberrypi/linux#7609. [#112]
 
+??? note "1.0.1 — patch release"
+
+    **Fixed**
+
+    - **HDOP on INAV showed the wrong figure.** The GPS tile read the position-error field instead
+      of HDOP, because the first field of INAV's GPS statistics message is 16 bits and Kite decoded
+      it as 32. The recorder stored the same two values one field out. [#PRNUM]
+    - **"Fly Here" opened with an empty radius field** on fixed wing, which reads as "no radius"
+      while the vehicle would in fact use its configured one. It now starts at the aircraft's own
+      loiter radius, and an explicit value from this session still wins. [#PRNUM]
+    - **The radius stepper was clipped** by the edge of the "Fly Here" popup, so its "+" button
+      could not be reached. [#PRNUM]
+    - **A saved Telemetry connection came back as MSP.** Restoring the last-used protocol mapped
+      everything that was not MAVLink onto MSP, so the passive Telemetry choice was silently
+      rewritten. [#PRNUM]
+
 ??? note "1.0.0 — Initial release"
 
     The first stable release of **Kite Ground Control**: a cross-platform ground station for

--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -114,15 +114,16 @@ below. The release you are reading the docs for is expanded; click an older vers
 
     - **HDOP on INAV showed the wrong figure.** The GPS tile read the position-error field instead
       of HDOP, because the first field of INAV's GPS statistics message is 16 bits and Kite decoded
-      it as 32. The recorder stored the same two values one field out. [#PRNUM]
+      it as 32. The recorder stored the same two values one field out. [#143]
     - **"Fly Here" opened with an empty radius field** on fixed wing, which reads as "no radius"
-      while the vehicle would in fact use its configured one. It now starts at the aircraft's own
-      loiter radius, and an explicit value from this session still wins. [#PRNUM]
+      while the vehicle would in fact use its configured one. The field now shows the aircraft's own
+      loiter radius. Leave it alone and the aircraft keeps using that setting, turn direction
+      included; type a value and yours wins. [#143]
     - **The radius stepper was clipped** by the edge of the "Fly Here" popup, so its "+" button
-      could not be reached. [#PRNUM]
+      could not be reached. [#143]
     - **A saved Telemetry connection came back as MSP.** Restoring the last-used protocol mapped
       everything that was not MAVLink onto MSP, so the passive Telemetry choice was silently
-      rewritten. [#PRNUM]
+      rewritten. [#143]
 
 ??? note "1.0.0 — Initial release"
 
@@ -152,3 +153,4 @@ below. The release you are reading the docs for is expanded; click an older vers
 [#105]: https://github.com/b14ckyy/Kite-GC/pull/105
 [#111]: https://github.com/b14ckyy/Kite-GC/pull/111
 [#112]: https://github.com/b14ckyy/Kite-GC/pull/112
+[#143]: https://github.com/b14ckyy/Kite-GC/pull/143

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -475,7 +475,7 @@ fn connect_msp(
             .and_then(|p| p.parent().map(|p| p.join(".portable").exists()))
             .unwrap_or(false);
 
-        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "MSP", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), msp_raw_sink.clone()) {
+        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "MSP", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), state.active_temp_path.clone(), msp_raw_sink.clone()) {
             Ok(mut rec) => {
                 rec.start_continuous_log();
                 let handle = std::sync::Arc::new(std::sync::Mutex::new(rec));
@@ -601,7 +601,7 @@ fn connect_mavlink(
 
         // MAVLink records via .tlog; the MSP raw sink is unused here (kept empty).
         let msp_raw_sink: MspRawSink = std::sync::Arc::new(std::sync::Mutex::new(None));
-        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "MAVLink", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), msp_raw_sink) {
+        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "MAVLink", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), state.active_temp_path.clone(), msp_raw_sink) {
             Ok(mut rec) => {
                 rec.start_continuous_log();
                 let handle = std::sync::Arc::new(std::sync::Mutex::new(rec));
@@ -680,7 +680,7 @@ fn connect_passive_telemetry(
             .and_then(|p| p.parent().map(|p| p.join(".portable").exists()))
             .unwrap_or(false);
         let msp_raw_sink: MspRawSink = std::sync::Arc::new(std::sync::Mutex::new(None));
-        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "Telemetry", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), msp_raw_sink) {
+        match FlightRecorder::new(flight_log_settings, fc_info.clone(), "Telemetry", portable, app_handle.clone(), state.pending_session.clone(), state.resume_pending.clone(), state.active_temp_path.clone(), msp_raw_sink) {
             Ok(mut rec) => {
                 rec.start_continuous_log();
                 log::info!("Flight recorder initialized (passive telemetry)");

--- a/src-tauri/src/commands/flightlog.rs
+++ b/src-tauri/src/commands/flightlog.rs
@@ -1168,7 +1168,15 @@ pub fn flightlog_discard_pending_session(
         .map_err(|_| "Pending-session lock poisoned".to_string())?
         .take();
     if let Some(session) = session {
+        let dir = session.temp_path.parent().map(|p| p.to_path_buf());
         crate::flightlog::recorder::discard_pending_session(session);
+        // Discard means "no temp log left": sweep any straggler from an earlier crash as well.
+        if let Some(dir) = dir {
+            let swept = db::sweep_temp_sessions(&dir, &protected_temp_paths(&state));
+            if swept > 0 {
+                log::info!("Discard: swept {} leftover temp session(s)", swept);
+            }
+        }
     }
     Ok(())
 }
@@ -1221,34 +1229,79 @@ fn sessions_dir(custom: &str) -> std::path::PathBuf {
         .join("sessions")
 }
 
-/// Scan `<db_dir>/sessions/*.ktmp` for an orphan session left by a crash/close. Empty temp files
-/// (no telemetry) are deleted in passing; the newest non-empty one is returned for the recovery
-/// prompt. There should be at most one (the single-temp invariant); a straggler is simply offered
-/// on a later launch.
+/// Temp sessions that belong to a live workflow in this process — the one the connected recorder is
+/// writing, the pending (awaiting Save/Discard) one and the continue-on-reconnect one. The orphan
+/// scan and the discard sweeps must never touch these.
+fn protected_temp_paths(state: &crate::state::AppState) -> Vec<std::path::PathBuf> {
+    let mut keep = Vec::new();
+    if let Ok(slot) = state.active_temp_path.lock() {
+        keep.extend(slot.clone());
+    }
+    for handle in [&state.pending_session, &state.resume_pending] {
+        if let Ok(slot) = handle.lock() {
+            keep.extend(slot.as_ref().map(|s| s.temp_path.clone()));
+        }
+    }
+    keep
+}
+
+/// An empty temp session younger than this is not a leftover: a previous instance of the app may
+/// still be shutting down and filling it (Windows keeps the process alive for a few seconds after
+/// the window closes, and a second instance can already be up by then).
+const EMPTY_TEMP_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Scan `<db_dir>/sessions/*.ktmp` for an orphan session left by a crash/close. Sessions that are
+/// live in this process (recording / pending / continue-on-reconnect) are skipped; stale empty temp
+/// files (no telemetry) are deleted in passing; the newest non-empty one is returned for the
+/// recovery prompt. The frontend scans again after Save / Continue, and Discard sweeps every
+/// leftover, so a pile of stragglers is settled in one launch instead of resurfacing one per start.
 #[tauri::command]
-pub fn flightlog_scan_orphan_sessions(db_path: Option<String>) -> Result<Option<OrphanInfo>, String> {
+pub fn flightlog_scan_orphan_sessions(
+    db_path: Option<String>,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<Option<OrphanInfo>, String> {
     let dir = sessions_dir(&db_path.unwrap_or_default());
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
         Err(_) => return Ok(None), // no sessions dir yet → nothing to recover
     };
+    let keep = protected_temp_paths(&state);
+    let mut candidates = 0usize;
     let mut best: Option<OrphanInfo> = None;
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("ktmp") {
+        if path.extension().and_then(|e| e.to_str()) != Some("ktmp") || keep.contains(&path) {
             continue;
         }
+        candidates += 1;
         let conn = match db::open_temp_session(&path) {
             Ok(c) => c,
             Err(e) => {
-                log::warn!("Orphan scan: cannot open {}: {}", path.display(), e);
+                log::warn!("Orphan scan: cannot open {}: {} — left alone", path.display(), e);
                 continue;
             }
         };
-        let count = db::temp_session_row_count(&conn).unwrap_or(0);
+        // A read failure is not "empty": never delete what could not be inspected.
+        let count = match db::temp_session_row_count(&conn) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("Orphan scan: cannot read {}: {} — left alone", path.display(), e);
+                continue;
+            }
+        };
         if count == 0 {
             drop(conn);
-            db::remove_temp_session(&path); // empty → worthless
+            let age = entry.metadata().and_then(|m| m.modified()).ok().and_then(|t| t.elapsed().ok());
+            match age {
+                Some(a) if a < EMPTY_TEMP_GRACE => log::info!(
+                    "Orphan scan: {} is empty but only {}s old — left alone (another instance may still be writing it)",
+                    path.display(), a.as_secs(),
+                ),
+                _ => {
+                    log::info!("Orphan scan: removing empty temp session {}", path.display());
+                    db::remove_temp_session(&path);
+                }
+            }
             continue;
         }
         let meta = db::read_session_meta(&conn).ok().flatten();
@@ -1272,13 +1325,34 @@ pub fn flightlog_scan_orphan_sessions(db_path: Option<String>) -> Result<Option<
             _ => Some(info),
         };
     }
+    match &best {
+        Some(b) => log::info!(
+            "Orphan scan: {} candidate(s) in {}, offering {} ({} samples)",
+            candidates, dir.display(), b.temp_path, b.sample_count,
+        ),
+        None => log::debug!("Orphan scan: nothing to recover in {}", dir.display()),
+    }
     Ok(best)
 }
 
-/// Recovery prompt → **Discard**: delete the orphan temp file; nothing reaches the main DB.
+/// Recovery prompt → **Discard**: delete the orphan temp file AND every other leftover in the
+/// sessions dir (live/pending/resume sessions excepted) — "discard" means no temp log remains,
+/// so a pile of stragglers cannot come back one per launch. Nothing reaches the main DB.
 #[tauri::command]
-pub fn flightlog_recover_discard(temp_path: String) -> Result<(), String> {
-    db::remove_temp_session(std::path::Path::new(&temp_path));
+pub fn flightlog_recover_discard(
+    temp_path: String,
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<(), String> {
+    let path = std::path::PathBuf::from(&temp_path);
+    db::remove_temp_session(&path);
+    let swept = path
+        .parent()
+        .map(|dir| db::sweep_temp_sessions(dir, &protected_temp_paths(&state)))
+        .unwrap_or(0);
+    log::info!(
+        "Recovery: discarded {} and swept {} further leftover temp session(s)",
+        path.display(), swept,
+    );
     Ok(())
 }
 

--- a/src-tauri/src/flightlog/db.rs
+++ b/src-tauri/src/flightlog/db.rs
@@ -1135,6 +1135,29 @@ pub fn remove_temp_session(temp_path: &Path) {
     }
 }
 
+/// Delete every temp `.ktmp` session in `dir` except the ones in `keep` (the live, pending and
+/// continue-on-reconnect sessions). Enforces the single-temp invariant whenever the user discards:
+/// stragglers from earlier crashes must not resurface one per launch. Returns the number removed.
+pub fn sweep_temp_sessions(dir: &Path, keep: &[PathBuf]) -> usize {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("ktmp") || keep.contains(&path) {
+            continue;
+        }
+        log::info!("Sweeping leftover temp session {}", path.display());
+        remove_temp_session(&path);
+        if !path.exists() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
 /// List flight summaries ordered by start_time DESC.
 pub fn list_flights(conn: &Connection) -> SqlResult<Vec<FlightSummary>> {
     let mut stmt = conn.prepare(
@@ -2914,5 +2937,27 @@ mod tests {
 
         assert_eq!(blackbox_count, 1);
         assert_eq!(file_count, 1);
+    }
+
+    #[test]
+    fn sweep_temp_sessions_keeps_protected_and_removes_the_rest() {
+        let dir = std::env::temp_dir().join(format!("kite-sweep-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let live = dir.join("active_live.ktmp");
+        let old_a = dir.join("active_old_a.ktmp");
+        let old_b = dir.join("active_old_b.ktmp");
+        for p in [&live, &old_a, &old_b] {
+            drop(open_temp_session(p).unwrap());
+        }
+        std::fs::write(dir.join("notes.txt"), b"unrelated").unwrap();
+
+        let removed = sweep_temp_sessions(&dir, std::slice::from_ref(&live));
+
+        assert_eq!(removed, 2);
+        assert!(live.exists(), "the protected live session must survive the sweep");
+        assert!(!old_a.exists() && !old_b.exists(), "stragglers must be gone");
+        assert!(dir.join("notes.txt").exists(), "only .ktmp files are touched");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/flightlog/recorder.rs
+++ b/src-tauri/src/flightlog/recorder.rs
@@ -77,6 +77,10 @@ pub struct PendingSession {
 /// Shared, connection-independent slot for the one pending session (see `state::AppState`).
 pub type PendingSessionHandle = Arc<Mutex<Option<PendingSession>>>;
 
+/// Path of the temp `.ktmp` the recorder is writing right now, mirrored into app-state so the
+/// recovery scan and the discard sweeps never touch a live session (`None` while not recording).
+pub type ActiveTempPathHandle = Arc<Mutex<Option<PathBuf>>>;
+
 /// Commit a pending session into the main DB: insert the finalized flight, copy the temp
 /// `telemetry_records`, remove the temp file, and spawn weather/geocode enrichment. Returns the new
 /// flight id. Shared by the Save command and the recorder's grace-lapsed re-arm path.
@@ -378,6 +382,8 @@ pub struct FlightRecorder {
     /// A recovered session the user chose to continue on reconnect (ADR-042), consulted once on the
     /// first polled status of this connection (armed → resume; disarmed → finalize).
     resume: PendingSessionHandle,
+    /// Mirror of the active session's temp path for the command layer (see `ActiveTempPathHandle`).
+    active_path: ActiveTempPathHandle,
     /// Whether the first polled status has been seen on this connection (the trustworthy point to
     /// evaluate the continue-on-reconnect decision — past any handshake residual flags).
     first_status_seen: bool,
@@ -398,6 +404,7 @@ impl FlightRecorder {
         app_handle: AppHandle,
         pending: PendingSessionHandle,
         resume: PendingSessionHandle,
+        active_path: ActiveTempPathHandle,
         msp_raw_sink: MspRawSink,
     ) -> Result<Self, String> {
         let db_path = db::resolve_db_path(&settings.db_path, portable);
@@ -425,8 +432,17 @@ impl FlightRecorder {
             app_handle,
             pending,
             resume,
+            active_path,
             first_status_seen: false,
         })
+    }
+
+    /// Publish (or clear) the active session's temp path for the command layer.
+    fn publish_active_path(&self) {
+        let path = self.active_flight.as_ref().and_then(|f| f.temp_path.clone());
+        if let Ok(mut slot) = self.active_path.lock() {
+            *slot = path;
+        }
     }
 
     /// Update the protocol label (recorded in the flight metadata). Passive telemetry detects its
@@ -732,6 +748,7 @@ impl FlightRecorder {
             last_lon: None,
             start_mah: p.start_mah,
         });
+        self.publish_active_path();
         if let Err(e) = self.app_handle.emit("flight-recording-resumed", ()) {
             log::warn!("Failed to emit flight-recording-resumed: {}", e);
         }
@@ -820,6 +837,7 @@ impl FlightRecorder {
             last_lon: None,
             start_mah: self.snapshot.mah_drawn,
         });
+        self.publish_active_path();
 
         log::info!("Flight recording started (db={})", self.settings.db_enabled);
 
@@ -838,6 +856,7 @@ impl FlightRecorder {
     /// lifecycle event they then emit.
     fn take_active_as_pending(&mut self) -> Option<(PendingSession, i64)> {
         let mut flight = self.active_flight.take()?;
+        self.publish_active_path();
         let end_time = Utc::now();
         let duration = flight.start_instant.elapsed().as_secs() as i64;
         let last_timestamp_ms = flight.start_instant.elapsed().as_millis() as i64;

--- a/src-tauri/src/scheduler/telemetry.rs
+++ b/src-tauri/src/scheduler/telemetry.rs
@@ -606,7 +606,7 @@ fn decode_gps_statistics(payload: &[u8]) -> TelemetryPayload {
     // eph (16–17) / epv (18–19) ride along in the same message — captured for the recorder.
     let eph = if payload.len() >= 18 { Some(read_u16(payload, 16) as f64) } else { None };
     let epv = if payload.len() >= 20 { Some(read_u16(payload, 18) as f64) } else { None };
-    eprintln!("[GPS-STATS] hdop_raw={} hdop={:.2} eph={:?} epv={:?}", hdop_raw, hdop, eph, epv);
+    log::debug!("[GPS-STATS] hdop_raw={} hdop={:.2} eph={:?} epv={:?}", hdop_raw, hdop, eph, epv);
     TelemetryPayload::GpsStats(GpsStatsData { hdop, eph, epv })
 }
 

--- a/src-tauri/src/scheduler/telemetry.rs
+++ b/src-tauri/src/scheduler/telemetry.rs
@@ -593,15 +593,19 @@ fn decode_misc2(payload: &[u8]) -> TelemetryPayload {
     })
 }
 
-/// MSP_GPSSTATISTICS (166): [lastDt:u32, errors:u32, timeouts:u32, packetCount:u32,
-///                            hdop:u16, eph:u16, epv:u16]
+/// MSP_GPSSTATISTICS (166): [lastMessageDt:u16, errors:u32, timeouts:u32, packetCount:u32,
+///                            hdop:u16, eph:u16, epv:u16, hwVersion:u8]
 /// HDOP is a raw u16, scaled * 100 by INAV (e.g. 100 = HDOP 1.00).
+///
+/// `lastMessageDt` is a **u16**, not a u32 (INAV `src/main/fc/fc_msp.c`, unchanged from 7.0 to
+/// master, which only appends `hwVersion`). Reading it as 32 bits shifted every later field by two
+/// bytes, so `eph` was reported as the HDOP.
 fn decode_gps_statistics(payload: &[u8]) -> TelemetryPayload {
-    let hdop_raw = read_u16(payload, 16); // bytes 16–17
+    let hdop_raw = read_u16(payload, 14); // bytes 14–15
     let hdop = hdop_raw as f64 / 100.0;
-    // eph (18–19) / epv (20–21) ride along in the same message — captured for the recorder.
-    let eph = if payload.len() >= 20 { Some(read_u16(payload, 18) as f64) } else { None };
-    let epv = if payload.len() >= 22 { Some(read_u16(payload, 20) as f64) } else { None };
+    // eph (16–17) / epv (18–19) ride along in the same message — captured for the recorder.
+    let eph = if payload.len() >= 18 { Some(read_u16(payload, 16) as f64) } else { None };
+    let epv = if payload.len() >= 20 { Some(read_u16(payload, 18) as f64) } else { None };
     eprintln!("[GPS-STATS] hdop_raw={} hdop={:.2} eph={:?} epv={:?}", hdop_raw, hdop, eph, epv);
     TelemetryPayload::GpsStats(GpsStatsData { hdop, eph, epv })
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 use crate::aero::AeroCache;
-use crate::flightlog::recorder::PendingSessionHandle;
+use crate::flightlog::recorder::{ActiveTempPathHandle, PendingSessionHandle};
 use crate::mavlink_proto::MavlinkHandle;
 use crate::msp::FcInfo;
 use crate::passive_telemetry::PassiveHandle;
@@ -53,6 +53,9 @@ pub struct AppState {
     /// recorder consults it on its first polled status: armed → resume the same `.ktmp`; disarmed →
     /// finalize it into `pending_session` + the End-Flight dialog.
     pub resume_pending: PendingSessionHandle,
+    /// Temp `.ktmp` the connected recorder is writing right now (`None` while not recording). The
+    /// orphan scan and the discard sweeps leave it alone — it is a live session, not a leftover.
+    pub active_temp_path: ActiveTempPathHandle,
 }
 
 impl AppState {
@@ -70,6 +73,7 @@ impl AppState {
             aero: Mutex::new(None),
             pending_session: Arc::new(Mutex::new(None)),
             resume_pending: Arc::new(Mutex::new(None)),
+            active_temp_path: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -1185,7 +1185,10 @@
       },
     });
 
-    guidedPopup = L.popup({ maxWidth: 240, closeOnClick: false, className: "guided-popup-wrap" })
+    // 240 was too narrow for the two-field (alt + loiter radius) fixed-wing form: each
+    // NumberStepper is a fixed ~132 px (24 px button + 74 px input + padding + 24 px button), so the
+    // pair plus their gap needs ~274 px and the second field's "+" was clipped by the popup edge.
+    guidedPopup = L.popup({ maxWidth: 300, closeOnClick: false, className: "guided-popup-wrap" })
       .setLatLng(e.latlng)
       .setContent(el)
       .openOn(map);

--- a/src/lib/components/control/GuidedTargetForm.svelte
+++ b/src/lib/components/control/GuidedTargetForm.svelte
@@ -9,7 +9,7 @@
   // `guidedParams` store so the last values persist for the next click. See VEHICLE_CONTROL.md.
   import { t } from 'svelte-i18n';
   import NumberStepper from '$lib/components/NumberStepper.svelte';
-  import { guidedParams, type GuidedParams } from '$lib/controllers/vehicleControl';
+  import { guidedParams, fcLoiterRadius, type GuidedParams } from '$lib/controllers/vehicleControl';
 
   let {
     lat,
@@ -26,7 +26,11 @@
 
   let alt = $state($guidedParams.alt);
   let yaw = $state<number>($guidedParams.yaw ?? NaN);
-  let radius = $state<number>($guidedParams.loiterRadius ?? NaN);
+  // Seed the radius from the FC's own default (WP_LOITER_RAD / NAV_LOITER_RAD, already read into
+  // `fcLoiterRadius` for the loiter ring) when this session has no explicit value yet. The field used
+  // to open blank, which reads as "no radius" while the vehicle will in fact use its configured one:
+  // showing that number is both the honest default and the one the aircraft is about to fly.
+  let radius = $state<number>($guidedParams.loiterRadius ?? $fcLoiterRadius ?? NaN);
 
   function fly() {
     const p: GuidedParams = {
@@ -67,6 +71,9 @@
   .gtf-fields {
     display: flex;
     gap: 10px;
+    /* Wrap rather than overflow: the steppers are fixed-width, so if the popup is ever narrower
+       than the pair needs, the second field drops to its own line instead of being clipped. */
+    flex-wrap: wrap;
   }
   .gtf-fly {
     width: 100%;

--- a/src/lib/components/control/GuidedTargetForm.svelte
+++ b/src/lib/components/control/GuidedTargetForm.svelte
@@ -30,14 +30,27 @@
   // `fcLoiterRadius` for the loiter ring) when this session has no explicit value yet. The field used
   // to open blank, which reads as "no radius" while the vehicle will in fact use its configured one:
   // showing that number is both the honest default and the one the aircraft is about to fly.
+  //
+  // The seed is a *display* value only, never sent. `fcLoiterRadius` holds the magnitude, but on
+  // ArduPilot the sign of WP_LOITER_RAD is the turn direction: with param3 = 0, `set_guided_WP`
+  // takes radius and direction from the parameter, while a positive param3 plus param4 = NaN makes
+  // `handle_command_int_do_reposition` clear `loiter_ccw` and force clockwise. Echoing the seed back
+  // would therefore reverse the turn on an aircraft configured counter-clockwise. So while the field
+  // still shows the untouched seed we send null and let the FC use its own value, sign included.
+  const seeded = $guidedParams.loiterRadius == null && $fcLoiterRadius != null;
   let radius = $state<number>($guidedParams.loiterRadius ?? $fcLoiterRadius ?? NaN);
 
   function fly() {
+    // Untouched seed: send nothing, and do not persist it as this session's explicit value either,
+    // or it would stick across a reconnect to an aircraft with a different radius.
+    const untouched = seeded && radius === $fcLoiterRadius;
     const p: GuidedParams = {
       alt,
       speed: $guidedParams.speed,
       yaw: multirotor ? (Number.isNaN(yaw) ? null : yaw) : $guidedParams.yaw,
-      loiterRadius: multirotor ? $guidedParams.loiterRadius : (Number.isNaN(radius) ? null : radius),
+      loiterRadius: multirotor
+        ? $guidedParams.loiterRadius
+        : (untouched || Number.isNaN(radius) ? null : radius),
     };
     guidedParams.set(p);
     onfly(lat, lon, p);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2389,20 +2389,26 @@
     }
   }
 
-  // Startup recovery (ADR-042): if a crash/close left an orphan temp session, prompt for it.
+  // Startup recovery (ADR-042): if a crash/close left an orphan temp session, prompt for it. A pile
+  // of stragglers is settled in this one launch: Discard sweeps them all in the backend, and after
+  // Save / Continue the scan runs again (the handled session is excluded by then) until nothing is
+  // left — no more "one prompt per start" for the same pile. Bounded so a failing action cannot spin.
   async function runStartupRecovery(): Promise<void> {
     try {
-      const orphan = await scanOrphanSessions(flightLogDbPath);
-      if (!orphan) return;
-      const choice = await recoveryPrompt.show(orphan);
-      if (choice === 'discard') {
-        await recoverDiscard(orphan.temp_path);
-      } else if (choice === 'save') {
-        await recoverSaveIncomplete(orphan.temp_path, flightLogDbPath);
-        void loadLogbook();
-      } else if (choice === 'continue') {
-        await recoverContinue(orphan.temp_path, flightLogDbPath);
-        awaitingResumeReconnect = true; // resolved by the next connection's first poll
+      for (let round = 0; round < 10; round++) {
+        const orphan = await scanOrphanSessions(flightLogDbPath);
+        if (!orphan) return;
+        const choice = await recoveryPrompt.show(orphan);
+        if (choice === 'discard') {
+          await recoverDiscard(orphan.temp_path); // drops every leftover, not just this one
+          return;
+        } else if (choice === 'save') {
+          await recoverSaveIncomplete(orphan.temp_path, flightLogDbPath);
+          void loadLogbook();
+        } else if (choice === 'continue') {
+          await recoverContinue(orphan.temp_path, flightLogDbPath);
+          awaitingResumeReconnect = true; // resolved by the next connection's first poll
+        }
       }
     } catch (e) {
       console.warn('[recovery] startup recovery failed', e);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -734,7 +734,13 @@
   const saved = get(settings);
   selectedPort = saved.lastPort;
   selectedBaud = saved.lastBaud;
-  selectedProtocol = (saved.lastProtocol === 'mavlink' ? 'mavlink' : 'msp') as ProtocolType;
+  // Honour any protocol we actually support. The old form mapped everything that was not 'mavlink'
+  // onto 'msp', which silently rewrote a stored 'telemetry' choice: a user who last connected in
+  // passive Telemetry mode came back to MSP selected. MSP stays the fallback for an unrecognised or
+  // missing value, so a fresh install is unchanged.
+  selectedProtocol = (saved.lastProtocol === 'mavlink' || saved.lastProtocol === 'telemetry'
+    ? saved.lastProtocol
+    : 'msp') as ProtocolType;
   // Restore the full last-used connection path so nothing has to be re-entered.
   if (saved.lastTransport === 'serial' || saved.lastTransport === 'tcp' || saved.lastTransport === 'udp' || saved.lastTransport === 'ble') {
     selectedTransport = saved.lastTransport;


### PR DESCRIPTION
Snapshot of `development` onto `master` after the forward-port #147. `master` was already contained in `development`, so this is a pure superset merge with no conflicts.

**New on master with this snapshot** (all already released on `release/1.0.x` as 1.0.1 work)

- #143 — INAV HDOP field offset, "Fly Here" radius seed and popup width, saved Telemetry protocol restore
- #145 — Discard sweeps every leftover temp session; the recovery scan protects live sessions
- #144 — docs workflow: "Dev" is deployed only from master

No docs change on master beyond what #147 carried (the 1.0.1 changelog box from #143). The docs workflow will redeploy "Dev" from this merge.

Merge with a **merge commit** (not squash).
