### PR TITLE
fix(ios): keep libapp.a out of the app bundle

### DIFF
--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -57,16 +57,61 @@ rustup target add aarch64-apple-ios
 echo "[2/4] Installing npm dependencies..."
 npm install
 
-if [ ! -d "gen/apple" ] || [ "${FORCE_INIT:-0}" = "1" ]; then
+GEN_APPLE="src-tauri/gen/apple"
+
+# `tauri ios init` lists Externals/ as a plain source group, so XcodeGen puts it in BOTH "Link
+# Binary With Libraries" and "Copy Bundle Resources". The second one copies the Rust static library
+# into the app bundle, which App Store validation rejects outright:
+#
+#   Invalid bundle structure. The "Kite Ground Control.app/libapp.a" binary file is not permitted.
+#
+# It also carried the library's ~37 MB into the ipa for nothing. libapp.a is linked, never a
+# resource, so the group needs `buildPhase: none`. src-tauri/gen/apple is generated and gitignored,
+# so this cannot be fixed by committing the project file: it has to be re-applied on every build.
+patch_externals_build_phase() {
+    local yml="$GEN_APPLE/project.yml"
+    if [ ! -f "$yml" ]; then
+        echo "[ERROR] $yml not found. Run with FORCE_INIT=1 to regenerate the Xcode project."
+        exit 1
+    fi
+    # Already carries a buildPhase? Leave the file alone.
+    local has_phase='$0 ~ /^[[:space:]]*- path: Externals$/ { getline nxt; if (nxt ~ /^[[:space:]]*buildPhase:/) found = 1 } END { exit !found }'
+    if awk "$has_phase" "$yml"; then
+        echo "      Externals already excluded from Copy Bundle Resources."
+        return 0
+    fi
+    awk '
+        { print }
+        /^[[:space:]]*- path: Externals$/ {
+            match($0, /^[[:space:]]*/)
+            indent = substr($0, 1, RLENGTH)
+            print indent "  buildPhase: none"
+        }
+    ' "$yml" > "$yml.tmp"
+    # Never build on a silent miss: a template change in Tauri that renames or re-indents the group
+    # would otherwise put libapp.a back in the bundle and the rejection would only surface at upload.
+    if ! awk "$has_phase" "$yml.tmp"; then
+        rm -f "$yml.tmp"
+        echo "[ERROR] Could not exclude Externals from Copy Bundle Resources in $yml."
+        echo "        Add 'buildPhase: none' under the Externals source group by hand, or the ipa"
+        echo "        will contain libapp.a and App Store validation will reject it."
+        exit 1
+    fi
+    mv "$yml.tmp" "$yml"
+    echo "      Excluded Externals from Copy Bundle Resources (keeps libapp.a out of the app)."
+}
+
+if [ ! -d "$GEN_APPLE" ] || [ "${FORCE_INIT:-0}" = "1" ]; then
     echo "[3/4] Generating the Xcode project (tauri ios init)..."
     npm run tauri ios init
 else
-    echo "[3/4] gen/apple already present — skipping init (FORCE_INIT=1 to redo)."
+    echo "[3/4] $GEN_APPLE already present — skipping init (FORCE_INIT=1 to redo)."
 fi
+patch_externals_build_phase
 
 echo "[4/4] Building signed release .ipa with Tauri..."
 npm run tauri ios build
 
 echo ""
 echo "[build-ios] Done. Look for the .ipa under:"
-echo "  gen/apple/build/arm64/  (and the Xcode archive/export path Tauri prints above)"
+echo "  $GEN_APPLE/build/arm64/  (and the Xcode archive/export path Tauri prints above)"

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -57,57 +57,12 @@ rustup target add aarch64-apple-ios
 echo "[2/4] Installing npm dependencies..."
 npm install
 
-GEN_APPLE="src-tauri/gen/apple"
+# Xcode-project plumbing (project generation + the libapp.a bundle fix) is shared with
+# scripts/run-ipad.sh.
+source "$ROOT/scripts/lib/ios-project.sh"
 
