### PR TITLE
feat(i18n): add script to generate nested key paths for translations

### DIFF
--- a/tools/i18n-key-paths.py
+++ b/tools/i18n-key-paths.py
@@ -1,0 +1,38 @@
+# This script reads the English locale JSON file, builds a dictionary of nested paths for all keys, and writes
+# the result to an output JSON file -- locales/xx.json.
+#
+# Usage: python tools/i18n-key-paths.py
+#
+# Then add the xx 'locale' to lib/i18n/index.ts
+#
+#   register('xx', () => import('./locales/xx.json'));
+#
+# and add
+#
+#   { code: 'xx', label: 'i18n-paths' },
+#
+# to SUPPORTED_LOCALES (also in lib/i18n/index.ts)
+#
+# After you switch to the xx locale in the app, you can see all the i18n keys in the UI.
+# Enjoy translating!
+#
+import json
+
+LOCALES_PATH = "src/lib/i18n/locales"
+FNAME_EN = f"{LOCALES_PATH}/en.json"  # en hardcoded as the master reference for all string keys
+OUTPUT_FNAME = f"{LOCALES_PATH}/xx.json"
+
+
+def build_paths(obj, path=()):
+    """Recursively build paths for nested dictionaries."""
+    if isinstance(obj, dict):
+        return {
+            key: build_paths(value, path + (key,))
+            for key, value in obj.items()
+        }
+    return ".".join(path)
+
+
+result = build_paths(json.load(open(FNAME_EN, 'r', encoding="utf-8")))
+json.dump(result, open(OUTPUT_FNAME, 'w', encoding="utf-8"), indent=2)
+print(f"Key paths written to {OUTPUT_FNAME}")


### PR DESCRIPTION
## Description

A tool that extracts all keys from the EN locale and writes key paths to a new, 'virtual' locale -- `xx.json`. 
Aimed at translators not fully familiar with with which string lives where. Using the 'virtual' locale in the UI makes it very obvious.

`xx.json` ends up having contents like

```json
...
  "sensors": {
    "gyro": "sensors.gyro",
    "acc": "sensors.acc",
    "mag": "sensors.mag",
    "baro": "sensors.baro",
    "gps": "sensors.gps",
    "rangefinder": "sensors.rangefinder",
    "pitot": "sensors.pitot",
    "gyroTooltip": "sensors.gyroTooltip",
    "accTooltip": "sensors.accTooltip",
    "magTooltip": "sensors.magTooltip",
    "baroTooltip": "sensors.baroTooltip",
    "rangefinderTooltip": "sensors.rangefinderTooltip",
    "pitotTooltip": "sensors.pitotTooltip",
    "ekfTooltip": "sensors.ekfTooltip"
  },
  "gps": {
    "noFix": "gps.noFix",
    "fix2d": "gps.fix2d",
    "fix3d": "gps.fix3d",
    "fix3dDgps": "gps.fix3dDgps"
  },
  "rcLink": {
    "title": "rcLink.title",
    "lq": "rcLink.lq",
    "rssi": "rcLink.rssi",
    "snr": "rcLink.snr",
    "noLink": "rcLink.noLink"
  },
...
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / Code health
- [x] Documentation
- [ ] Build / CI

## Checklist

- [x] `npm run check` passes
- [x] `cargo check` (in `src-tauri`) passes
- [x] I have tested the changes locally (dev + relevant build)
- [ ] Documentation (ROADMAP / CHANGELOG) updated if needed
- [x] No unrelated changes

## Notes for reviewer


