### PR TITLE
fix(panel): tablet panels honour --panel-bottom-reserve; rename the width-based isPhone

### DIFF
--- a/src/lib/components/panel/PanelShell.svelte
+++ b/src/lib/components/panel/PanelShell.svelte
@@ -181,16 +181,17 @@
   /* Tablet (iPad): the toolbar is taller than the desktop default (iOS status-bar + safe-top padding),
      so the fixed 65px top clipped the panel header under the bar. Track the live bar height, and size
      the panel to the gap between the bar and the bottom dock (iPad keeps the above-dock layout, unlike
-     the phone which overlays the dock). */
+     the phone which overlays the dock). Same `--panel-bottom-reserve` rule as the desktop: on a
+     window too short for the nav rail the panel may overlay the dock instead of being squeezed. */
   :global(html.is-tablet) .ps {
     top: calc(var(--toolbar-h, 65px) + 8px);
   }
   :global(html.is-tablet) .ps-compact,
   :global(html.is-tablet) .ps-advanced {
-    height: calc(100% - var(--toolbar-h, 65px) - var(--grid-bottom-height) - 24px - 20px);
+    height: calc(100% - var(--toolbar-h, 65px) - var(--panel-bottom-reserve, var(--grid-bottom-height)) - 24px - 20px);
   }
   :global(html.is-tablet) .ps-info {
-    max-height: calc(100% - var(--toolbar-h, 65px) - var(--grid-bottom-height) - 24px - 20px);
+    max-height: calc(100% - var(--toolbar-h, 65px) - var(--panel-bottom-reserve, var(--grid-bottom-height)) - 24px - 20px);
   }
   /* iPhone (any orientation): the screen is small, so
      - width is capped to the viewport (minus the rail + a margin) so the panel never clips off-screen;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -251,12 +251,12 @@
   // Phone portrait: too narrow to fit the bottom HUD tiles in one row without clipping, so the dock
   // wraps them onto two rows (see the sizing below + the flex-wrap rule in WidgetPanel). Tablets and
   // desktop keep the single row. `winW`/`isMobile` are reactive so a rotate re-evaluates this.
-  const isPhone = $derived(isMobile && winW <= 600);
-  const bottomRows = $derived(isPhone ? 2 : 1);
+  const isPhonePortrait = $derived(isMobile && winW <= 600);
+  const bottomRows = $derived(isPhonePortrait ? 2 : 1);
   // Phone gets a taller dock (room for two HUD rows); otherwise the layout store override or default.
   const gridBottomHeight = $derived(
     $layout.bottomDock.sizeOverride ??
-      (isPhone ? 'clamp(230px, 40vh, 380px)' : GRID_DEFAULTS.bottomDockHeight)
+      (isPhonePortrait ? 'clamp(230px, 40vh, 380px)' : GRID_DEFAULTS.bottomDockHeight)
   );
 
   // Map-swap: the full-size video sink shown in the map zone when videoPrimary.
@@ -276,9 +276,11 @@
   // widget dock, but once that cap would make them shorter than the nav rail, they may overlay the
   // dock instead — the rail already scrolls past it, so the panel just follows. Logical px
   // throughout, so the switch adapts to the UI scale. The 6px keeps the rail's visual gap above
-  // the status bar instead of sitting flush on it.
+  // the status bar instead of sitting flush on it. `toolbarH` is the live bar height (53 on the
+  // desktop, taller on the iPad where the bar carries the status-bar inset), so the tablet uses the
+  // same rule (PanelShell's tablet block reads the reserve too).
   const panelBottomReserve = $derived(
-    winH / uiScale - 53 - bottomDockH - 24 - 12 < NAV_RAIL_FULL_HEIGHT ? '6px' : gridBottomHeight
+    winH / uiScale - toolbarH - bottomDockH - 24 - 12 < NAV_RAIL_FULL_HEIGHT ? '6px' : gridBottomHeight
   );
 
   // Floating-window rect — ONE computation (`floatFrameRect`, store) for the window itself (it gets
@@ -3705,7 +3707,7 @@
         orientation="horizontal"
         availableVmin={bottomAvailUnits}
         pxPerVmin={bottomPxPerUnit}
-        smallBoost={isPhone ? 1.5 : isTablet ? 1.4 : 1}
+        smallBoost={isPhonePortrait ? 1.5 : isTablet ? 1.4 : 1}
         sizes={panels.sizes ?? {}}
         bind:crossPx={bottomPanelCrossPx}
         {telem}


### PR DESCRIPTION
## Summary

Two frontend leftovers from the QUICK_NOTES sweep.

- **Tablet panels honour the short-window rule.** `PanelShell`'s tablet block still sized compact/advanced/info panels against `--grid-bottom-height`, so on a short iPad window the panel was squeezed above the dock while the desktop already overlays the dock via `--panel-bottom-reserve`. The tablet block now reads the reserve as well, and the reserve rule in `+page.svelte` uses the live `toolbarH` instead of the desktop's fixed 53 px (the iPad bar is taller because of the status-bar inset). No change on the desktop, where the bar is 53 px.
- **`isPhone` rename.** The width-based `isPhone` `$derived` in `+page.svelte` shadowed the UA-based `isPhone` flag from `platform.ts` (imported as `isPhoneDevice`). It is now `isPhonePortrait`, which is what it tests (mobile and <= 600 px wide). Cosmetic.

Affects: v1.0.1 and earlier (tablet reserve); the rename is cosmetic.

## Test plan

- [x] `npm run check` — 0 errors
- [ ] iPad: open a compact panel on a window too short for the nav rail → the panel overlays the dock instead of being squeezed (no device at hand; the rule only diverges from the dock height below 424 px of panel room)
- [ ] Desktop: panel heights unchanged