-# `tauri ios init` lists Externals/ as a plain source group, so XcodeGen puts it in BOTH "Link
-# Binary With Libraries" and "Copy Bundle Resources". The second one copies the Rust static library
-# into the app bundle, which App Store validation rejects outright:
-#
-#   Invalid bundle structure. The "Kite Ground Control.app/libapp.a" binary file is not permitted.
-#
-# It also carried the library's ~37 MB into the ipa for nothing. libapp.a is linked, never a
-# resource, so the group needs `buildPhase: none`. src-tauri/gen/apple is generated and gitignored,
-# so this cannot be fixed by committing the project file: it has to be re-applied on every build.
-patch_externals_build_phase() {
-    local yml="$GEN_APPLE/project.yml"
-    if [ ! -f "$yml" ]; then
-        echo "[ERROR] $yml not found. Run with FORCE_INIT=1 to regenerate the Xcode project."
-        exit 1
-    fi
-    # Already carries a buildPhase? Leave the file alone.
-    local has_phase='$0 ~ /^[[:space:]]*- path: Externals$/ { getline nxt; if (nxt ~ /^[[:space:]]*buildPhase:/) found = 1 } END { exit !found }'
-    if awk "$has_phase" "$yml"; then
-        echo "      Externals already excluded from Copy Bundle Resources."
-        return 0
-    fi
-    awk '
-        { print }
-        /^[[:space:]]*- path: Externals$/ {
-            match($0, /^[[:space:]]*/)
-            indent = substr($0, 1, RLENGTH)
-            print indent "  buildPhase: none"
-        }
-    ' "$yml" > "$yml.tmp"
-    # Never build on a silent miss: a template change in Tauri that renames or re-indents the group
-    # would otherwise put libapp.a back in the bundle and the rejection would only surface at upload.
-    if ! awk "$has_phase" "$yml.tmp"; then
-        rm -f "$yml.tmp"
-        echo "[ERROR] Could not exclude Externals from Copy Bundle Resources in $yml."
-        echo "        Add 'buildPhase: none' under the Externals source group by hand, or the ipa"
-        echo "        will contain libapp.a and App Store validation will reject it."
-        exit 1
-    fi
-    mv "$yml.tmp" "$yml"
-    echo "      Excluded Externals from Copy Bundle Resources (keeps libapp.a out of the app)."
-}
-
-if [ ! -d "$GEN_APPLE" ] || [ "${FORCE_INIT:-0}" = "1" ]; then
-    echo "[3/4] Generating the Xcode project (tauri ios init)..."
-    npm run tauri ios init
-else
-    echo "[3/4] $GEN_APPLE already present — skipping init (FORCE_INIT=1 to redo)."
-fi
-patch_externals_build_phase
+echo "[3/4] Preparing the Xcode project..."
+ios_prepare_project
 
 echo "[4/4] Building signed release .ipa with Tauri..."
 npm run tauri ios build

