### PR TITLE
fix(android): strip hidden system-bar insets; Chromium tile seams on fractional DPR

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/com/kitegc/app/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/kitegc/app/MainActivity.kt
@@ -7,6 +7,8 @@ import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -65,6 +67,21 @@ class MainActivity : TauriActivity() {
     super.onCreate(savedInstanceState)
 
     hideSystemBars()
+
+    // The bars are hidden, but Android 9 (the RadioMaster AX12, the API 28 emulator) keeps reporting
+    // them as system-window insets - 40 px top, 80 px right in landscape - and the WebView turns those
+    // into `env(safe-area-inset-*)`: the phone chrome then pads itself off the screen (widget column
+    // cut at the right edge, rail and buttons pushed down) while the page itself fills the display.
+    // Strip the system-bar insets before the view tree sees them; the display cutout stays, which is
+    // the one thing the safe-area rules exist for. Android 14 already reports 0 here, so this is a
+    // no-op on current devices.
+    ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { v, insets ->
+      val stripped = WindowInsetsCompat.Builder(insets)
+        .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.NONE)
+        .setInsetsIgnoringVisibility(WindowInsetsCompat.Type.systemBars(), Insets.NONE)
+        .build()
+      ViewCompat.onApplyWindowInsets(v, stripped)
+    }
 
     // The display stays on only while a telemetry link is active — nav-app behaviour, driven from
     // Rust through ScreenLock on connect / disconnect / lost link. Unconnected, the normal screen

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -36,7 +36,7 @@
   import { MAP_PROVIDERS, getProviderById, type MapProvider } from "$lib/config/mapProviders";
   import { cachedTileLayer } from "$lib/cache/CachedTileLayer";
   import { initTileCache } from "$lib/cache/tileCache";
-  import { isWebKitGtk } from "$lib/platform";
+  import { isWebKitGtk, isAndroid } from "$lib/platform";
   import { homePosition, homeMarkerShown } from "$lib/stores/home";
   import { editMode, geoWaypoints, launchPoint, replayActive, toDeg } from "$lib/stores/mission";
   import { autopilotSystem } from "$lib/stores/autopilotContext";
@@ -2231,7 +2231,7 @@
 </script>
 
 <div class="map-wrapper" style="--map-inset-right: {centerInsetRight}px">
-  <div bind:this={mapContainer} class="map" class:tile-overlap={isWebKitGtk} class:mini={miniControls} style="--map-rotation: 0deg"></div>
+  <div bind:this={mapContainer} class="map" class:tile-overlap={isWebKitGtk} class:tile-snap={isAndroid} class:mini={miniControls} style="--map-rotation: 0deg"></div>
 
   <div class="map-controls-corner">
     {#if !miniControls}
@@ -2338,6 +2338,23 @@
   :global(.map.tile-overlap img.leaflet-tile) {
     width: 256.5px !important;
     height: 256.5px !important;
+  }
+
+  /* Android (Chromium WebView): every tile is its own composited layer and cc snaps each layer's
+     origin to whole device pixels. At a fractional device pixel ratio (1.67 on a 1280×720 / 267 dpi
+     screen: a 256px tile is 427.26 device px) the shared edge of two tiles therefore rounds UP at one
+     boundary — a 1px gap, dark hairline — and DOWN at the next — a 1px overlap. Leaflet's own remedy
+     for Chromium, `mix-blend-mode: plus-lighter` on every tile, turns that overlap into a BRIGHT
+     hairline (the sum of both tiles), which is also why the WebKitGTK half-pixel stretch above made
+     the phone worse. Fix: a full-pixel stretch so neighbours always overlap, drawn with normal
+     blending so the overlap is simply the upper tile. Covers the over-zoom placeholder tiles (div)
+     too. Reproduced + verified on the API 28 emulator at 1280×720 / 267 dpi (2026-09-10); the Sony
+     at DPR 2.625 only showed it while the map moved. Windows (WebView2) at 125 % scaling is the same
+     engine and untested. */
+  :global(.map.tile-snap .leaflet-tile) {
+    mix-blend-mode: normal;
+    width: 257px !important;
+    height: 257px !important;
   }
 
   /* Heading-up: container size set via inline styles (JS),


### PR DESCRIPTION
Two Android rendering fixes, both found with an API 28 emulator at 1280×720 / 267 dpi (the RadioMaster AX12 report) and verified there; both are engine-level, not device-specific.

## Hidden system-bar insets (Android 9)

Kite hides the system bars and draws edge to edge, but Android 9 keeps reporting the hidden status bar (40 px top) and navigation bar (80 px right in landscape) as system-window insets, and the WebView turns those into `env(safe-area-inset-*)`. The phone chrome then pads itself off the screen: widget column 48 CSS px past the right edge, rail and buttons 24 px too low, while the page itself fills the display. Android 14 reports 0 there, which is why no Sony or tablet ever showed it.

Fix: an `OnApplyWindowInsets` listener on the decor view strips the system-bar insets (visible and ignoring-visibility) before the view tree sees them; the display cutout stays.

**Regression: introduced by 73b6332, never released** (Android support is 1.1).

## Chromium tile seams at a fractional device pixel ratio

Every Leaflet tile is its own composited layer and Chromium snaps layer origins to whole device pixels. At DPR 1.67 a 256 px tile is 427.26 device px, so the shared edge of two tiles rounds up at one boundary (1 px gap, dark hairline) and down at the next (1 px overlap) — which Leaflet's own Chromium remedy, `mix-blend-mode: plus-lighter`, turns into a bright hairline. That is also why the WebKitGTK half-pixel stretch (#64) made the phone worse.

Fix: `tile-snap` class on the map container (Android only): every tile stretched to 257 px with normal blending, so neighbours always overlap by at least one device pixel and the overlap is simply the upper tile. Covers the over-zoom placeholder tiles too. Hairline score at tile boundaries 30–54 before, texture level after; clean in follow with the mini map (Marc, emulator).

**Affects: every Android build so far, unreleased.**

## Test plan

- [x] Kotlin compiled through Gradle; `npm run check` 0 errors; arm64 + x86_64 release builds
- [x] API 28 emulator (WebView 138): insets 0/0/0/0 after the fix, chrome in place; seams gone static and in motion
- [x] API 34 emulator and Sony XQ-CT54: no change (insets already 0)
- [x] AX12 testers (APK sent from `feat/ax12-radio`, which carries this branch merged)
- [x] Windows WebView2 at 125 % display scaling: same layer snapping, `tile-snap` is Android-only for now
