### PR TITLE
chore(i18n): follow-up to the key-path pseudo-locale (#169)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,10 @@ src-tauri/binaries/
 # =============================================================================
 __pycache__/
 *.pyc
+
+# =============================================================================
+# Generated i18n pseudo-locale (tools/i18n-key-paths.py) — every string is its
+# own key path, for translators. Local only: index.ts must not register it in
+# a commit either.
+# =============================================================================
+src/lib/i18n/locales/xx.json

--- a/docs/user/for-developers/contributing.md
+++ b/docs/user/for-developers/contributing.md
@@ -106,6 +106,13 @@ Kite ships in English, German, French, Chinese and Bulgarian. For contributions:
 Missing non-English keys fall back gracefully, so an English-only PR is fine — a maintainer (or you, with
 AI help) can top up the other languages afterwards.
 
+**Finding the key for a string you see on screen:** `python tools/i18n-key-paths.py` writes a pseudo-locale
+`src/lib/i18n/locales/xx.json` in which every string is replaced by its own key path (`sensors.gyro`,
+`rcLink.noLink`, …). Register it locally in `src/lib/i18n/index.ts` as described in the script's header,
+start the dev app and switch the language to it — the interface then shows the key at every position
+instead of the text. The file is git-ignored; take the `index.ts` registration out again before you commit.
+Contributed by teodoryantcheff.
+
 ## Licensing & contributor terms
 
 Kite Ground Control is licensed under **[GPL-3.0-or-later](https://www.gnu.org/licenses/gpl-3.0.html)**.

--- a/tools/i18n-key-paths.py
+++ b/tools/i18n-key-paths.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 Teodor Yantcheff
 # This script reads the English locale JSON file, builds a dictionary of nested paths for all keys, and writes
 # the result to an output JSON file -- locales/xx.json.
 #


### PR DESCRIPTION
Follow-up to #169 (`tools/i18n-key-paths.py` by @teodoryantcheff):

- `src/lib/i18n/locales/xx.json` is git-ignored — the pseudo-locale is local only; a registration left in `index.ts` now fails the build instead of shipping it.
- Shebang + SPDX header on the script like the other `tools/` scripts (contributor's copyright).
- *Contributing* page, section *Internationalisation*: how to use the pseudo-locale to find the key for a string on screen.

Script verified: runs from the repo root, output is ignored by git.