--- a/scripts/lib/ios-project.sh
+++ b/scripts/lib/ios-project.sh
@@ -1,0 +1,111 @@
+# ============================================================
+# Shared iOS Xcode-project plumbing for scripts/build-ios.sh and
+# scripts/run-ipad.sh. Sourced, not executed; the caller has already
+# cd'd to the repository root.
+# ============================================================
+
+# src-tauri/gen/apple is generated and gitignored, so nothing in it can be
+# committed: every fix to the generated project has to be re-applied here.
+GEN_APPLE="src-tauri/gen/apple"
+
+# `tauri ios init` lists Externals/ as a plain source group. XcodeGen has no default build phase for
+# a `.a` and falls back to `resources` (SourceGenerator.getDefaultBuildPhase), so the Rust static
+# library is added to "Copy Bundle Resources" as well; the link itself comes from the target's
+# `dependencies: - framework: libapp.a`, not from the group. The copy puts the library inside the
+# app bundle, which App Store validation rejects:
+#
+#   Invalid bundle structure. The "Kite Ground Control.app/libapp.a" binary file is not permitted.
+#
+# It also carries the library into the ipa for nothing (56 MB before, 19 MB after), and once several
+# copies exist side by side (debug + release, device + simulator) Xcode fails outright with
+# "Multiple commands produce .../libapp.a".
+#
+# Upstream fixes this in tauri-apps/tauri#15890 by adding `excludes: ["**/*.a"]` to the group, which
+# is not in a released CLI yet (2.11.4 still ships the bare entry). This patch is compatible with
+# that template: it only adds `buildPhase`, leaving any `excludes` in place.
+IOS_YML_PATCHED=0
+
+# Does the Externals source group already carry a buildPhase?
+_ios_yml_has_build_phase() {
+    awk '$0 ~ /^[[:space:]]*- path: Externals$/ {
+             getline nxt
+             if (nxt ~ /^[[:space:]]*buildPhase:/) found = 1
+         }
+         END { exit !found }' "$1"
+}
+
+ios_patch_externals_build_phase() {
+    local yml="$GEN_APPLE/project.yml"
+    if [ ! -f "$yml" ]; then
+        echo "[ERROR] $yml not found. Run with FORCE_INIT=1 to regenerate the Xcode project."
+        exit 1
+    fi
+    if _ios_yml_has_build_phase "$yml"; then
+        echo "      Externals already excluded from Copy Bundle Resources."
+        return 0
+    fi
+    awk '
+        { print }
+        /^[[:space:]]*- path: Externals$/ {
+            match($0, /^[[:space:]]*/)
+            print substr($0, 1, RLENGTH) "  buildPhase: none"
+        }
+    ' "$yml" > "$yml.tmp"
+    # Never build on a silent miss: a template change in Tauri that renames or re-indents the group
+    # would otherwise put libapp.a back in the bundle, and the rejection would only surface at
+    # upload, after a signed archive and a wait.
+    if ! _ios_yml_has_build_phase "$yml.tmp"; then
+        rm -f "$yml.tmp"
+        echo "[ERROR] Could not exclude Externals from Copy Bundle Resources in $yml."
+        echo "        Add 'buildPhase: none' under the Externals source group by hand, or the app"
+        echo "        will contain libapp.a and App Store validation will reject it."
+        exit 1
+    fi
+    mv "$yml.tmp" "$yml"
+    IOS_YML_PATCHED=1
+    echo "      Excluded Externals from Copy Bundle Resources (keeps libapp.a out of the app)."
+}
+
+# Is the existing pbxproj one that still copies the library into the bundle? This is the state left
+# by any earlier run: the project was generated while Externals/ already held a built libapp.a.
+_ios_pbxproj_copies_libapp() {
+    local pbx="$GEN_APPLE/kite-gc.xcodeproj/project.pbxproj"
+    [ -f "$pbx" ] && grep -q 'libapp\.a in Resources' "$pbx"
+}
+
+# Only `tauri ios init` runs XcodeGen (crates/tauri-cli/src/mobile/ios/project.rs is its single call
+# site). `tauri ios build` and `tauri ios dev` load the existing pbxproj and synchronize values into
+# it, so a patched project.yml on its own reaches nothing: the project has to be regenerated for the
+# change to take effect. Tauri writes the signing team and configuration back afterwards, so a
+# regenerated project loses nothing that a re-init would not lose as well.
+ios_regenerate_project() {
+    if ! command -v xcodegen &> /dev/null; then
+        echo "[ERROR] xcodegen not found, so the Xcode project cannot be regenerated."
+        echo "        Install it with: brew install xcodegen"
+        exit 1
+    fi
+    echo "      Regenerating the Xcode project from project.yml (xcodegen)..."
+    xcodegen generate --spec "$GEN_APPLE/project.yml" --quiet
+    if _ios_pbxproj_copies_libapp; then
+        echo "[ERROR] The regenerated project still copies libapp.a into the bundle."
+        exit 1
+    fi
+}
+
+# Generate the Xcode project if it is missing (or FORCE_INIT=1), then make sure it is one that keeps
+# libapp.a out of the app bundle. Regenerates only when something actually needs it, so a project
+# that is already correct is left alone.
+ios_prepare_project() {
+    if [ ! -d "$GEN_APPLE" ] || [ "${FORCE_INIT:-0}" = "1" ]; then
+        echo "      Generating the Xcode project (tauri ios init)..."
+        npm run tauri ios init
+    else
+        echo "      $GEN_APPLE already present — skipping init (FORCE_INIT=1 to redo)."
+    fi
+    ios_patch_externals_build_phase
+    if [ "$IOS_YML_PATCHED" = "1" ] || _ios_pbxproj_copies_libapp; then
+        ios_regenerate_project
+    else
+        echo "      Xcode project already keeps libapp.a out of the bundle."
+    fi
+}

--- a/scripts/run-ipad.sh
+++ b/scripts/run-ipad.sh
@@ -59,14 +59,15 @@ rustup target add aarch64-apple-ios aarch64-apple-ios-sim
 echo "[2/4] Installing npm dependencies..."
 npm install
 
