### PR TITLE
chore: forward-port the heading-up upright overlays fix (1.0.1 → development)

### DIFF
--- a/docs/user/changelog.md
+++ b/docs/user/changelog.md
@@ -236,6 +236,11 @@ inside the box of the feature release they belong to, so the notes for one relea
     - **A saved Telemetry connection came back as MSP.** Restoring the last-used protocol mapped
       everything that was not MAVLink onto MSP, so the passive Telemetry choice was silently
       rewritten. [#143]
+    - **Markers and pop-ups turned with the map in heading-up mode.** Waypoint markers, labels,
+      the "Fly Here" pop-up and the waypoint editor rotated together with the map tiles, so they
+      were unreadable while the map followed the aircraft's heading. They now stay bound to their
+      position but upright; the aircraft symbol and radar contacts keep pointing along their
+      track. [#168]
 
 ??? note "1.0.0 — Initial release · Live"
 
@@ -282,3 +287,4 @@ inside the box of the feature release they belong to, so the notes for one relea
 [#160]: https://github.com/b14ckyy/Kite-GC/pull/160
 [#162]: https://github.com/b14ckyy/Kite-GC/pull/162
 [#163]: https://github.com/b14ckyy/Kite-GC/pull/163
+[#168]: https://github.com/b14ckyy/Kite-GC/issues/168

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -82,7 +82,11 @@
   import { t } from "svelte-i18n";
   import { contactColor, ffContactColor, contactVisibleOnMap, relevanceFactor } from "$lib/helpers/radarMap";
   import { pickShape, buildContactIconHtml } from "$lib/helpers/radarIcons";
+  import { installUprightOverlays } from "$lib/helpers/leafletUpright";
   import { convertAltitude, convertSpeed, convertDistance, convertVerticalSpeed, formatConverted, speedDigits } from "$lib/utils/units";
+
+  // Heading-up: markers, popups and tooltips counter-rotate about their anchor (see leafletUpright.ts).
+  installUprightOverlays();
 
   let {
     playbackTrack = [],
@@ -2395,6 +2399,23 @@
   :global(.map.heading-up .leaflet-control-zoom),
   :global(.map.heading-up .leaflet-control-attribution) {
     transform: rotate(calc(-1 * var(--map-rotation, 0deg)));
+  }
+
+  /* Heading-up: everything we draw onto the map keeps its geographic anchor but stays upright —
+     marker icons, popups and tooltips carry `rotate(var(--kite-upright))` in their inline transform
+     (leafletUpright.ts), pivoting on the anchor point. Defined here so a heading change is a single
+     CSS-variable write; outside heading-up the variable is unset and the rotation falls back to 0. */
+  :global(.map.heading-up) {
+    --kite-upright: calc(-1 * var(--map-rotation, 0deg));
+  }
+  /* Exception — the UAV model is drawn with its heading; the map rotation is what makes it point up. */
+  :global(.map.heading-up .uav-model-icon) {
+    --kite-upright: 0deg;
+  }
+  /* Radar contacts: the icon stands upright (callsign label readable, below the symbol), but the
+     silhouette itself points along the contact's track, so it turns back with the map. */
+  :global(.map.heading-up .radar-divicon .radar-icon > svg) {
+    transform: rotate(var(--map-rotation, 0deg));
   }
 
   .map-controls-corner {

--- a/src/lib/helpers/leafletUpright.ts
+++ b/src/lib/helpers/leafletUpright.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Marc Hoffmann (b14ckyy)
+/**
+ * Upright overlays on a rotated map (heading-up mode).
+ *
+ * The 2D map rotates as a whole — the `.map` container carries `transform: rotate(var(--map-rotation))`
+ * — so everything Leaflet draws into it turns with the tiles: marker icons, popups, tooltips. Vector
+ * geometry (tracks, zones) should, but a waypoint teardrop, a callsign label or the "Fly here"
+ * popup must stay readable: bound to its geographic anchor, drawn upright.
+ *
+ * Leaflet positions those elements with an inline `transform: translate3d(...)` that it rewrites on
+ * every move (`DomUtil.setPosition`), so a CSS rule cannot add the counter-rotation. This module
+ * patches the few prototype methods that write that transform and appends
+ * `rotate(var(--kite-upright, 0deg))`, pivoting on the element's anchor point:
+ *   - `L.Marker._setPos`        — the icon's anchor sits at (-marginLeft, -marginTop) of its box;
+ *   - `L.Draggable._updatePosition` — a dragged icon is moved by the Draggable, not by `_setPos`;
+ *   - `L.Popup._updatePosition` / `_animateZoom` — the popup box hangs above the anchor by
+ *     `margin-bottom` plus the popup offset (see `_updatePosition` in Leaflet's DivOverlay);
+ *   - `L.Tooltip._setPosition` — the box is placed by `direction` (top/bottom/left/right/center)
+ *     minus offset and anchor.
+ * The angle itself is a CSS custom property set by Map.svelte on the `.map` element
+ * (`--kite-upright: calc(-1 * var(--map-rotation))` while heading-up, unset = 0deg otherwise), so a
+ * heading change is one variable write, not a walk over every marker. Elements whose orientation IS
+ * geographic (the UAV model, radar silhouettes) opt out by redefining the variable to 0deg.
+ */
+import L from 'leaflet';
+
+const ROT = ' rotate(var(--kite-upright, 0deg))';
+
+let installed = false;
+
+/** Append the counter-rotation to the transform Leaflet just wrote, pivoting on `origin`. */
+function upright(el: HTMLElement, origin?: string): void {
+  if (!el.style.transform.includes(ROT)) el.style.transform += ROT;
+  if (origin !== undefined) el.style.transformOrigin = origin;
+}
+
+type MarkerInternals = { _icon?: HTMLElement; _setPos(pos: L.Point): void };
+type DraggableInternals = { _element: HTMLElement; _updatePosition(): void };
+type PopupInternals = {
+  _container: HTMLElement;
+  _containerWidth: number;
+  _kiteMarginBottom?: number;
+  options: L.PopupOptions;
+  _getAnchor(): L.Point;
+  _updatePosition(): void;
+  _animateZoom(e: unknown): void;
+};
+type TooltipInternals = {
+  _container: HTMLElement;
+  options: L.TooltipOptions;
+  _getAnchor(): L.Point;
+  _setPosition(pos: L.Point): void;
+};
+
+/** Install the prototype patches once per document (both the main map and the mini map share them). */
+export function installUprightOverlays(): void {
+  if (installed) return;
+  installed = true;
+
+  // ── Markers ─────────────────────────────────────────────────────────────────────────────────────
+  const marker = L.Marker.prototype as unknown as MarkerInternals;
+  const origSetPos = marker._setPos;
+  marker._setPos = function (this: MarkerInternals, pos: L.Point) {
+    origSetPos.call(this, pos);
+    const icon = this._icon;
+    if (!icon) return;
+    // Leaflet shifts the icon by negative margins so the anchor lands on the coordinate.
+    const ax = -(parseFloat(icon.style.marginLeft) || 0);
+    const ay = -(parseFloat(icon.style.marginTop) || 0);
+    upright(icon, `${ax}px ${ay}px`);
+  };
+
+  const draggable = L.Draggable.prototype as unknown as DraggableInternals;
+  const origDragUpdate = draggable._updatePosition;
+  draggable._updatePosition = function (this: DraggableInternals) {
+    origDragUpdate.call(this);
+    // Only marker icons — the map pane is dragged through the same class. The origin was set by _setPos.
+    if (this._element.classList.contains('leaflet-marker-icon')) upright(this._element);
+  };
+
+  // ── Popups ──────────────────────────────────────────────────────────────────────────────────────
+  const popup = L.Popup.prototype as unknown as PopupInternals;
+  const origPopupUpdate = popup._updatePosition;
+  popup._updatePosition = function (this: PopupInternals) {
+    origPopupUpdate.call(this);
+    // `.leaflet-popup { margin-bottom }` (20px in leaflet.css) keeps the box above the anchor. Read
+    // once the container is in the DOM (a detached element has no computed style).
+    if (this._kiteMarginBottom === undefined) {
+      this._kiteMarginBottom = parseFloat(getComputedStyle(this._container).marginBottom) || 0;
+    }
+    // Leaflet places the box with its horizontal centre `offset.x + anchor.x` right of the coordinate
+    // and its bottom margin edge `offset.y + anchor.y` below it (as `left`/`bottom` on top of the
+    // translated point, or in `left`/`bottom` alone when zoom animation is off — same geometry).
+    // The coordinate relative to the box is therefore
+    // (round(width/2) - offset.x - anchor.x, height + marginBottom - offset.y - anchor.y).
+    const offset = L.point(this.options.offset ?? [0, 0]);
+    const anchor = this._getAnchor();
+    const x = Math.round(this._containerWidth / 2) - offset.x - anchor.x;
+    const y = this._kiteMarginBottom - offset.y - anchor.y;
+    upright(this._container, `${x}px calc(100% + ${y}px)`);
+  };
+  const origPopupZoom = popup._animateZoom;
+  popup._animateZoom = function (this: PopupInternals, e: unknown) {
+    origPopupZoom.call(this, e);
+    upright(this._container);
+  };
+
+  // ── Tooltips ────────────────────────────────────────────────────────────────────────────────────
+  const tooltip = L.Tooltip.prototype as unknown as TooltipInternals;
+  const origTipSetPos = tooltip._setPosition;
+  tooltip._setPosition = function (this: TooltipInternals, pos: L.Point) {
+    origTipSetPos.call(this, pos);
+    // The box is placed at coordinate - sub + offset + anchor, `sub` depending on the resolved
+    // direction (Leaflet leaves it as a class); `auto` resolving to "left" subtracts the offset and
+    // anchor twice. leaflet.css then nudges the box away from the point with a 6px margin per
+    // direction, which shifts the border box the origin is measured against. The coordinate relative
+    // to the box is therefore sub - offset - anchor - margin.
+    const c = this._container;
+    const offset = L.point(this.options.offset ?? [0, 0]);
+    const anchor = this._getAnchor();
+    const cs = getComputedStyle(c);
+    const dx = offset.x + anchor.x + (parseFloat(cs.marginLeft) || 0);
+    const dy = offset.y + anchor.y + (parseFloat(cs.marginTop) || 0);
+    const cls = c.classList;
+    let subX = '50%';
+    let subY = '50%';
+    if (cls.contains('leaflet-tooltip-top')) subY = '100%';
+    else if (cls.contains('leaflet-tooltip-bottom')) subY = '0%';
+    else if (cls.contains('leaflet-tooltip-right')) subX = '0%';
+    else if (cls.contains('leaflet-tooltip-left')) {
+      subX = this.options.direction === 'auto' ? `calc(100% + ${2 * (offset.x + anchor.x)}px)` : '100%';
+    }
+    upright(c, `calc(${subX} - ${dx}px) calc(${subY} - ${dy}px)`);
+  };
+}


### PR DESCRIPTION
Forward-port of #170 (issue #168) from `release/1.0.x`: markers, popups and tooltips stay upright in heading-up mode.

Cherry-picks of `665c6dc` (changelog) and `81215e0` (fix) with `-x`. The code applied cleanly (new `src/lib/helpers/leafletUpright.ts` plus the import, install call and CSS block in `Map.svelte`); only `docs/user/changelog.md` conflicted because `development` still has the older separate "1.0.1 — patch release" box — the #168 entry was added to that box's Fixed list, the rest of the file is untouched (reconciled at the next snapshot).

`npm run check`: 0 errors.

Refs #168
