### PR TITLE
docs: release-support page and 1.0.1 patch notes inside the 1.0 box (1.0 site)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,23 @@
   <a href="LICENSE"><img alt="License: GPL-3.0-or-later" src="https://img.shields.io/badge/License-GPLv3-blue.svg"></a>
   <a href="https://b14ckyy.github.io/Kite-GC/"><img alt="Documentation" src="https://img.shields.io/badge/docs-online-37a8db"></a>
   <img alt="Platform" src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-555">
-  <img alt="Status" src="https://img.shields.io/badge/status-release%20candidate-f5a623">
+  <a href="https://github.com/b14ckyy/Kite-GC/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/b14ckyy/Kite-GC?label=release&color=59aa29"></a>
   <a href="https://paypal.me/b14ckyy"><img alt="Donate via PayPal" src="https://img.shields.io/badge/Donate-PayPal-00457C?logo=paypal&logoColor=white"></a>
 </p>
 
 ---
-## Development State: 
+## Development state
 
-Kite is currently in **feature-freeze** for the 1.0 release, so which branch you target matters:
+**Kite 1.0 is released** — the first stable version, after a summer of betas and release candidates.
+Work on 1.1 (mobile, native video decode, and more) continues on the integration trunk:
 
-- **Bugfixes for 1.0** → pull request against **`master`**, the release line.
-- **New features or functional changes** → pull request against **`development`**, the integration
-  trunk. They are welcome there now, but will not reach `master` until after the final 1.0 release.
+- **All changes** → pull request against **`development`**, the always-current trunk. Features and
+  fixes alike land there and reach `master` as tested snapshots — so `master` builds are what you
+  install if you want to try the development state.
+- **A fix for the released 1.0** → pull request against **`release/1.0.x`**, the maintenance branch cut
+  from the `v1.0.0` tag. Patch releases are tagged from it, and it is merged forward into `development`.
+  1.0 stays maintained until 1.2.0 ships — see
+  **[Release support](https://b14ckyy.github.io/Kite-GC/release-support/)** for the policy.
 
 Nobody commits to either branch directly — see
 **[Contributing](https://b14ckyy.github.io/Kite-GC/for-developers/contributing/)** for the full
@@ -70,8 +75,8 @@ Everything you'd expect from a ground station:
 - **Mission planning** — create, upload, download and edit missions; undo/redo; a survey-pattern
   generator; terrain-following / AGL waypoints.
 - **Vehicle control** — arm/disarm, flight-mode changes, takeoff/RTL/loiter and more (ArduPilot/PX4).
-- **Comfort** — a multi-language interface (English, German, French at launch) with persistent window,
-  layout and settings between sessions.
+- **Comfort** — a multi-language interface (English, German, French, Bulgarian and Chinese) with persistent
+  window, layout and settings between sessions.
 
 ## What makes Kite special
 
@@ -103,8 +108,8 @@ Everything you'd expect from a ground station:
 - **Connections:** USB / serial, Bluetooth (SPP & BLE), TCP, UDP.
 - **Link modes:** live control link, **passive** listen-only telemetry, or a **relay** that
   re-broadcasts to other ground stations.
-- **Platforms:** Windows, macOS (universal, unsigned) and Linux (x86-64 / ARM64). Android and iOS are
-  in development for a release after 1.0.
+- **Platforms:** Windows, macOS (universal, signed and notarized) and Linux (x86-64 / ARM64).
+  Android and iOS / iPadOS are in development on `development` and target the 1.1 release.
 
 ## Download
 

--- a/docs/user/assets/branding/extra.css
+++ b/docs/user/assets/branding/extra.css
@@ -37,3 +37,24 @@
     font-weight: 700;
   }
 }
+
+/* Changelog: a patch release is a sub-segment inside its feature release's box. `.kite-patch` is
+   the patch version label, `.kite-badge` the status pill next to it ("in development" until the
+   patch ships, then replaced by the release date). Both are attr_list classes on inline text. */
+.kite-patch {
+  font-size: 1.15em;
+}
+.kite-badge {
+  display: inline-block;
+  margin-left: 0.35em;
+  padding: 0.05em 0.6em;
+  border-radius: 1em;
+  background: var(--md-accent-fg-color);
+  color: var(--md-accent-bg-color);
+  font-size: 0.68em;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  vertical-align: 0.15em;
+}

--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -7,7 +7,7 @@ Each version heading ends with the line's support status — **Live**, **Mainten
 defined on the [release support](release-support.md) page. Patch releases (1.0.1, 1.0.2, …) are listed
 inside the box of the feature release they belong to, so the notes for one release line stay together.
 
-???+ note "1.1.0 — in development"
+???+ note "1.1 — in development"
 
     **Highlights**
 
@@ -112,10 +112,29 @@ inside the box of the feature release they belong to, so the notes for one relea
       and after any packet loss the video pauses until the next keyframe instead of freezing the
       Pi's hardware decoder. Kernel-side report: raspberrypi/linux#7609. [#112]
 