-# gen/apple is gitignored + regenerable. Create it on first run, or when
-# FORCE_INIT=1 (e.g. after changing the min deployment target in the config).
-if [ ! -d "gen/apple" ] || [ "${FORCE_INIT:-0}" = "1" ]; then
-    echo "[3/4] Generating the Xcode project (tauri ios init)..."
-    npm run tauri ios init
-else
-    echo "[3/4] gen/apple already present — skipping init (FORCE_INIT=1 to redo)."
-fi
+# src-tauri/gen/apple is gitignored + regenerable. Created on first run, or when FORCE_INIT=1
+# (e.g. after changing the min deployment target in the config). The plumbing, including the fix
+# that keeps libapp.a out of the app bundle, is shared with scripts/build-ios.sh: a dev run that
+# generated the project without it leaves a pbxproj that copies the library in, which later breaks
+# a release archive and, once several copies of libapp.a exist, the build itself.
+source "$ROOT/scripts/lib/ios-project.sh"
+
+echo "[3/4] Preparing the Xcode project..."
+ios_prepare_project
 
 echo "[4/4] Building + launching on device (live reload)..."
 echo ""


### PR DESCRIPTION
## Description

The iOS archive is rejected by App Store validation:

```
Invalid bundle structure. The "Kite Ground Control.app/libapp.a" binary file is not permitted.
```

`tauri ios init` lists `Externals/` as a plain source group. XcodeGen has no default build phase for
a `.a` and falls back to `resources`, so the Rust static library is added to "Copy Bundle Resources"
as well; the link itself comes from the target's `dependencies: - framework: libapp.a`, not from the
group. The copy puts the library inside the app, which Apple refuses, and it carried the library
into the ipa for nothing: 56 MB before, 19 MB after. Once several copies exist side by side (debug +
release, device + simulator) the build fails outright with `Multiple commands produce .../libapp.a`.

`src-tauri/gen/apple/` is generated and gitignored, so the project file cannot carry the fix. The
scripts apply `buildPhase: none` to the group and then **regenerate the project**, because a patched
`project.yml` on its own reaches nothing: only `tauri ios init` runs XcodeGen, while `tauri ios
build` and `tauri ios dev` load the existing pbxproj and synchronize values into it. Regeneration
happens only when it is needed, i.e. when the patch changed the file or the existing pbxproj still
copies the library, and the signing team survives it because that lives in `project.yml`.

The plumbing is shared by `scripts/build-ios.sh` and `scripts/run-ipad.sh` in
`scripts/lib/ios-project.sh`. That matters: a dev run generates the project while `Externals/`
already holds a built library, so it produces exactly the pbxproj a later release archive is
rejected for.

Both scripts also had the same path bug: the init check and the output hint looked for `gen/apple`
rather than `src-tauri/gen/apple`, so `tauri ios init` ran on every single build and the path
printed at the end did not exist.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / Code health
- [ ] Documentation
- [x] Build / CI

## Checklist

- [x] `npm run check` passes
- [x] `cargo check` (in `src-tauri`) passes
- [x] I have tested the changes locally (dev + relevant build)
- [x] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes

## Notes for reviewer

Scripts only, no Rust or frontend change, so both checks are unaffected; I ran them anyway. No
changelog entry, since the bug never reached a release.

That `tauri ios build` does not regenerate the project is measured, not assumed: with a marker
setting added to `project.yml`, a full `tauri ios build` reached `xcodebuild` without the marker ever
appearing in `project.pbxproj`, whose mtime did not move.

`ios_prepare_project` tested against the real generated project:

| Case | Result |
| --- | --- |
| Already correct | no regeneration, nothing touched |
| Unpatched yml + pbxproj copying libapp.a (the state a dev run leaves) | patched, regenerated, 2 Resources entries to 0 |
| Patched yml + stale pbxproj | regenerated, 2 to 0 |
| Upstream's `excludes: ["**/*.a"]` form (tauri-apps/tauri#15890) | `buildPhase` added alongside, still valid YAML |
| Externals group renamed | exits 1, no leftover `.tmp` |
| `xcodegen` absent | exits 1 with the `brew install xcodegen` hint |

The end-to-end proof of the original fix is the archive: the 19 MB ipa passed Apple's validation, the
56 MB one did not.