-??? note "1.0.1 — patch release"
+??? note "1.0 — Initial release · Live"
+
+    The first stable release of **Kite Ground Control**: a cross-platform ground station for
+    **INAV**, **ArduPilot** and **PX4** — live telemetry over serial, Bluetooth and network links,
+    mission planning on 2D and 3D maps, safety subsystems (safe homes, geozones, geofence), a full
+    flight logbook with replay, FPV video, radar / airspace awareness and telemetry relaying.
+
+    Everything this version contains is covered by the regular documentation — start with the
+    [quick tour](getting-started/quick-tour.md) or the [GitHub release](https://github.com/b14ckyy/Kite-GC/releases).
+
+    ---
+
+    **1.0.1**{ .kite-patch } *in development*{ .kite-badge }
 
     **Fixed**
 
+    - **The 3D live view stuttered more the longer a flight went on.** The live trail was rebuilt
+      on every frame, so its cost grew with the length of the track, and the hidden 2D map kept
+      re-centring and drawing the aircraft underneath. Both now cost the same on every frame. [#140]
+    - **"Incomplete recording found" came back on every start.** When unfinished temp logs had piled
+      up (the app killed mid-recording, for example by the operating system), the prompt offered them
+      one per launch and Discard removed only that one. Discard now clears every leftover, and a
+      recording in progress is never touched. [#145]
     - **HDOP on INAV showed the wrong figure.** The GPS tile read the position-error field instead
       of HDOP, because the first field of INAV's GPS statistics message is 16 bits and Kite decoded
       it as 32. The recorder stored the same two values one field out. [#143]
@@ -128,16 +147,7 @@ inside the box of the feature release they belong to, so the notes for one relea
     - **A saved Telemetry connection came back as MSP.** Restoring the last-used protocol mapped
       everything that was not MAVLink onto MSP, so the passive Telemetry choice was silently
       rewritten. [#143]
-
-??? note "1.0.0 — Initial release · Live"
-
-    The first stable release of **Kite Ground Control**: a cross-platform ground station for
-    **INAV**, **ArduPilot** and **PX4** — live telemetry over serial, Bluetooth and network links,
-    mission planning on 2D and 3D maps, safety subsystems (safe homes, geozones, geofence), a full
-    flight logbook with replay, FPV video, radar / airspace awareness and telemetry relaying.
-
-    Everything this version contains is covered by the regular documentation — start with the
-    [quick tour](getting-started/quick-tour.md) or the [GitHub release](https://github.com/b14ckyy/Kite-GC/releases).
+    - **Bulgarian translation corrected** — 26 strings, contributed by teodoryantcheff. [#141]
 
 [#16]: https://github.com/b14ckyy/Kite-GC/pull/16
 [#48]: https://github.com/b14ckyy/Kite-GC/pull/48
@@ -157,4 +167,7 @@ inside the box of the feature release they belong to, so the notes for one relea
 [#105]: https://github.com/b14ckyy/Kite-GC/pull/105
 [#111]: https://github.com/b14ckyy/Kite-GC/pull/111
 [#112]: https://github.com/b14ckyy/Kite-GC/pull/112
+[#140]: https://github.com/b14ckyy/Kite-GC/pull/140
+[#141]: https://github.com/b14ckyy/Kite-GC/pull/141
 [#143]: https://github.com/b14ckyy/Kite-GC/pull/143
+[#145]: https://github.com/b14ckyy/Kite-GC/pull/145

--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -3,6 +3,10 @@
 What's new in each Kite Ground Control release — the big features up top, the full list of changes
 below. The release you are reading the docs for is expanded; click an older version to unfold it.
 
+Each version heading ends with the line's support status — **Live**, **Maintenance** or **EOL** — as
+defined on the [release support](release-support.md) page. Patch releases (1.0.1, 1.0.2, …) are listed
+inside the box of the feature release they belong to, so the notes for one release line stay together.
+
 ???+ note "1.1.0 — in development"
 
     **Highlights**
@@ -125,7 +129,7 @@ below. The release you are reading the docs for is expanded; click an older vers
       everything that was not MAVLink onto MSP, so the passive Telemetry choice was silently
       rewritten. [#143]
 
-??? note "1.0.0 — Initial release"
+??? note "1.0.0 — Initial release · Live"
 
     The first stable release of **Kite Ground Control**: a cross-platform ground station for
     **INAV**, **ArduPilot** and **PX4** — live telemetry over serial, Bluetooth and network links,

--- a/docs/user/for-developers/contributing.md
+++ b/docs/user/for-developers/contributing.md
@@ -37,6 +37,12 @@ repository, everyone else forks and opens the PR from the fork. The workflow is 
 afterwards, so nothing is lost. If a released version needs a patch after the trunk has moved on, the
 branch is cut from that version's **tag**, not from `master`.
 
+Maintenance branches are long-lived: a release line receives patches until the **second** feature
+release after it has shipped (1.0.x until 1.2.0 — see [Release support](../release-support.md)), and
+its branch stays open until then. Two lines are maintained side by side, so a bug that exists in both
+gets a fix on each maintenance branch. That is why the regression marker below matters: it tells us at
+a glance which lines a fix belongs to.
+
 **Documentation is the one exception.** A change to these pages that touches no code — a correction, a
 clarification, a missing note — targets `master` directly, because the published site must always
 describe the released app. Documentation *for a new or changed feature* is not covered by this: it

--- a/docs/user/release-support.md
+++ b/docs/user/release-support.md
@@ -1,0 +1,71 @@
+# Release support
+
+Kite Ground Control is used in places where a ground station simply has to work — so a released
+version does not stop receiving fixes the moment the next one appears. This page states what you can
+rely on.
+
+## Version numbers
+
+Kite uses `MAJOR.MINOR.PATCH`:
+
+| Kind | Example | What it brings |
+| --- | --- | --- |
+| **Feature release** | 1.1.0, 2.0.0 | New features and larger changes. A new *release line* starts here. |
+| **Patch release** | 1.0.1, 1.0.2 | Bug fixes for an existing release line — nothing else. |
+| **Pre-release** | 1.1.0-b1, 1.1.0-rc1 | Betas and release candidates on the way to a feature release. |
+
+## The support window
+
+**Every feature release keeps receiving patches until the *second* feature release after it has
+shipped.** A feature release is a minor or a major version — whichever comes next counts.
+
+For 1.0 this means:
+
+- 1.0.x receives patches while 1.1 is in development **and for the whole life of 1.1**.
+- Only when **1.2.0** ships (or 2.0.0, if that is the second release after 1.0) does 1.0.x reach its
+  end of life. From then on, fixes land in 1.1.x and 1.2.x.
+
+Two release lines are therefore maintained side by side at any time. A version you have proven in the
+field stays supported long enough for its successor to go through its own round of field testing and
+patching before you have to move.
+
+| Line | Status | Patches until |
+| --- | --- | --- |
+| **1.0.x** | Live | 1.2.0 (or 2.0.0) ships |
+| **1.1** | In development | — |
+
+### Status tags
+
+Each release line carries one of three tags — you will find it at the end of the version heading in
+the [changelog](changelog.md):
+
+| Tag | Meaning |
+| --- | --- |
+| **Live** | The current feature release. It receives patches. |
+| **Maintenance** | Superseded by a newer feature release, but still inside its support window — it receives patches. |
+| **EOL** | End of life. No further patches; move to a supported line. |
+
+Pre-releases are not covered by the support window: a beta or release candidate is replaced by the
+next pre-release or by the final version, never patched on its own.
+
+## What a patch release contains
+
+A patch release is the same version you already run, plus fixes:
+
+- **Bug fixes**, including compatibility fixes for new firmware or operating-system versions and
+  corrected translations.
+- **No new features.** Those go into the next feature release.
+- **No changes to your data** — file formats, the flight database and settings are read and written
+  exactly as before, so updating to a patch never converts anything.
+
+Every fix is recorded in the [changelog](changelog.md) inside the box of the feature release it
+belongs to, under its patch version, so the notes for a release line stay in one place.
+
+## Getting patch releases
+
+Patch releases are published on the [GitHub releases page](https://github.com/b14ckyy/Kite-GC/releases)
+like every other version. With **Check for updates** set to *Stable releases* in the settings, Kite
+tells you at start-up when a newer stable version exists (see [Settings](reference/settings.md)).
+
+Found a problem in a supported line? See [Reporting a problem](troubleshooting/reporting-issues.md) —
+please mention the version you run, so the fix reaches your release line.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
       - Reporting a problem: troubleshooting/reporting-issues.md
   - FAQ: faq.md
   - Changelog: changelog.md
+  - Release support: release-support.md
   - For developers:
       - Overview: for-developers/index.md
       - Architecture: for-developers/architecture.md


### PR DESCRIPTION
Cherry-pick of two master docs commits onto the maintenance branch so the published **1.0 / latest** docs carry the release-support policy and the restructured changelog.

- 6770f00 — **Release support** page (support window: patches until the second following feature release), nav entry, changelog intro explaining the status tags, contributing/README links.
- 852dbcb — **Changelog**: patch notes live inside the feature release's box. The 1.0.1 notes (#140, #141, #143, #145) sit at the end of the 1.0 box as a sub-segment with an "in development" badge; feature-release headings are `1.0` / `1.1` (only patch segments carry the third number). Badge CSS in `extra.css`.

Conflicts resolved: README takes the master wording (the branch had the pre-`release/1.0.x` text); the changelog link list keeps only the references this branch uses.

No app code touched. `mkdocs build --strict` passes; every `[#N]` reference on the page has a definition and none is unused.

**After merge:** run the `docs` workflow via *Run workflow* on `release/1.0.x` to redeploy the 1.0 version.
